### PR TITLE
Cosmetic: remove some gcc wswitch warning

### DIFF
--- a/far2l/tvar.cpp
+++ b/far2l/tvar.cpp
@@ -241,14 +241,14 @@ static const wchar_t *toString(int64_t num)
 	static wchar_t str[128];
 	_i64tow(num, str, 10);
 	return str;
-};
+}
 
 static const wchar_t *toString(double num)
 {
 	static wchar_t str[256];
 	swprintf(str, ARRAYSIZE(str)-1, Opt.Macro.strMacroCONVFMT.CPtr(), num);
 	return str;
-};
+}
 
 static wchar_t *dubstr(const wchar_t *s)
 {
@@ -422,7 +422,7 @@ double TVar::toDouble()
 
 	vType = vtDouble;
 	return dnum;
-};
+}
 
 int64_t TVar::getInteger() const
 {
@@ -434,7 +434,7 @@ int64_t TVar::getInteger() const
 		ret=(int64_t)dnum;
 
 	return ret;
-};
+}
 
 double TVar::getDouble() const
 {
@@ -451,7 +451,6 @@ double TVar::getDouble() const
 	return ret;
 };
 
-
 static int _cmp_Ne(TVarType vt,const void *a, const void *b)
 {
 	int r = 1;
@@ -460,7 +459,8 @@ static int _cmp_Ne(TVarType vt,const void *a, const void *b)
 	{
 		case vtInteger: r = *(int64_t*)a != *(int64_t*)b?1:0; break;
 		case vtDouble:  r = *(double*)a != *(double*)b?1:0; break;
-		case vtString:  r = StrCmp((const wchar_t*)a, (const wchar_t*)b) ; break;
+		case vtString:  r = StrCmp((const wchar_t*)a, (const wchar_t*)b); break;
+		case vtUnknown: break;
 	}
 
 	return r;
@@ -475,10 +475,12 @@ static int _cmp_Eq(TVarType vt,const void *a, const void *b)
 		case vtInteger: r = *(int64_t*)a == *(int64_t*)b?1:0; break;
 		case vtDouble:  r = *(double*)a == *(double*)b?1:0; break;
 		case vtString:  r = !StrCmp((const wchar_t*)a, (const wchar_t*)b); break;
+		case vtUnknown: break;
 	}
 
 	return r;
 }
+
 static int _cmp_Lt(TVarType vt,const void *a, const void *b)
 {
 	int r = 0;
@@ -488,6 +490,7 @@ static int _cmp_Lt(TVarType vt,const void *a, const void *b)
 		case vtInteger: r = *(int64_t*)a < *(int64_t*)b?1:0; break;
 		case vtDouble:  r = *(double*)a < *(double*)b?1:0; break;
 		case vtString:  r = StrCmp((const wchar_t*)a, (const wchar_t*)b) < 0; break;
+		case vtUnknown: break;
 	}
 
 	return r;
@@ -502,6 +505,7 @@ static int _cmp_Le(TVarType vt,const void *a, const void *b)
 		case vtInteger: r = *(int64_t*)a <= *(int64_t*)b?1:0; break;
 		case vtDouble:  r = *(double*)a <= *(double*)b?1:0; break;
 		case vtString:  r = StrCmp((const wchar_t*)a, (const wchar_t*)b) <= 0; break;
+		case vtUnknown: break;
 	}
 
 	return r;
@@ -516,6 +520,7 @@ static int _cmp_Gt(TVarType vt,const void *a, const void *b)
 		case vtInteger: r = *(int64_t*)a > *(int64_t*)b?1:0; break;
 		case vtDouble:  r = *(double*)a > *(double*)b?1:0; break;
 		case vtString:  r = StrCmp((const wchar_t*)a, (const wchar_t*)b) > 0; break;
+		case vtUnknown: break;
 	}
 
 	return r;
@@ -530,6 +535,7 @@ static int _cmp_Ge(TVarType vt,const void *a, const void *b)
 		case vtInteger: r = *(int64_t*)a >= *(int64_t*)b?1:0; break;
 		case vtDouble:  r = *(double*)a >= *(double*)b?1:0; break;
 		case vtString:  r = StrCmp((const wchar_t*)a, (const wchar_t*)b) >= 0; break;
+		case vtUnknown: break;
 	}
 
 	return r;
@@ -548,18 +554,19 @@ int TVar::CompAB(const TVar& a, const TVar& b, TVarFuncCmp fcmp)
 			switch (b.vType)
 			{
 				case vtInteger: r = fcmp(vtInteger,&a.inum,&b.inum); break;
-				case vtDouble:  r = fcmp(vtDouble,&a.inum,&b.dnum);  break;
+				case vtDouble:  r = fcmp(vtDouble,&a.inum,&b.dnum); break;
 				case vtString:
 				{
 					switch (checkTypeString(b.s()))
 					{
 						case tsStr:             r = fcmp(vtString,a.s(),b.str); break;
-						case tsInt:   bi=b.i(); r = fcmp(vtInteger,&a.inum,&bi);  break;
-						case tsFloat: bd=b.d(); r = fcmp(vtDouble,&a.inum,&bd);   break;
+						case tsInt:   bi=b.i(); r = fcmp(vtInteger,&a.inum,&bi); break;
+						case tsFloat: bd=b.d(); r = fcmp(vtDouble,&a.inum,&bd); break;
 					}
 
 					break;
 				}
+				case vtUnknown: break;
 			}
 
 			break;
@@ -575,11 +582,12 @@ int TVar::CompAB(const TVar& a, const TVar& b, TVarFuncCmp fcmp)
 					{
 						case tsStr:             r = fcmp(vtString,a.s(),b.str); break;
 						case tsInt:
-						case tsFloat: bd=b.d(); r = fcmp(vtDouble,&a.inum,&bd);   break;
+						case tsFloat: bd=b.d(); r = fcmp(vtDouble,&a.inum,&bd); break;
 					}
 
 					break;
 				}
+				case vtUnknown: break;
 			}
 
 			break;
@@ -617,6 +625,7 @@ int TVar::CompAB(const TVar& a, const TVar& b, TVarFuncCmp fcmp)
 #endif
 			break;
 		}
+		case vtUnknown: break;
 	}
 
 	return r;
@@ -662,19 +671,20 @@ TVar operator+(const TVar& a, const TVar& b)
 		{
 			switch (b.vType)
 			{
-				case vtInteger: r = a.inum + b.inum;                   break;
-				case vtDouble:  r = (double)a.inum + b.dnum;           break;
+				case vtInteger: r = a.inum + b.inum; break;
+				case vtDouble:  r = (double)a.inum + b.dnum; break;
 				case vtString:
 				{
 					switch (checkTypeString(b.str))
 					{
-						case tsStr:   r = addStr(::toString(a.inum), b.s());   break;
-						case tsInt:   r = a.inum + b.i();                  break;
-						case tsFloat: r = (double)a.inum + b.d();          break;
+						case tsStr:   r = addStr(::toString(a.inum), b.s()); break;
+						case tsInt:   r = a.inum + b.i(); break;
+						case tsFloat: r = (double)a.inum + b.d(); break;
 					}
 
 					break;
 				}
+				case vtUnknown: break;
 			}
 
 			break;
@@ -683,19 +693,20 @@ TVar operator+(const TVar& a, const TVar& b)
 		{
 			switch (b.vType)
 			{
-				case vtInteger: r = (double)a.inum + b.dnum;                break;
-				case vtDouble:  r = a.dnum + b.dnum;                        break;
+				case vtInteger: r = (double)a.inum + b.dnum; break;
+				case vtDouble:  r = a.dnum + b.dnum; break;
 				case vtString:
 				{
 					switch (checkTypeString(b.str))
 					{
-						case tsStr:   r = addStr(::toString(a.dnum), b.s());  break;
+						case tsStr:   r = addStr(::toString(a.dnum), b.s()); break;
 						case tsInt:
 						case tsFloat: r = a.dnum * b.d(); break;
 					}
 
 					break;
 				}
+				case vtUnknown: break;
 			}
 
 			break;
@@ -720,6 +731,7 @@ TVar operator+(const TVar& a, const TVar& b)
 
 			break;
 		}
+		case vtUnknown: break;
 	}
 
 	return r;
@@ -735,19 +747,20 @@ TVar operator-(const TVar& a, const TVar& b)
 		{
 			switch (b.vType)
 			{
-				case vtInteger: r = a.inum - b.inum;                   break;
-				case vtDouble:  r = (double)a.inum - b.dnum;           break;
+				case vtInteger: r = a.inum - b.inum; break;
+				case vtDouble:  r = (double)a.inum - b.dnum; break;
 				case vtString:
 				{
 					switch (checkTypeString(b.str))
 					{
 						case tsStr:   r = a; break; //addStr(::toString(a.inum), b.s());   break;
-						case tsInt:   r = a.inum - b.i();                  break;
-						case tsFloat: r = (double)a.inum - b.d();          break;
+						case tsInt:   r = a.inum - b.i(); break;
+						case tsFloat: r = (double)a.inum - b.d(); break;
 					}
 
 					break;
 				}
+				case vtUnknown: break;
 			}
 
 			break;
@@ -756,8 +769,8 @@ TVar operator-(const TVar& a, const TVar& b)
 		{
 			switch (b.vType)
 			{
-				case vtInteger: r = (double)a.inum - b.dnum;                break;
-				case vtDouble:  r = a.dnum - b.dnum;                        break;
+				case vtInteger: r = (double)a.inum - b.dnum; break;
+				case vtDouble:  r = a.dnum - b.dnum; break;
 				case vtString:
 				{
 					switch (checkTypeString(b.str))
@@ -769,6 +782,7 @@ TVar operator-(const TVar& a, const TVar& b)
 
 					break;
 				}
+				case vtUnknown: break;
 			}
 
 			break;
@@ -793,6 +807,7 @@ TVar operator-(const TVar& a, const TVar& b)
 
 			break;
 		}
+		case vtUnknown: break;
 	}
 
 	return r;
@@ -814,13 +829,14 @@ TVar operator*(const TVar& a, const TVar& b)
 				{
 					switch (checkTypeString(b.str))
 					{
-						case tsStr:   r = a;     break;
+						case tsStr:   r = a; break;
 						case tsInt:   r = a.inum * b.i(); break;
 						case tsFloat: r = (double)a.inum * b.d(); break;
 					}
 
 					break;
 				}
+				case vtUnknown: break;
 			}
 
 			break;
@@ -829,19 +845,20 @@ TVar operator*(const TVar& a, const TVar& b)
 		{
 			switch (b.vType)
 			{
-				case vtInteger: r = a.dnum * (double)b.inum;          break;
-				case vtDouble:  r = a.dnum * b.dnum;                  break;
+				case vtInteger: r = a.dnum * (double)b.inum; break;
+				case vtDouble:  r = a.dnum * b.dnum; break;
 				case vtString:
 				{
 					switch (checkTypeString(b.str))
 					{
-						case tsStr:   r = a;     break;
+						case tsStr:   r = a; break;
 						case tsInt:
 						case tsFloat: r = a.dnum * b.d(); break;
 					}
 
 					break;
 				}
+				case vtUnknown: break;
 			}
 
 			break;
@@ -866,6 +883,7 @@ TVar operator*(const TVar& a, const TVar& b)
 
 			break;
 		}
+		case vtUnknown: break;
 	}
 
 	return r;
@@ -887,7 +905,7 @@ TVar operator/(const TVar& a, const TVar& b)
 				{
 					switch (checkTypeString(b.str))
 					{
-						case tsStr:   r = a;     break;
+						case tsStr:   r = a; break;
 						case tsInt:
 						{
 							int64_t bi=b.i();
@@ -902,6 +920,7 @@ TVar operator/(const TVar& a, const TVar& b)
 
 					break;
 				}
+				case vtUnknown: break;
 			}
 
 			break;
@@ -916,7 +935,7 @@ TVar operator/(const TVar& a, const TVar& b)
 				{
 					switch (checkTypeString(b.str))
 					{
-						case tsStr:   r = a;     break;
+						case tsStr:   r = a; break;
 						case tsInt:
 						case tsFloat:
 						{
@@ -927,6 +946,7 @@ TVar operator/(const TVar& a, const TVar& b)
 
 					break;
 				}
+				case vtUnknown: break;
 			}
 
 			break;
@@ -957,6 +977,7 @@ TVar operator/(const TVar& a, const TVar& b)
 
 			break;
 		}
+		case vtUnknown: break;
 	}
 
 	return r;
@@ -978,7 +999,7 @@ TVar operator%(const TVar& a, const TVar& b)
 				{
 					switch (checkTypeString(b.str))
 					{
-						case tsStr:   r = a;     break;
+						case tsStr:   r = a; break;
 						case tsInt:
 						{
 							int64_t bi=b.i();
@@ -993,6 +1014,7 @@ TVar operator%(const TVar& a, const TVar& b)
 
 					break;
 				}
+				case vtUnknown: break;
 			}
 
 			break;
@@ -1007,7 +1029,7 @@ TVar operator%(const TVar& a, const TVar& b)
 				{
 					switch (checkTypeString(b.str))
 					{
-						case tsStr:   r = a;     break;
+						case tsStr:   r = a; break;
 						case tsInt:
 						case tsFloat:
 						{
@@ -1018,6 +1040,7 @@ TVar operator%(const TVar& a, const TVar& b)
 
 					break;
 				}
+				case vtUnknown: break;
 			}
 
 			break;
@@ -1048,6 +1071,7 @@ TVar operator%(const TVar& a, const TVar& b)
 
 			break;
 		}
+		case vtUnknown: break;
 	}
 
 	return r;
@@ -1063,19 +1087,20 @@ TVar operator|(const TVar& a, const TVar& b)
 		{
 			switch (b.vType)
 			{
-				case vtInteger: r = a.inum | b.inum;                  break;
-				case vtDouble:  r = a.inum | b.i();                   break;
+				case vtInteger: r = a.inum | b.inum; break;
+				case vtDouble:  r = a.inum | b.i(); break;
 				case vtString:
 				{
 					switch (checkTypeString(b.str))
 					{
-						case tsStr:   r = a;     break;
+						case tsStr:   r = a; break;
 						case tsInt:
 						case tsFloat: r = a.inum | b.i(); break;
 					}
 
 					break;
 				}
+				case vtUnknown: break;
 			}
 
 			break;
@@ -1084,19 +1109,20 @@ TVar operator|(const TVar& a, const TVar& b)
 		{
 			switch (b.vType)
 			{
-				case vtInteger: r = a.i() | b.inum;                   break;
-				case vtDouble:  r = a.i() | b.i();                    break;
+				case vtInteger: r = a.i() | b.inum; break;
+				case vtDouble:  r = a.i() | b.i(); break;
 				case vtString:
 				{
 					switch (checkTypeString(b.str))
 					{
-						case tsStr:   r = a;     break;
+						case tsStr:   r = a; break;
 						case tsInt:
 						case tsFloat: r = a.i() | b.i(); break;
 					}
 
 					break;
 				}
+				case vtUnknown: break;
 			}
 
 			break;
@@ -1119,6 +1145,7 @@ TVar operator|(const TVar& a, const TVar& b)
 
 			break;
 		}
+		case vtUnknown: break;
 	}
 
 	return r;
@@ -1134,19 +1161,20 @@ TVar operator&(const TVar& a, const TVar& b)
 		{
 			switch (b.vType)
 			{
-				case vtInteger: r = a.inum & b.inum;                  break;
-				case vtDouble:  r = a.inum & b.i();                   break;
+				case vtInteger: r = a.inum & b.inum; break;
+				case vtDouble:  r = a.inum & b.i(); break;
 				case vtString:
 				{
 					switch (checkTypeString(b.str))
 					{
-						case tsStr:   r = a;     break;
+						case tsStr:   r = a; break;
 						case tsInt:
 						case tsFloat: r = a.inum & b.i(); break;
 					}
 
 					break;
 				}
+				case vtUnknown: break;
 			}
 
 			break;
@@ -1155,19 +1183,20 @@ TVar operator&(const TVar& a, const TVar& b)
 		{
 			switch (b.vType)
 			{
-				case vtInteger: r = a.i() & b.inum;                   break;
-				case vtDouble:  r = a.i() & b.i();                    break;
+				case vtInteger: r = a.i() & b.inum; break;
+				case vtDouble:  r = a.i() & b.i(); break;
 				case vtString:
 				{
 					switch (checkTypeString(b.str))
 					{
-						case tsStr:   r = a;     break;
+						case tsStr:   r = a; break;
 						case tsInt:
 						case tsFloat: r = a.i() & b.i(); break;
 					}
 
 					break;
 				}
+				case vtUnknown: break;
 			}
 
 			break;
@@ -1190,6 +1219,7 @@ TVar operator&(const TVar& a, const TVar& b)
 
 			break;
 		}
+		case vtUnknown: break;
 	}
 
 	return r;
@@ -1205,19 +1235,20 @@ TVar operator^(const TVar& a, const TVar& b)
 		{
 			switch (b.vType)
 			{
-				case vtInteger: r = a.inum ^ b.inum;                  break;
-				case vtDouble:  r = a.inum ^ b.i();                   break;
+				case vtInteger: r = a.inum ^ b.inum; break;
+				case vtDouble:  r = a.inum ^ b.i(); break;
 				case vtString:
 				{
 					switch (checkTypeString(b.str))
 					{
-						case tsStr:   r = a;     break;
+						case tsStr:   r = a; break;
 						case tsInt:
 						case tsFloat: r = a.inum ^ b.i(); break;
 					}
 
 					break;
 				}
+				case vtUnknown: break;
 			}
 
 			break;
@@ -1226,19 +1257,20 @@ TVar operator^(const TVar& a, const TVar& b)
 		{
 			switch (b.vType)
 			{
-				case vtInteger: r = a.i() ^ b.inum;                   break;
-				case vtDouble:  r = a.i() ^ b.i();                    break;
+				case vtInteger: r = a.i() ^ b.inum; break;
+				case vtDouble:  r = a.i() ^ b.i(); break;
 				case vtString:
 				{
 					switch (checkTypeString(b.str))
 					{
-						case tsStr:   r = a;     break;
+						case tsStr:   r = a; break;
 						case tsInt:
 						case tsFloat: r = a.i() ^ b.i(); break;
 					}
 
 					break;
 				}
+				case vtUnknown: break;
 			}
 
 			break;
@@ -1261,6 +1293,7 @@ TVar operator^(const TVar& a, const TVar& b)
 
 			break;
 		}
+		case vtUnknown: break;
 	}
 
 	return r;
@@ -1276,19 +1309,20 @@ TVar operator>>(const TVar& a, const TVar& b)
 		{
 			switch (b.vType)
 			{
-				case vtInteger: r = a.inum >> b.inum;                  break;
-				case vtDouble:  r = a.inum >> b.i();                   break;
+				case vtInteger: r = a.inum >> b.inum; break;
+				case vtDouble:  r = a.inum >> b.i(); break;
 				case vtString:
 				{
 					switch (checkTypeString(b.str))
 					{
-						case tsStr:   r = a;     break;
+						case tsStr:   r = a; break;
 						case tsInt:
 						case tsFloat: r = a.inum >> b.i(); break;
 					}
 
 					break;
 				}
+				case vtUnknown: break;
 			}
 
 			break;
@@ -1297,19 +1331,20 @@ TVar operator>>(const TVar& a, const TVar& b)
 		{
 			switch (b.vType)
 			{
-				case vtInteger: r = a.i() >> b.inum;                   break;
-				case vtDouble:  r = a.i() >> b.i();                    break;
+				case vtInteger: r = a.i() >> b.inum; break;
+				case vtDouble:  r = a.i() >> b.i(); break;
 				case vtString:
 				{
 					switch (checkTypeString(b.str))
 					{
-						case tsStr:   r = a;     break;
+						case tsStr:   r = a; break;
 						case tsInt:
 						case tsFloat: r = a.i() >> b.i(); break;
 					}
 
 					break;
 				}
+				case vtUnknown: break;
 			}
 
 			break;
@@ -1332,6 +1367,7 @@ TVar operator>>(const TVar& a, const TVar& b)
 
 			break;
 		}
+		case vtUnknown: break;
 	}
 
 	return r;
@@ -1347,19 +1383,20 @@ TVar operator<<(const TVar& a, const TVar& b)
 		{
 			switch (b.vType)
 			{
-				case vtInteger: r = a.inum << b.inum;                  break;
-				case vtDouble:  r = a.inum << b.i();                   break;
+				case vtInteger: r = a.inum << b.inum; break;
+				case vtDouble:  r = a.inum << b.i(); break;
 				case vtString:
 				{
 					switch (checkTypeString(b.str))
 					{
-						case tsStr:   r = a;     break;
+						case tsStr:   r = a; break;
 						case tsInt:
 						case tsFloat: r = a.inum << b.i(); break;
 					}
 
 					break;
 				}
+				case vtUnknown: break;
 			}
 
 			break;
@@ -1368,19 +1405,20 @@ TVar operator<<(const TVar& a, const TVar& b)
 		{
 			switch (b.vType)
 			{
-				case vtInteger: r = a.i() << b.inum;                   break;
-				case vtDouble:  r = a.i() << b.i();                    break;
+				case vtInteger: r = a.i() << b.inum; break;
+				case vtDouble:  r = a.i() << b.i(); break;
 				case vtString:
 				{
 					switch (checkTypeString(b.str))
 					{
-						case tsStr:   r = a;     break;
+						case tsStr:   r = a; break;
 						case tsInt:
 						case tsFloat: r = a.i() << b.i(); break;
 					}
 
 					break;
 				}
+				case vtUnknown: break;
 			}
 
 			break;
@@ -1403,6 +1441,7 @@ TVar operator<<(const TVar& a, const TVar& b)
 
 			break;
 		}
+		case vtUnknown: break;
 	}
 
 	return r;
@@ -1421,6 +1460,7 @@ TVar operator||(const TVar& a, const TVar& b)
 				case vtInteger: r = a.inum || b.inum?1:0; break;
 				case vtDouble:  r = a.inum || b.dnum?1:0; break;
 				case vtString:  r = a.inum || *b.str?1:0; break;
+				case vtUnknown: break;
 			}
 
 			break;
@@ -1432,6 +1472,7 @@ TVar operator||(const TVar& a, const TVar& b)
 				case vtInteger: r = a.dnum || b.inum?1:0; break;
 				case vtDouble:  r = a.dnum || b.dnum?1:0; break;
 				case vtString:  r = a.dnum || *b.str?1:0; break;
+				case vtUnknown: break;
 			}
 
 			break;
@@ -1440,13 +1481,15 @@ TVar operator||(const TVar& a, const TVar& b)
 		{
 			switch (b.vType)
 			{
-				case vtInteger: r = *a.str || b.inum?1:0;  break;
-				case vtDouble:  r = *a.str || b.dnum?1:0;   break;
+				case vtInteger: r = *a.str || b.inum?1:0; break;
+				case vtDouble:  r = *a.str || b.dnum?1:0; break;
 				case vtString:  r = *a.str || *b.str?1:0; break;
+				case vtUnknown: break;
 			}
 
 			break;
 		}
+		case vtUnknown: break;
 	}
 
 	return r;
@@ -1465,6 +1508,7 @@ TVar operator&&(const TVar& a, const TVar& b)
 				case vtInteger: r = a.inum && b.inum?1:0; break;
 				case vtDouble:  r = a.inum && b.dnum?1:0; break;
 				case vtString:  r = a.inum && *b.str?1:0; break;
+				case vtUnknown: break;
 			}
 
 			break;
@@ -1476,6 +1520,7 @@ TVar operator&&(const TVar& a, const TVar& b)
 				case vtInteger: r = a.dnum && b.inum?1:0; break;
 				case vtDouble:  r = a.dnum && b.dnum?1:0; break;
 				case vtString:  r = a.dnum && *b.str?1:0; break;
+				case vtUnknown: break;
 			}
 
 			break;
@@ -1484,13 +1529,15 @@ TVar operator&&(const TVar& a, const TVar& b)
 		{
 			switch (b.vType)
 			{
-				case vtInteger: r = *a.str && b.inum?1:0;  break;
-				case vtDouble:  r = *a.str && b.dnum?1:0;   break;
+				case vtInteger: r = *a.str && b.inum?1:0; break;
+				case vtDouble:  r = *a.str && b.dnum?1:0; break;
 				case vtString:  r = *a.str && *b.str?1:0; break;
+				case vtUnknown: break;
 			}
 
 			break;
 		}
+		case vtUnknown: break;
 	}
 
 	return r;
@@ -1509,6 +1556,7 @@ TVar xor_op(const TVar& a, const TVar& b)
 				case vtInteger: r = (a.inum || b.inum) && (! (a.inum && b.inum))?1:0; break;
 				case vtDouble:  r = (a.inum || b.dnum) && (! (a.inum && b.dnum))?1:0; break;
 				case vtString:  r = (a.inum || *b.str) && (! (a.inum && *b.str))?1:0; break;
+				case vtUnknown: break;
 			}
 
 			break;
@@ -1520,6 +1568,7 @@ TVar xor_op(const TVar& a, const TVar& b)
 				case vtInteger: r = (a.dnum || b.inum) && (! (a.dnum && b.inum))?1:0; break;
 				case vtDouble:  r = (a.dnum || b.dnum) && (! (a.dnum && b.dnum))?1:0; break;
 				case vtString:  r = (a.dnum || *b.str) && (! (a.dnum && *b.str))?1:0; break;
+				case vtUnknown: break;
 			}
 
 			break;
@@ -1531,10 +1580,12 @@ TVar xor_op(const TVar& a, const TVar& b)
 				case vtInteger: r = (*a.str || b.inum) && (! (*a.str && b.inum))?1:0; break;
 				case vtDouble:  r = (*a.str || b.dnum) && (! (*a.str && b.dnum))?1:0; break;
 				case vtString:  r = (*a.str || *b.str) && (! (*a.str && *b.str))?1:0; break;
+				case vtUnknown: break;
 			}
 
 			break;
 		}
+		case vtUnknown: break;
 	}
 
 	return r;

--- a/inside/src/inside.cpp
+++ b/inside/src/inside.cpp
@@ -266,9 +266,9 @@ SHAREDSYMBOL int WINAPI _export Configure(int ItemNumber)
 		return 0;
 
 	struct FarDialogItem fdi[] = {
-            {DI_DOUBLEBOX,  3,  1,  70, 5,  0,0,0,0, 0},
-            {DI_TEXT,      -1,  2,  0,  2,  0,0,0,0, 0},
-            {DI_BUTTON,     34, 4,  0,  4,  0,0,0,0, 0}
+            {DI_DOUBLEBOX,  3,  1,  70, 5,  0,{},0,0, {}},
+            {DI_TEXT,      -1,  2,  0,  2,  0,{},0,0, {}},
+            {DI_BUTTON,     34, 4,  0,  4,  0,{},0,0, {}}
 	};
 
 	strncpy(fdi[0].Data, G.GetMsg(MTitle), sizeof(fdi[0].Data));


### PR DESCRIPTION
По второму, где 0 на {} меняется: для полей-стуктур это ведь более корректная запись? Если по какой-либо причине не подходит, можешь отклонить, так то в коде много таких мест, это так сказать на пробу.