### PR TITLE
Add virtual escape sequences for numeric keys to support Ctrl/Shift/Alt+0...9 keys in TTY (needs additional setup in terminal settings);

### DIFF
--- a/WinPort/src/Backend/TTY/TTYInputSequenceParser.cpp
+++ b/WinPort/src/Backend/TTY/TTYInputSequenceParser.cpp
@@ -86,16 +86,16 @@ void TTYInputSequenceParser::AddStr(WORD vk, DWORD control_keys, const char *fmt
 	}
 }
 
+void TTYInputSequenceParser::AddStrTilde_Controls(WORD vk, int code)
+{
+	char tmp[32];
+	AddStr_CodeThenControls(vk, "[%s;%d~", itoa(code, tmp, 10));
+}
+
 void TTYInputSequenceParser::AddStrTilde(WORD vk, int code)
 {
 	AddStr(vk, 0, "[%d~", code);
-	for (int i = 0; i <= 7; ++i) {
-		DWORD control_keys = 0;
-		if (i & 1) control_keys|= SHIFT_PRESSED;
-		if (i & 2) control_keys|= LEFT_ALT_PRESSED;
-		if (i & 4) control_keys|= LEFT_CTRL_PRESSED;
-		AddStr(vk, control_keys, "[%d;%d~", code, 1 + i);
-	}
+	AddStrTilde_Controls(vk, code);
 }
 
 void TTYInputSequenceParser::AddStr_ControlsThenCode(WORD vk, const char *fmt, const char *code)
@@ -214,6 +214,17 @@ TTYInputSequenceParser::TTYInputSequenceParser(ITTYInputSpecialSequenceHandler *
 	AddStrTilde(VK_F10, 21);
 	AddStrTilde(VK_F11, 23);
 	AddStrTilde(VK_F12, 24);
+
+	AddStrTilde_Controls('0', 50);
+	AddStrTilde_Controls('1', 51);
+	AddStrTilde_Controls('2', 52);
+	AddStrTilde_Controls('3', 53);
+	AddStrTilde_Controls('4', 54);
+	AddStrTilde_Controls('5', 55);
+	AddStrTilde_Controls('6', 56);
+	AddStrTilde_Controls('7', 57);
+	AddStrTilde_Controls('8', 58);
+	AddStrTilde_Controls('9', 59);
 
 	AddStr(VK_ESCAPE, 0, "\x1b");
 

--- a/WinPort/src/Backend/TTY/TTYInputSequenceParser.h
+++ b/WinPort/src/Backend/TTY/TTYInputSequenceParser.h
@@ -106,6 +106,7 @@ class TTYInputSequenceParser
 	void AddStr_ControlsThenCode(WORD vk, const char *fmt, const char *code);
 	void AddStr_CodeThenControls(WORD vk, const char *fmt, const char *code);
 	void AddStrTilde(WORD vk, int code);
+	void AddStrTilde_Controls(WORD vk, int code);
 	void AddStrF1F5(WORD vk, const char *code);
 	void AddStrCursors(WORD vk, const char *code);
 


### PR DESCRIPTION
In TTY mode it is not possible to use numeric keys with modifiers (Ctrl/Shift/Alt) because there are no special ANSI codes are sent by terminals. 

Some shortcuts in FAR depend on these keys, e.g. folder shortcuts, and it's not possible to make them work in TTY.

I introduced support of virtual escape sequences form ESC+[50;M~ to ESC+[59;M~ which could be bound to numeric keys in terminal. 

See https://gist.github.com/anteo/864c72f64c2e7863353d909bf076aed7 for custom key mapping for iTerm2.

I personally actively used it in my fork.

If this fix is appropriate, it makes sense to write a note in README.md as well.