### PR TITLE
strip maxAge from status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Linux port of FAR v2<br>
 PRE-ALPHA VERSION - currently interesting only for programmers!!!
 
-[![Travis](https://img.shields.io/travis/elfmz/far2l.svg?maxAge=2592000)](https://travis-ci.org/elfmz/far2l)
+[![Travis](https://img.shields.io/travis/elfmz/far2l.svg)](https://travis-ci.org/elfmz/far2l)
 
 Better use CodeLite to open and compile this<br>
 


### PR DESCRIPTION
There seems to be a bug in shields.io interface that produces cached badges, which is not what we want for public build status - https://github.com/badges/shields/issues/782 