### PR TITLE
fix compile errors (neon, nfsc)

### DIFF
--- a/cmake/modules/FindLibNEON.cmake
+++ b/cmake/modules/FindLibNEON.cmake
@@ -4,9 +4,9 @@
 
 find_path(LIBNEON_INCLUDE_DIR
     NAMES
-      ne_basic.h
-      ne_session.h
-      ne_props.h
+      neon/ne_basic.h
+      neon/ne_session.h
+      neon/ne_props.h
     PATHS
       /usr/include
       /usr/local/include

--- a/cmake/modules/FindLibNfs.cmake
+++ b/cmake/modules/FindLibNfs.cmake
@@ -4,7 +4,7 @@
 
 find_path(LIBNFS_INCLUDE_DIR
     NAMES
-      libnfs.h
+      nfsc/libnfs.h
     PATHS
       /usr/include
       /usr/local/include


### PR DESCRIPTION
>>try branch https://github.com/elfmz/far2l/tree/fix-some-includes

>make result:
>/usr/local/include/nfsc/libnfs-raw-nfs.h:37:10: fatal error: 'nfsc/libnfs-zdr.h' file not found

this is another way (modify cmake configs, not sources)
make result:
[100%] Built target far2l

Far Manager, version 2.2 (build 19/06/10-7f13718-alpha) Darwin x86_64