### PR TITLE
Fix detection of LibArchive library on MacOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,13 +119,11 @@ if(NOT PCRE_FOUND)
 	message(WARNING "${Esc}[1;31mlibpcre not found, multiarc will have no custom archives support. Install libpcre and reconfigure far2l if you need that functionality.${Esc}[39;22m")
 endif()
 
-
-find_package(LibArchive)
-if(NOT LibArchive_FOUND)
-	# workaround for brew's libarchive
-	if(IS_DIRECTORY "/usr/local/opt/libarchive/include")
-		set(LibArchive_INCLUDE_DIR "/usr/local/opt/libarchive/include")
-	endif()
+# workaround for brew's libarchive
+if(IS_DIRECTORY "/usr/local/opt/libarchive/include")
+	set(LibArchive_INCLUDE_DIR "/usr/local/opt/libarchive/include")
+	set(LibArchive_LIBRARY "/usr/local/opt/libarchive/lib/libarchive.a")
+else()
 	find_package(LibArchive)
 	if(NOT LibArchive_FOUND)
 		message(WARNING "${Esc}[1;31mlibarchive not found, multiarc will have weaker archives support. Its recommended to install libarchive-dev and reconfigure far2l.${Esc}[39;22m")


### PR DESCRIPTION
In the latest toolchain LibArchive is included, so even if brew has own version of LibArchive, the version from SDK is used causing build errors. Need to set library location explicitly.