### PR TITLE
remove ReservedFilenameSymbols

### DIFF
--- a/far2l/copy.cpp
+++ b/far2l/copy.cpp
@@ -1045,7 +1045,7 @@ ShellCopy::ShellCopy(Panel *SrcPanel,        // исходная панель (�
 					InsertQuote(strCopyDlgValue);
 				}
 
-				if (DestList.Set(strCopyDlgValue) && !wcspbrk(strCopyDlgValue,ReservedFilenameSymbols))
+				if (DestList.Set(strCopyDlgValue))
 				{
 					// Запомнить признак использования фильтра. KM
 					UseFilter=CopyDlg[ID_SC_USEFILTER].Selected;

--- a/far2l/fileedit.cpp
+++ b/far2l/fileedit.cpp
@@ -2159,9 +2159,6 @@ BOOL FileEditor::SetFileName(const wchar_t *NewFileName)
 
 	if (StrCmp(strFileName,MSG(MNewFileName)))
 	{
-		if (wcspbrk(strFileName, ReservedFilenameSymbols))
-			return FALSE;
-
 		ConvertNameToFull(strFileName, strFullFileName);
 		FARString strFilePath=strFullFileName;
 

--- a/far2l/pathmix.cpp
+++ b/far2l/pathmix.cpp
@@ -37,8 +37,6 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "pathmix.hpp"
 #include "strmix.hpp"
 
-const wchar_t *ReservedFilenameSymbols = L"<>|";
-
 NTPath::NTPath(LPCWSTR Src)
 {
 	if (Src&&*Src)

--- a/far2l/pathmix.hpp
+++ b/far2l/pathmix.hpp
@@ -33,8 +33,6 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-extern const wchar_t *ReservedFilenameSymbols;
-
 const size_t cVolumeGuidLen = 48;
 
 class NTPath


### PR DESCRIPTION
в линуксе имена файлов могут содержать <, > и | 
кейс: редактор (F4) такие файлы не открывал; вьювер открывал.