### PR TITLE
fix shell scripts without '#' header

### DIFF
--- a/_All/_All.project
+++ b/_All/_All.project
@@ -19,6 +19,14 @@
   </Plugins>
   <Description/>
   <Dependencies/>
+  <Dependencies Name="Debug">
+    <Project Name="WinPort"/>
+    <Project Name="farlng"/>
+    <Project Name="far2l"/>
+    <Project Name="colorer"/>
+    <Project Name="farftp"/>
+    <Project Name="multiarc"/>
+  </Dependencies>
   <Settings Type="Executable">
     <GlobalSettings>
       <Compiler Options="" C_Options="" Assembler="">
@@ -38,7 +46,7 @@
         <LibraryPath Value="Debug"/>
       </Linker>
       <ResourceCompiler Options="" Required="no"/>
-      <General OutputFile="" IntermediateDirectory="./Debug" Command="./$(ProjectName)" CommandArguments="" UseSeparateDebugArgs="no" DebugArguments="" WorkingDirectory="./Debug" PauseExecWhenProcTerminates="yes" IsGUIProgram="no" IsEnabled="yes"/>
+      <General OutputFile="" IntermediateDirectory="./Debug" Command="../Build/far2l" CommandArguments="" UseSeparateDebugArgs="no" DebugArguments="" WorkingDirectory="../Build" PauseExecWhenProcTerminates="yes" IsGUIProgram="no" IsEnabled="yes"/>
       <Environment EnvVarSetName="&lt;Use Defaults&gt;" DbgSetName="&lt;Use Defaults&gt;">
         <![CDATA[]]>
       </Environment>
@@ -71,12 +79,4 @@
       </Completion>
     </Configuration>
   </Settings>
-  <Dependencies Name="Debug">
-    <Project Name="WinPort"/>
-    <Project Name="farlng"/>
-    <Project Name="far2l"/>
-    <Project Name="colorer"/>
-    <Project Name="farftp"/>
-    <Project Name="multiarc"/>
-  </Dependencies>
 </CodeLite_Project>

--- a/far2l/execute.cpp
+++ b/far2l/execute.cpp
@@ -97,6 +97,7 @@ public:
 				} else {
 					fprintf(stderr, "ExecClassifier('%s') - unknown: %02x %02x %02x %02x\n", 
 						cmd, (unsigned)buf[0], (unsigned)buf[1], (unsigned)buf[2], (unsigned)buf[3]);
+					_executable = true;
 				}
 			} else
 				fprintf(stderr, "IsPossibleXDGOpeSubject('%s') - not executable mode=0x%x\n", cmd, s.st_mode);	


### PR DESCRIPTION
Уже давно вроде как заголовок #/bin/bash для шел скриптов не нужен, они по дефолту таковыми считаются. В mc и дефолтном терминае такие скрипты стартуют. Фикс позволяет их запускать.