### PR TITLE
macos: fix idle performance problem

### DIFF
--- a/WinPort/src/UI/Main.cpp
+++ b/WinPort/src/UI/Main.cpp
@@ -384,8 +384,9 @@ void WinPortPanel::CheckForResizePending()
 				ir.Event.WindowBufferSizeEvent.dwSize.Y = height;
 				g_wx_con_in.Enqueue(&ir, 1);
 			}
-	
+#ifndef __APPLE__
 			Refresh(false);
+#endif
 		} else if (_resize_pending != RP_INSTANT) {
 			_resize_pending = RP_INSTANT;
 			//fprintf(stderr, "RP_INSTANT\n");


### PR DESCRIPTION
Теперь фоновая загрузка 1%. Однако ректы все равно избыточные, а скрол в эдиторе тормозит.
