### PR TITLE
remove ExtractIfExistCommand()

### DIFF
--- a/far2l/filelist.cpp
+++ b/far2l/filelist.cpp
@@ -4483,7 +4483,6 @@ bool FileList::ApplyCommand()
 		int PreserveLFN=SubstFileName(strConvertedCommand,strSelName,strSelShortName,&strListName,&strAnotherListName,&strShortListName, &strAnotherShortListName);
 		bool ListFileUsed=!strListName.IsEmpty()||!strAnotherListName.IsEmpty()||!strShortListName.IsEmpty()||!strAnotherShortListName.IsEmpty();
 
-		if (ExtractIfExistCommand(strConvertedCommand))
 		{
 			PreserveLongName PreserveName(strSelShortName,PreserveLFN);
 			RemoveExternalSpaces(strConvertedCommand);

--- a/far2l/filetype.cpp
+++ b/far2l/filetype.cpp
@@ -74,39 +74,6 @@ const FileTypeStrings FTS=
 };
 
 
-/* $ 25.04.2001 DJ
-   îáðàáîòêà @ â IF EXIST: ôóíêöèÿ, êîòîðàÿ èçâëåêàåò êîìàíäó èç ñòðîêè
-   ñ IF EXIST ñ ó÷åòîì @ è âîçâðàùàåò TRUE, åñëè óñëîâèå IF EXIST
-   âûïîëåíî, è FALSE â ïðîòèâíîì ñëó÷àå/
-*/
-
-bool ExtractIfExistCommand(FARString &strCommandText)
-{
-	bool Result=true;
-	const wchar_t *wPtrCmd=PrepareOSIfExist(strCommandText);
-
-	// Âî! Óñëîâèå íå âûïîëíåíî!!!
-	// (íàïðèìåð, ïîêà ðàññìàòðèâàëè ìåíþõó, â ýòî âðåìÿ)
-	// êàêîé-òî çëîáíûé ÷åáóðàøêà ñòåð ôàéë!
-	if (wPtrCmd)
-	{
-		if (!*wPtrCmd)
-		{
-			Result=false;
-		}
-		else
-		{
-			size_t offset = wPtrCmd-strCommandText.CPtr();
-			wchar_t *CommandText = strCommandText.GetBuffer();
-			wchar_t *PtrCmd = CommandText+offset;
-			// ïðîêèíåì "if exist"
-			wmemmove(CommandText+(*CommandText==L'@'?1:0),PtrCmd,StrLength(PtrCmd)+1);
-			strCommandText.ReleaseBuffer();
-		}
-	}
-
-	return Result;
-}
 
 int GetDescriptionWidth(const wchar_t *Name=nullptr,const wchar_t *ShortName=nullptr)
 {
@@ -242,10 +209,6 @@ bool ProcessLocalFileTypes(const wchar_t *Name, const wchar_t *ShortName, int Mo
 		FARString strCommandText = strCommand;
 		SubstFileName(strCommandText,Name,ShortName,nullptr,nullptr,nullptr,nullptr,TRUE);
 
-		// âñå "ïîäñòàâëåíî", òåïåðü ïðîâåðèì óñëîâèÿ "if exist"
-		if (!ExtractIfExistCommand(strCommandText))
-			continue;
-
 		ActualCmdCount++;
 		FARString strMenuText;
 
@@ -301,8 +264,6 @@ bool ProcessLocalFileTypes(const wchar_t *Name, const wchar_t *ShortName, int Mo
 	int PreserveLFN=SubstFileName(strCommand,Name,ShortName,&strListName,&strAnotherListName, &strShortListName, &strAnotherShortListName);
 	bool ListFileUsed=!strListName.IsEmpty()||!strAnotherListName.IsEmpty()||!strShortListName.IsEmpty()||!strAnotherShortListName.IsEmpty();
 
-	// Ñíîâà âñå "ïîäñòàâëåíî", òåïåðü ïðîâåðèì óñëîâèÿ "if exist"
-	if (ExtractIfExistCommand(strCommand))
 	{
 		PreserveLongName PreserveName(ShortName,PreserveLFN);
 		RemoveExternalSpaces(strCommand);
@@ -396,19 +357,11 @@ void ProcessExternal(const wchar_t *Command, const wchar_t *Name, const wchar_t 
 		int PreserveLFN=SubstFileName(strExecStr,Name,ShortName,&strListName,&strAnotherListName, &strShortListName, &strAnotherShortListName);
 		bool ListFileUsed=!strListName.IsEmpty()||!strAnotherListName.IsEmpty()||!strShortListName.IsEmpty()||!strAnotherShortListName.IsEmpty();
 
-		// Ñíîâà âñå "ïîäñòàâëåíî", òåïåðü ïðîâåðèì óñëîâèÿ "if exist"
-		if (!ExtractIfExistCommand(strExecStr))
-			return;
-
 		PreserveLongName PreserveName(ShortName,PreserveLFN);
 		ConvertNameToFull(Name,strFullName);
 		strFullShortName = strFullName;
 		//BUGBUGBUGBUGBUGBUG !!! Same ListNames!!!
 		SubstFileName(strFullExecStr,strFullName,strFullShortName,&strListName,&strAnotherListName, &strShortListName, &strAnotherShortListName);
-
-		// Ñíîâà âñå "ïîäñòàâëåíî", òåïåðü ïðîâåðèì óñëîâèÿ "if exist"
-		if (!ExtractIfExistCommand(strFullExecStr))
-			return;
 
 		CtrlObject->ViewHistory->AddToHistory(strFullExecStr,(AlwaysWaitFinish&1)+2);
 

--- a/far2l/filetype.hpp
+++ b/far2l/filetype.hpp
@@ -47,5 +47,4 @@ enum
 void ProcessGlobalFileTypes(const wchar_t *Name, bool AlwaysWaitFinish, bool RunAs);
 bool ProcessLocalFileTypes(const wchar_t *Name, const wchar_t *ShortName, int Mode, bool AlwaysWaitFinish);
 void ProcessExternal(const wchar_t *Command, const wchar_t *Name, const wchar_t *ShortName, bool AlwaysWaitFinish);
-bool ExtractIfExistCommand(FARString &strCommandText);
 void EditFileTypes();

--- a/far2l/usermenu.cpp
+++ b/far2l/usermenu.cpp
@@ -855,7 +855,6 @@ int UserMenu::ProcessSingleMenu(const wchar_t *MenuKey,int MenuPos,const wchar_t
 					int PreserveLFN=SubstFileName(strCommand,strName,strShortName,&strListName,&strAnotherListName, &strShortListName,&strAnotherShortListName, FALSE, strCmdLineDir);
 					bool ListFileUsed=!strListName.IsEmpty()||!strAnotherListName.IsEmpty()||!strShortListName.IsEmpty()||!strAnotherShortListName.IsEmpty();
 
-					if (ExtractIfExistCommand(strCommand))
 					{
 						PreserveLongName PreserveName(strShortName,PreserveLFN);
 						RemoveExternalSpaces(strCommand);

--- a/far2l/usermenu.cpp
+++ b/far2l/usermenu.cpp
@@ -836,7 +836,6 @@ int UserMenu::ProcessSingleMenu(const wchar_t *MenuKey,int MenuPos,const wchar_t
 				  ÝÒÎ âûïîëíÿåòñÿ âñåãäà, ò.ê. ïàðñèíã âñåé ñòðîêè èäåò, à íàäî
 				  ïðîâåðèòü ôàçó "if exist ..\a.bat", à óæ ïîòîì äåëàòü âûâîäû...
 				*/
-				//if(ExtractIfExistCommand(Command))
 				{
 					/* $ 01.05.2001 IS Îòêëþ÷èì äî ëó÷øèõ âðåìåí */
 					/*


### PR DESCRIPTION
предлагаю выкинуть ExtractIfExistCommand(), т.к.
1. она не работает, всегда возвращает false, т.к. PrepareOSIfExist() пустая.
2. из-за этого не работают file associations.
3. т.к. командная строка целиком передаётся /bin/sh нет смысла проверять существование исполняемого файла; даже его отсутсвие это нормальная ситуация, исполняться может не файл а функция из ~/.bashrc