### PR TITLE
fix for wrong detection files as Unicode

### DIFF
--- a/editorcomp/src/Editor.cpp
+++ b/editorcomp/src/Editor.cpp
@@ -284,15 +284,7 @@ void Editor::putSuggestion() {
                     this->suggestion = fi.substr(prefix.length(), cp - prefix.length());
                     this->suggestionRow = ei.CurLine;
                     this->suggestionCol = ei.CurPos;
-
-                    EditorUndoRedo eur = {0};
-                    eur.Command = EUR_BEGIN;
-                    info.EditorControl(ECTL_UNDOREDO, &eur);
-
                     info.EditorControl(ECTL_INSERTTEXT, (void *) suggestion.c_str());
-
-                    eur.Command = EUR_END;
-                    info.EditorControl(ECTL_UNDOREDO, &eur);
 
 #if defined(DEBUG_EDITORCOMP)
                     debug("Added suggestion of length " + std::to_string(suggestion.length()) +
@@ -367,9 +359,8 @@ void Editor::declineSuggestion() {
 
         const EditorInfo &editorInfo = getInfo();
         if (editorInfo.CurLine == suggestionRow && editorInfo.CurPos == suggestionCol) {
-            EditorUndoRedo eur = {0};
-            eur.Command = EUR_UNDO;
-            info.EditorControl(ECTL_UNDOREDO, &eur);
+            for (int i = 0; i < int(suggestion.length()); i++)
+                info.EditorControl(ECTL_DELETECHAR, nullptr);
         } else {
             int beforeRow = editorInfo.CurLine;
             int beforeCol = editorInfo.CurPos;

--- a/far2l/filestr.cpp
+++ b/far2l/filestr.cpp
@@ -925,7 +925,10 @@ bool GetFileFormat(File& file, UINT& nCodePage, bool* pSignatureFound, bool bUse
 					}
 				}
 			}
-			else if (IsTextUTF8(reinterpret_cast<LPBYTE>(Buffer), ReadSize))
+			if(bDetect) {
+				// do nothing
+			} else
+			if (IsTextUTF8(reinterpret_cast<LPBYTE>(Buffer), ReadSize))
 			{
 				nCodePage=CP_UTF8;
 				bDetect=true;


### PR DESCRIPTION
originally IsTextUnicode was used as the 1st test for unicode. 
Them return flags are checked if it is REALLY unicode.
Below we had UTF8 and euristic codepage checks
But due to wrong condition we never get to these check if IsTextUnicode reported that MY BY we have unicode check, regardless of further inspection on our side.
Actually we should continue with codepage checks if IsTextUnicode returns TRUE, but flag analysis tells that it doesn not.