### PR TITLE
Allow shell to be overriden in "Command line settings"

### DIFF
--- a/far2l/bootstrap/scripts/farlang.templ.m4
+++ b/far2l/bootstrap/scripts/farlang.templ.m4
@@ -1999,6 +1999,15 @@ upd:"AutoComplete"
 upd:"AutoComplete"
 "&AutoCompletar"
 
+MConfigCmdlineUseShell
+"Использовать &шелл"
+"Use &shell"
+upd:"Use shell"
+upd:"Use shell"
+upd:"Use shell"
+upd:"Use shell"
+upd:"Use shell"
+
 MConfigCmdlineUsePromptFormat
 "Установить &формат командной строки"
 "Set command line &prompt format"

--- a/far2l/config.cpp
+++ b/far2l/config.cpp
@@ -62,6 +62,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "udlist.hpp"
 #include "datetime.hpp"
 #include "FarDlgBuilder.hpp"
+#include "vtshell.h"
 
 Options Opt={0};
 
@@ -389,13 +390,23 @@ void CmdlineSettings()
 	DialogItemEx *PromptFormat = Builder.AddEditField(&Opt.CmdLine.strPromptFormat, 19);
 	PromptFormat->Indent(4);
 	Builder.LinkFlags(UsePromptFormat, PromptFormat, DIF_DISABLE);
+    DialogItemEx *UseShell = Builder.AddCheckbox(MConfigCmdlineUseShell, &Opt.CmdLine.UseShell);
+    DialogItemEx *Shell =Builder.AddEditField(&Opt.CmdLine.strShell, 19);
+    Shell->Indent(4);
+    Builder.LinkFlags(UseShell, Shell, DIF_DISABLE);
 	Builder.AddOKCancel();
+
+	int oldUseShell = Opt.CmdLine.UseShell;
+	FARString oldShell = FARString(Opt.CmdLine.strShell);
 
 	if (Builder.ShowDialog())
 	{
 		CtrlObject->CmdLine->SetPersistentBlocks(Opt.CmdLine.EditBlock);
 		CtrlObject->CmdLine->SetDelRemovesBlocks(Opt.CmdLine.DelRemovesBlocks);
 		CtrlObject->CmdLine->SetAutoComplete(Opt.CmdLine.AutoComplete);
+
+		if (Opt.CmdLine.UseShell != oldUseShell || Opt.CmdLine.strShell != oldShell)
+		    VTShell_Shutdown();
 	}
 }
 
@@ -620,6 +631,8 @@ static struct FARConfig
 
 	{1, REG_DWORD,  NKeyCmdline, L"UsePromptFormat", &Opt.CmdLine.UsePromptFormat,0, 0},
 	{1, REG_SZ,     NKeyCmdline, L"PromptFormat",&Opt.CmdLine.strPromptFormat, 0, L"$p$# "},
+	{1, REG_DWORD,  NKeyCmdline, L"UseShell",&Opt.CmdLine.UseShell, 0, 0},
+	{1, REG_SZ,     NKeyCmdline, L"Shell",&Opt.CmdLine.strShell, 0, L"/bin/bash"},
 	{1, REG_DWORD,  NKeyCmdline, L"DelRemovesBlocks", &Opt.CmdLine.DelRemovesBlocks,1, 0},
 	{1, REG_DWORD,  NKeyCmdline, L"EditBlock", &Opt.CmdLine.EditBlock,0, 0},
 	{1, REG_DWORD,  NKeyCmdline, L"AutoComplete",&Opt.CmdLine.AutoComplete,1, 0},

--- a/far2l/config.hpp
+++ b/far2l/config.hpp
@@ -332,7 +332,9 @@ struct CommandLineOptions
 	int DelRemovesBlocks;
 	int AutoComplete;
 	int UsePromptFormat;
+	int UseShell;
 	FARString strPromptFormat;
+	FARString strShell;
 };
 
 struct NowellOptions

--- a/far2l/vtshell.cpp
+++ b/far2l/vtshell.cpp
@@ -578,7 +578,6 @@ class VTShell : VTOutputReader::IProcessor, VTInputReader::IProcessor, IVTShell
 	void RunShell()
 	{
 		//CheckedCloseFD(fd_term);
-			
 		const char *shell = getenv("SHELL");
 		if (!shell)
 			shell = "/bin/sh";
@@ -591,6 +590,11 @@ class VTShell : VTOutputReader::IProcessor, VTInputReader::IProcessor, IVTShell
 		//shell = "/usr/bin/zsh";
 		//shell = "/bin/bash";
 		//shell = "/bin/sh";
+
+		std::string forceShell = Wide2MB(Opt.CmdLine.strShell);
+		if (Opt.CmdLine.UseShell)
+			shell = forceShell.c_str();
+
 		std::vector<const char *> args;
 		args.push_back(shell);
 #if 0		


### PR DESCRIPTION
User can select the shell he prefer to use in FAR2L.

<img width="465" alt="Screenshot 2020-10-01 в 21 44 23" src="https://user-images.githubusercontent.com/2268089/94824536-5884bc00-042f-11eb-9f78-70f6efee736a.png">