### PR TITLE
fix some valgrind errors

### DIFF
--- a/colorer/src/pcolorer2/FarHrcSettings.cpp
+++ b/colorer/src/pcolorer2/FarHrcSettings.cpp
@@ -72,7 +72,7 @@ void FarHrcSettings::readUserProfile()
 {
   wchar_t key[MAX_KEY_LENGTH];
   swprintf(key,MAX_KEY_LENGTH, L"%ls/colorer/HrcSettings", Info.RootKey);
-  HKEY dwKey;
+  HKEY dwKey = NULL;
 
   if (WINPORT(RegOpenKeyEx)( HKEY_CURRENT_USER, key, 0, KEY_READ, &dwKey) == ERROR_SUCCESS ){
     readProfileFromRegistry(dwKey);

--- a/far2l/editor.cpp
+++ b/far2l/editor.cpp
@@ -91,7 +91,12 @@ Editor::Editor(ScreenObject *pOwner,bool DialogUsed):
 	StackPos(0),
 	NewStackPos(FALSE),
 	EditorID(::EditorID++),
-	HostFileEditor(nullptr)
+	HostFileEditor(nullptr),
+	TopList(nullptr),
+	EndList(nullptr),
+	TopScreen(nullptr),
+	CurLine(nullptr),
+	LastGetLineNumber(0)
 {
 	_KEYMACRO(SysLog(L"Editor::Editor()"));
 	_KEYMACRO(SysLog(1));

--- a/netbox/src/core/SessionData.cpp
+++ b/netbox/src/core/SessionData.cpp
@@ -111,44 +111,45 @@ TSessionData * TSessionData::Clone()
 
 void TSessionData::Default()
 {
+  FSource = ssStored;
   SetHostName(L"");
-  SetPortNumber(SshPortNumber);
-  SetUserName(ANONYMOUS_USER_NAME);
-  SetPassword(ANONYMOUS_PASSWORD);
-  SetPingInterval(30);
-  SetPingType(ptOff);
-  SetTimeout(15);
-  SetTryAgent(true);
-  SetAgentFwd(false);
-  SetAuthTIS(false);
-  SetAuthKI(true);
-  SetAuthKIPassword(true);
-  SetAuthGSSAPI(false);
-  SetGSSAPIFwdTGT(false);
+  FPortNumber = SshPortNumber;
+  FUserName = ANONYMOUS_USER_NAME;
+  FPassword = ANONYMOUS_PASSWORD;
+  FPingInterval = 30;
+  FPingType = ptOff;
+  FTimeout = 15;
+  FTryAgent = true;
+  FAgentFwd = false;
+  FAuthTIS = false;
+  FAuthKI = true;
+  FAuthKIPassword = true;
+  FAuthGSSAPI = false;
+  FGSSAPIFwdTGT = false;
   SetGSSAPIServerRealm(L"");
-  SetChangeUsername(false);
-  SetCompression(false);
-  SetSshProt(ssh2only);
-  SetSsh2DES(false);
-  SetSshNoUserAuth(false);
+  FChangeUsername = false;
+  FCompression = false;
+  FSshProt = ssh2only;
+  FSsh2DES = false;
+  FSshNoUserAuth = false;
   for (intptr_t Index = 0; Index < CIPHER_COUNT; ++Index)
   {
-    SetCipher(Index, DefaultCipherList[Index]);
+    FCiphers[Index] = DefaultCipherList[Index];
   }
   for (intptr_t Index = 0; Index < KEX_COUNT; ++Index)
   {
-    SetKex(Index, DefaultKexList[Index]);
+    FKex[Index] = DefaultKexList[Index];
   }
   SetPublicKeyFile(L"");
   SetPassphrase(L"");
   SetPuttyProtocol(L"");
-  SetTcpNoDelay(true);
-  SetSendBuf(DefaultSendBuf);
-  SetSshSimple(true);
+  FTcpNoDelay = true;
+  FSendBuf = DefaultSendBuf;
+  FSshSimple = true;
   FNotUtf = asAuto;
   FIsWorkspace = false;
   SetHostKey(L"");
-  SetFingerprintScan(false);
+  FFingerprintScan = false;
   FOverrideCachedHostKey = true;
   SetNote(L"");
   FOrigHostName.Clear();
@@ -156,120 +157,120 @@ void TSessionData::Default()
   FOrigProxyMethod = pmNone;
   FTunnelConfigured = false;
 
-  SetProxyMethod(::pmNone);
+  FProxyMethod = ::pmNone;
   SetProxyHost(L"proxy");
-  SetProxyPort(ProxyPortNumber);
+  FProxyPort = ProxyPortNumber;
   SetProxyUsername(L"");
   SetProxyPassword(L"");
   SetProxyTelnetCommand(L"connect %host %port" WGOOD_SLASH "n");
   SetProxyLocalCommand(L"");
-  SetProxyDNS(asAuto);
-  SetProxyLocalhost(false);
+  FProxyDNS = asAuto;
+  FProxyLocalhost = false;
 
   for (intptr_t Index = 0; Index < static_cast<intptr_t>(_countof(FBugs)); ++Index)
   {
-    SetBug(static_cast<TSshBug>(Index), asAuto);
+    FBugs[Index] = asAuto;
   }
 
-  SetSpecial(false);
-  SetFSProtocol(CONST_DEFAULT_PROTOCOL);
-  SetAddressFamily(afAuto);
+  FSpecial = false;
+  FFSProtocol = CONST_DEFAULT_PROTOCOL;
+  FAddressFamily = afAuto;
   SetRekeyData(L"1G");
-  SetRekeyTime(MinsPerHour);
+  FRekeyTime = MinsPerHour;
 
   // FS common
   SetLocalDirectory(L"");
   SetRemoteDirectory(L"");
-  SetSynchronizeBrowsing(false);
-  SetUpdateDirectories(true);
-  SetCacheDirectories(true);
-  SetCacheDirectoryChanges(true);
-  SetPreserveDirectoryChanges(true);
-  SetLockInHome(false);
-  SetResolveSymlinks(true);
-  SetFollowDirectorySymlinks(true);
-  SetDSTMode(dstmUnix);
-  SetDeleteToRecycleBin(false);
-  SetOverwrittenToRecycleBin(false);
+  FSynchronizeBrowsing = false;
+  FUpdateDirectories = true;
+  FCacheDirectories = true;
+  FCacheDirectoryChanges = true;
+  FPreserveDirectoryChanges = true;
+  FLockInHome = false;
+  FResolveSymlinks = true;
+  FFollowDirectorySymlinks = true;
+  FDSTMode = dstmUnix;
+  FDeleteToRecycleBin = false;
+  FOverwrittenToRecycleBin = false;
   SetRecycleBinPath(L"");
-  SetColor(0);
+  FColor = 0;
   SetPostLoginCommands(L"");
 
   // SCP
   SetReturnVar(L"");
-  SetLookupUserGroups(asAuto);
-  SetEOLType(eolLF);
-  SetTrimVMSVersions(false),
+  FLookupUserGroups = asAuto;
+  FEOLType = eolLF;
+  FTrimVMSVersions = false;
   SetShell(L""); //default shell
   SetReturnVar(L"");
-  SetClearAliases(true);
-  SetUnsetNationalVars(true);
+  FClearAliases = true;
+  FUnsetNationalVars = true;
   SetListingCommand(L"ls -la");
-  SetIgnoreLsWarnings(true);
-  SetScp1Compatibility(false);
-  SetTimeDifference(TDateTime(0.0));
-  SetTimeDifferenceAuto(true);
-  SetSCPLsFullTime(asAuto);
-  SetNotUtf(asOn); // asAuto
+  FIgnoreLsWarnings = true;
+  FScp1Compatibility = false;
+  FTimeDifference = TDateTime(0.0);
+  FTimeDifferenceAuto = true;
+  FSCPLsFullTime = asAuto;
+  FNotUtf = asOn; // asAuto
 
   // SFTP
   SetSftpServer(L"");
-  SetSFTPDownloadQueue(32);
-  SetSFTPUploadQueue(32);
-  SetSFTPListingQueue(2);
-  SetSFTPMaxVersion(::SFTPMaxVersion);
-  SetSFTPMaxPacketSize(0);
-  SetSFTPMinPacketSize(0);
+  FSFTPDownloadQueue = 32;
+  FSFTPUploadQueue = 32;
+  FSFTPListingQueue = 2;
+  FSFTPMaxVersion = ::SFTPMaxVersion;
+  FSFTPMaxPacketSize = 0;
+  FSFTPMinPacketSize = 0;
 
   for (intptr_t Index = 0; Index < static_cast<intptr_t>(_countof(FSFTPBugs)); ++Index)
   {
-    SetSFTPBug(static_cast<TSftpBug>(Index), asAuto);
+    FSFTPBugs[Index] = asAuto;
   }
 
-  SetTunnel(false);
+  FTunnel = false;
   SetTunnelHostName(L"");
-  SetTunnelPortNumber(SshPortNumber);
+  FTunnelPortNumber = SshPortNumber;
   SetTunnelUserName(L"");
   SetTunnelPassword(L"");
   SetTunnelPublicKeyFile(L"");
-  SetTunnelLocalPortNumber(0);
+  FTunnelLocalPortNumber = 0;
   SetTunnelPortFwd(L"");
   SetTunnelHostKey(L"");
 
   // FTP
-  SetFtpPasvMode(true);
-  SetFtpForcePasvIp(asAuto);
-  SetFtpUseMlsd(asAuto);
+  FFtpPasvMode = true;
+  FFtpForcePasvIp = asAuto;
+  FFtpUseMlsd = asAuto;
   SetFtpAccount(L"");
-  SetFtpPingInterval(30);
-  SetFtpPingType(ptDummyCommand);
-  SetFtpTransferActiveImmediately(asAuto);
-  SetFtps(ftpsNone);
-  SetMinTlsVersion(tls10);
-  SetMaxTlsVersion(tls12);
-  SetFtpListAll(asAuto);
-  SetFtpHost(asAuto);
-  SetFtpDupFF(false);
-  SetFtpUndupFF(false);
-  SetSslSessionReuse(true);
+  FFtpPingInterval = 30;
+  FFtpPingType = ptDummyCommand;
+  FFtpTransferActiveImmediately = asAuto;
+  FFtps = ftpsNone;
+  FMinTlsVersion = tls10;
+  FMaxTlsVersion = tls12;
+  FFtpListAll = asAuto;
+  FFtpHost = asAuto;
+  FFtpDupFF = false;
+  FFtpUndupFF = false;
+  FSslSessionReuse = true;
   SetTlsCertificateFile(L"");
 
-  SetFtpProxyLogonType(0); // none
+  FFtpProxyLogonType = 0; // none
 
   SetCustomParam1(L"");
   SetCustomParam2(L"");
 
-  SetIsWorkspace(false);
+  FIsWorkspace = false;
   // SetLink(L"");
 
-  SetSelected(false);
+  FSelected = false;
   FModified = false;
   FSource = ::ssNone;
   FSaveOnly = false;
 
   SetCodePage(::GetCodePageAsString(CONST_DEFAULT_CODEPAGE));
-  SetLoginType(ltAnonymous);
-  SetFtpAllowEmptyPassword(false);
+  FLoginType = ltAnonymous;
+  FFtpAllowEmptyPassword = false;
 
   FNumberOfRetries = 0;
   FSessionVersion = ::StrToVersionNumber(GetGlobalFunctions()->GetStrVersionNumber());


### PR DESCRIPTION
Продолжаем бороться с сообщениями от valgrind.
Вот еще требует внимания:
```
==24529== Thread 7:
==24529== Source and destination overlap in memcpy(0x16673040, 0x16673040, 1280)
==24529==    at 0x4C32513: memcpy@@GLIBC_2.14 (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==24529==    by 0x46ACDE: memcpy (string3.h:53)
==24529==    by 0x46ACDE: swap_m(char*, char*, unsigned long, void*) (farrtl.cpp:1568)
==24529==    by 0x46BAAE: shortsort_m (farrtl.cpp:1532)
==24529==    by 0x46BAAE: qsort_m(void*, unsigned long, unsigned long, int (*)(void const*, void const*)) (farrtl.cpp:1291)
==24529==    by 0x176D7400: SetStartupInfo (MultiArc.cpp:40)
==24529==    by 0x557FDC: PluginA::SetStartupInfo(bool&) [clone .part.17] [clone .constprop.43] (PluginA.cpp:543)
==24529==    by 0x558068: PluginA::SetStartupInfo(bool&) (PluginA.cpp:526)
==24529==    by 0x557186: PluginA::Load() (PluginA.cpp:366)
==24529==    by 0x4FFE27: PluginManager::LoadPlugin(wchar_t const*, FAR_FIND_DATA_EX const&, bool) (plugins.cpp:270)
==24529==    by 0x5022D1: PluginManager::LoadPlugins() (plugins.cpp:452)
==24529==    by 0x43BB21: ControlObject::Init() (ctrlobj.cpp:129)
==24529==    by 0x4E592F: MainProcess(wchar_t const*, wchar_t const*, wchar_t const*, wchar_t const*, int, int) (main.cpp:221)
==24529==    by 0x4E65E2: MainProcessSEH (main.cpp:294)
==24529==    by 0x4E65E2: FarAppMain(int, char**) (main.cpp:549)
```

```
==24529== Conditional jump or move depends on uninitialised value(s)
==24529==    at 0x4E330A: KeyMacro::GetKey() (macro.cpp:4084)
==24529==    by 0x4CC181: GetInputRecord(_INPUT_RECORD*, bool, bool, bool) (keyboard.cpp:588)
==24529==    by 0x4E919F: Manager::ProcessMainLoop() (manager.cpp:701)
==24529==    by 0x4E93F3: Manager::EnterMainLoop() (manager.cpp:676)
==24529==    by 0x4E5ABF: MainProcess(wchar_t const*, wchar_t const*, wchar_t const*, wchar_t const*, int, int) (main.cpp:277)
==24529==    by 0x4E65E2: MainProcessSEH (main.cpp:294)
==24529==    by 0x4E65E2: FarAppMain(int, char**) (main.cpp:549)
==24529==    by 0x57AFAD: WinPortAppThread::Entry() (Main.cpp:37)
==24529==    by 0x5D7C4A1: wxThread::CallEntry() (in /usr/lib/x86_64-linux-gnu/libwx_baseu-3.0.so.0.2.0)
==24529==    by 0x5D82E92: ??? (in /usr/lib/x86_64-linux-gnu/libwx_baseu-3.0.so.0.2.0)
==24529==    by 0x69026F9: start_thread (pthread_create.c:333)
==24529==    by 0x6C1EB5C: clone (clone.S:109)
```
Я не стал их топорно чинить, т.к. может быть ошибка глубже.