### PR TITLE
fix for CopyToSelf check

### DIFF
--- a/editorcomp/src/Editor.cpp
+++ b/editorcomp/src/Editor.cpp
@@ -284,15 +284,7 @@ void Editor::putSuggestion() {
                     this->suggestion = fi.substr(prefix.length(), cp - prefix.length());
                     this->suggestionRow = ei.CurLine;
                     this->suggestionCol = ei.CurPos;
-
-                    EditorUndoRedo eur = {0};
-                    eur.Command = EUR_BEGIN;
-                    info.EditorControl(ECTL_UNDOREDO, &eur);
-
                     info.EditorControl(ECTL_INSERTTEXT, (void *) suggestion.c_str());
-
-                    eur.Command = EUR_END;
-                    info.EditorControl(ECTL_UNDOREDO, &eur);
 
 #if defined(DEBUG_EDITORCOMP)
                     debug("Added suggestion of length " + std::to_string(suggestion.length()) +
@@ -367,9 +359,8 @@ void Editor::declineSuggestion() {
 
         const EditorInfo &editorInfo = getInfo();
         if (editorInfo.CurLine == suggestionRow && editorInfo.CurPos == suggestionCol) {
-            EditorUndoRedo eur = {0};
-            eur.Command = EUR_UNDO;
-            info.EditorControl(ECTL_UNDOREDO, &eur);
+            for (int i = 0; i < int(suggestion.length()); i++)
+                info.EditorControl(ECTL_DELETECHAR, nullptr);
         } else {
             int beforeRow = editorInfo.CurLine;
             int beforeCol = editorInfo.CurPos;

--- a/far2l/copy.cpp
+++ b/far2l/copy.cpp
@@ -486,9 +486,11 @@ CopyProgress *CP;
 
 static int CmpFullNames(const wchar_t *Src,const wchar_t *Dest)
 {
-	FARString strSrcFullName = Src, strDestFullName = Dest;
+	FARString strSrcFullName, strDestFullName;
 
 	// получим полные пути с учетом символических связей
+    	ConvertNameToFull(Src, strSrcFullName);
+    	ConvertNameToFull(Dest, strDestFullName);
 	DeleteEndSlash(strSrcFullName);
 	DeleteEndSlash(strDestFullName);
 


### PR DESCRIPTION
CmpFullNames() didn't use ConvertNameToFull() 
this caused CopyToSelf check to fail in case of copying files from current directory to itself, but with full path specification like this:
*.cpp  -> /full/path/to/current/dir/ 
So it was possible to mistakenly truncate all copied files to 0 
Proposed patch fixes this problem.