### PR TITLE
Fix If logic

### DIFF
--- a/farftp/src/HGet.cpp
+++ b/farftp/src/HGet.cpp
@@ -177,7 +177,7 @@ int FTP::GetHostFiles(struct PluginPanelItem *PanelItem,int ItemsNumber,int Move
 
 			if(dest_exists)
 			{
-				if(!unlink(DestName)<0) WriteFailed=TRUE;
+				if(unlink(DestName) == -1) WriteFailed=TRUE;
 //				if(!WINPORT(DeleteFile)(DestName))
 	//				if(!WINPORT(SetFileAttributes)(DestName,FILE_ATTRIBUTE_NORMAL) && !DeleteFile(DestName//))
 		//				WriteFailed=TRUE;


### PR DESCRIPTION
From unlink man:
RETURN VALUE

    Upon successful completion, these functions shall return 0. Otherwise, these functions shall return -1 and set errno to indicate the error. If -1 is returned, the named file shall not be changed.