### PR TITLE
Remove useless checks for uint variables

### DIFF
--- a/WinPort/src/APITime.cpp
+++ b/WinPort/src/APITime.cpp
@@ -111,10 +111,10 @@ WINPORT_DECL(SystemTimeToFileTime, BOOL, (const SYSTEMTIME *lpSystemTime, LPFILE
 
 	/* FIXME: normalize the TIME_FIELDS structure here */
 	/* No, native just returns 0 (error) if the fields are not */
-	if( lpSystemTime->wMilliseconds< 0 || lpSystemTime->wMilliseconds > 999 ||
-		lpSystemTime->wSecond < 0 || lpSystemTime->wSecond > 59 ||
-		lpSystemTime->wMinute < 0 || lpSystemTime->wMinute > 59 ||
-		lpSystemTime->wHour < 0 || lpSystemTime->wHour > 23 ||
+	if(     lpSystemTime->wMilliseconds > 999 ||
+		lpSystemTime->wSecond > 59 ||
+		lpSystemTime->wMinute > 59 ||
+		lpSystemTime->wHour > 23 ||
 		lpSystemTime->wMonth < 1 || lpSystemTime->wMonth > 12 ||
 		lpSystemTime->wDay < 1 ||
 		lpSystemTime->wDay > MonthLengths [ lpSystemTime->wMonth ==2 || IsLeapYear(lpSystemTime->wYear)] [ lpSystemTime->wMonth - 1] ||


### PR DESCRIPTION
Related to https://github.com/elfmz/far2l/issues/418
Maybe also put assert check for this line https://github.com/elfmz/far2l/blob/master/far2l/vtlog.cpp#L141 and put comment /* check for bug uint <0 */ near this line https://github.com/elfmz/far2l/blob/master/far2l/macro.cpp#L5564 ?