### PR TITLE
fix console utilities colors output and .bashrc processing

### DIFF
--- a/far2l/execute.cpp
+++ b/far2l/execute.cpp
@@ -124,7 +124,7 @@ void ExecuteOrForkProc(const char *CmdStr, int (WINAPI *ForkProc)(int argc, char
 		} else
 			fprintf(stderr, "ExecuteOrForkProc: wordexp('%s') errno %u\n", CmdStr, errno);
 	} else {
-		r = execl("/bin/sh", "sh", "-c", CmdStr, NULL);
+		r = execl("/bin/bash", "bash", "-c", "-i", CmdStr, NULL);
 		fprintf(stderr, "ExecuteOrForkProc: execl returned %d errno %u\n", r, errno);
 	}
 	exit(r);

--- a/far2l/execute.cpp
+++ b/far2l/execute.cpp
@@ -124,7 +124,7 @@ void ExecuteOrForkProc(const char *CmdStr, int (WINAPI *ForkProc)(int argc, char
 		} else
 			fprintf(stderr, "ExecuteOrForkProc: wordexp('%s') errno %u\n", CmdStr, errno);
 	} else {
-		r = execl("/bin/bash", "bash", "-c", "-i", CmdStr, NULL);
+		r = execl("/bin/bash", "bash", "-ci", CmdStr, NULL);
 		fprintf(stderr, "ExecuteOrForkProc: execl returned %d errno %u\n", r, errno);
 	}
 	exit(r);


### PR DESCRIPTION
Выяснил почему цвета не отображались. Из-за отсутствия ключа interactive, .bashrc вылетает сразу же и не устанавливает переменные окружения для цветов, а то что там setenv() перед этим делали bash все обнуляет.
Теперь почти все отсюда https://github.com/elfmz/far2l/issues/9 работает, остался $PS1, но не знаю насколько он нужен.