### PR TITLE
Fixed the right-ctrl support

### DIFF
--- a/WinPort/src/Backend/WX/wxWinTranslations.cpp
+++ b/WinPort/src/Backend/WX/wxWinTranslations.cpp
@@ -335,7 +335,7 @@ wx2INPUT_RECORD::wx2INPUT_RECORD(wxKeyEvent& event, BOOL KeyDown)
 		Event.KeyEvent.dwControlKeyState|= LEFT_ALT_PRESSED;
 
 	if (event.ControlDown())
-		Event.KeyEvent.dwControlKeyState|= LEFT_CTRL_PRESSED;
+		Event.KeyEvent.dwControlKeyState|= RIGHT_CTRL_PRESSED;
 		
 		
 }


### PR DESCRIPTION
Каждый раз при обновлении и пересборке у себя фара приходится менять одну строчку, чтобы заработл правый Ctrl, чтобы корректно работали закладки по RCtrl+1 RCtrl+2 RCtrl+3 и т.д. Очень привык к ним. До этого вроде работало только c левым Ctrl. Поэтому решил запелить Pull Request ) Надеюсь примите изменеия. 

Ну и огромное вам спасибо за порт Far на Linux, это было единственное, что меня мучало при переходе на Linux c винды (и не меня одного), теперь жизнь прекрасна )