### PR TITLE
fix for Hex pgUp/Down offset missmatch issue #474

### DIFF
--- a/editorcomp/src/Editor.cpp
+++ b/editorcomp/src/Editor.cpp
@@ -284,15 +284,7 @@ void Editor::putSuggestion() {
                     this->suggestion = fi.substr(prefix.length(), cp - prefix.length());
                     this->suggestionRow = ei.CurLine;
                     this->suggestionCol = ei.CurPos;
-
-                    EditorUndoRedo eur = {0};
-                    eur.Command = EUR_BEGIN;
-                    info.EditorControl(ECTL_UNDOREDO, &eur);
-
                     info.EditorControl(ECTL_INSERTTEXT, (void *) suggestion.c_str());
-
-                    eur.Command = EUR_END;
-                    info.EditorControl(ECTL_UNDOREDO, &eur);
 
 #if defined(DEBUG_EDITORCOMP)
                     debug("Added suggestion of length " + std::to_string(suggestion.length()) +
@@ -367,9 +359,8 @@ void Editor::declineSuggestion() {
 
         const EditorInfo &editorInfo = getInfo();
         if (editorInfo.CurLine == suggestionRow && editorInfo.CurPos == suggestionCol) {
-            EditorUndoRedo eur = {0};
-            eur.Command = EUR_UNDO;
-            info.EditorControl(ECTL_UNDOREDO, &eur);
+            for (int i = 0; i < int(suggestion.length()); i++)
+                info.EditorControl(ECTL_DELETECHAR, nullptr);
         } else {
             int beforeRow = editorInfo.CurLine;
             int beforeCol = editorInfo.CurPos;

--- a/far2l/viewer.cpp
+++ b/far2l/viewer.cpp
@@ -889,8 +889,11 @@ void Viewer::ReadString(ViewerString *pString, int MaxSize, int StrSize)
 
 	if (VM.Hex)
 	{
-		size_t len = 8;
-		if (IsFullWideCodePage(VM.CodePage)) len*= sizeof(wchar_t);
+		size_t len = 16;
+		// Alter-1: ::vread accepts number of displayable bytes for 8/16 bit charsets
+		// and number of w_char's for 32 bit charsets
+		// But we always display 16 bytes
+		if (IsFullWideCodePage(VM.CodePage)) len/= sizeof(wchar_t); // TODO: ??? 
 
 		OutPtr=vread(pString->lpData, len);
 		pString->lpData[len] = 0;
@@ -1956,7 +1959,10 @@ void Viewer::Up()
 
 	if (VM.Hex)
 	{
-		int UpSize=IsFullWideCodePage(VM.CodePage) ? 8 : 8 * sizeof(wchar_t);
+		// Alter-1: here we use BYTE COUNT, while in Down handler we use ::vread which may 
+		// accept either CHARACTER COUNT or w_char count. 
+		//int UpSize=IsFullWideCodePage(VM.CodePage) ? 8 : 8 * sizeof(wchar_t);
+		int UpSize=16; // always have 16 bytes per row
 
 		if (FilePos<(int64_t)UpSize)
 			FilePos=0;


### PR DESCRIPTION
::Up() always uses byte offset, must be 16
::ReadString() uses byte count for 8/16-bit charsets, but word-count for 32-bit charset (checked by IsFullWideCodePage()). Must be 16 and adjusted for 32-bit charsets (those are not supported yet)