### PR TITLE
Fix colorer plugin build in MacOS

### DIFF
--- a/colorer/src/shared/common/Logging.cpp
+++ b/colorer/src/shared/common/Logging.cpp
@@ -10,30 +10,30 @@ static const char *levelNames[] = {"QUIET", "ERROR", "WARN", "TRACE", "INFO"};
 
 static const char *toTrace[] = {"BaseEditorNative", "JavaLineSource" };
 
-static FILE *log = 0;
+static FILE *logFile = 0;
 
 static void file_logger(int level, const char *cname, const char *msg, va_list v){
 
   int idx = 0;
 
-  while (log == 0 && idx < 10){
+  while (logFile == 0 && idx < 10){
     char log_name[30];
 #ifdef __unix__
     sprintf(log_name, "/tmp/clr-trace%d.log", idx);
 #else
     sprintf(log_name, "c:/clr-trace%d.log", idx);
 #endif
-    log = fopen(log_name, "ab+");
+    logFile = fopen(log_name, "ab+");
     idx++;
   }
 
-  fprintf(log, "[%s][%s] ", levelNames[level], cname);
+  fprintf(logFile, "[%s][%s] ", levelNames[level], cname);
 
-  vfprintf(log, msg, v);
+  vfprintf(logFile, msg, v);
 
-  fprintf(log, "\n");
+  fprintf(logFile, "\n");
 
-  fflush(log);
+  fflush(logFile);
 }
 
 static void console_logger(int level, const char *cname, const char *msg, va_list v){
@@ -48,10 +48,10 @@ static void console_logger(int level, const char *cname, const char *msg, va_lis
 
 void colorer_logger_set_target(const char *logfile){
   if (logfile == 0) return;
-  if (log != 0){
-    fclose(log);
+  if (logFile != 0){
+    fclose(logFile);
   }
-  log = fopen(logfile, "ab+");
+  logFile = fopen(logfile, "ab+");
 }
 
 


### PR DESCRIPTION
Colorer uses global variable "log" which interferes with globals in standard library (in math.h)
It causes build to fail (Xcode 12.0.1)