### PR TITLE
Simplify README.md to use `make`

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,14 +52,14 @@ ninja -j4
 
 #### Macos build
 
- * Run brew install glib gawk
+ * Run brew install glib gawk cmake pkg-config
 
  * Build latest wxWidgets (brew version is not good one).
 Sample configuration: ./configure --disable-shared --disable-debug CC=clang CXX=clang++ CXXFLAGS="-stdlib=libc++ -std=c++11" OBJCXXFLAGS="-stdlib=libc++ -std=c++11" LDFLAGS=-stdlib=libc++ --enable-monolithic --enable-unicode
 
- * Run cmake -G "CodeLite - Unix Makefiles"
+ * Run cmake -G "Unix Makefiles"
 
- * Open FAR.workspace and build project
+ * Run make
 
 #### IDE Setup
 You can import the project into your favourite IDE like QtCreator, CodeLite or any other, which supports cmake or cmake is able to generate projects for


### PR DESCRIPTION
To avoid using IDE. Probably most users will just need to make binaries without opening the project in IDE.