### PR TITLE
Fix empty menu bar in "Always show menu bar" mode

### DIFF
--- a/far2l/menubar.cpp
+++ b/far2l/menubar.cpp
@@ -47,7 +47,7 @@ void MenuBar::DisplayObject()
 	RemoveHighlights(strMsg);
 	int Length=X2-X1+1;
 	FARString strFullMsg;
-	strFullMsg.Format(L"%-*.*s", Length,Length, strMsg.CPtr());
+    strFullMsg.Format(L"%-*.*ls", Length,Length, strMsg.CPtr());
 	GotoXY(X1,Y1);
 	SetColor(COL_HMENUTEXT);
 	Text(strFullMsg);


### PR DESCRIPTION
Wide string should be formatted with %ls specifier

For issue https://github.com/elfmz/far2l/issues/491