### PR TITLE
fix RegDeleteKey with values (farftp and netbox now deletes hosts correctly)

### DIFF
--- a/WinPort/APIRegistry.cpp
+++ b/WinPort/APIRegistry.cpp
@@ -198,6 +198,15 @@ extern "C" {
 		if (lpSubKey)
 			AppendAndRectifyPath(dir, WINPORT_REG_DIV_KEY, lpSubKey);
 
+		for (;;)
+		{
+			std::string name = LookupIndexedRegItem(dir, WINPORT_REG_DIV_VALUE, 0);
+			if (name.empty())
+				break;
+			std::string file = dir + "/" + name;
+			if (remove(file.c_str())) return ERROR_PATH_NOT_FOUND;
+		}
+
 		if (_rmdir(dir.c_str())!=0) {
 			struct stat s = {0};
 			if (stat(dir.c_str(), &s)==0)


### PR DESCRIPTION
Теперь farftp и netbox может удалять хосты.