### PR TITLE
Multiarc destination arc folder update

### DIFF
--- a/multiarc/src/arccmd.cpp
+++ b/multiarc/src/arccmd.cpp
@@ -344,6 +344,12 @@ int ArcCommand::ReplaceVar(char *Command,int &Length)
         }
       }
       break;
+    case 'r':
+      *Command=0;
+      if (RealArcDir && *RealArcDir) {
+        FSF.sprintf(Command,"%s/",RealArcDir);
+      }
+      break;
     case 'R':
       strcpy(Command,RealArcDir);
       if (UseSlash)

--- a/multiarc/src/arcput.cpp
+++ b/multiarc/src/arcput.cpp
@@ -665,7 +665,7 @@ int PluginClass::PutFiles(struct PluginPanelItem *PanelItem,int ItemsNumber,
     GetRegKey(pdd.ArcFormat,CmdNames[CommandType],Command,Command,sizeof(Command));
     ArcPlugin->GetDefaultCommands(ArcPluginNumber,ArcPluginType,CMD_ALLFILESMASK,AllFilesMask);
     GetRegKey(pdd.ArcFormat,"AllFilesMask",AllFilesMask,AllFilesMask,sizeof(AllFilesMask));
-    if (*CurDir && strstr(Command,"%%R")==NULL)
+    if (*CurDir && strstr(Command,"%%R")==NULL && strstr(Command,"%%r")==NULL)
     {
       const char *MsgItems[]={GetMsg(MWarning),GetMsg(MCannotPutToFolder),
                         GetMsg(MPutToRoot),GetMsg(MOk),GetMsg(MCancel)};


### PR DESCRIPTION
Multiarc has "%%R - Current archive folder" variable to specify destination archive sub-folder.  Unfortunately, it is always quoted, so combining it to form a path fails:
```
%%R/%%f
"fold name"/file name
```

This pull adds a new %%r variable (lowercase). It adds the current archive folder unquoted, and if the value is not empty, it appends a "/" - notice the quotes are added in the manually:
```
"%%r%%f"
"fold name/file name"
```
This allows adding to zpaq and probably other archives in sub folders.