### PR TITLE
Smarter processing of non-latin filenames inside .zip archives

### DIFF
--- a/multiarc/src/MultiArc.cpp
+++ b/multiarc/src/MultiArc.cpp
@@ -73,6 +73,9 @@ SHAREDSYMBOL void WINAPI _export SetStartupInfo(const struct PluginStartupInfo *
 
 SHAREDSYMBOL HANDLE WINAPI _export OpenFilePlugin(const char *Name,const unsigned char *Data,int DataSize,int OpMode)
 {
+
+  detect_oem_cp();
+
   if (ArcPlugin==NULL)
     return INVALID_HANDLE_VALUE;
 
@@ -298,4 +301,87 @@ std::string gMultiArcPluginPath;
 SHAREDSYMBOL void WINPORT_DllStartup(const char *path)
 {
 	gMultiArcPluginPath = path;
+}
+
+int oem_cp;
+
+void detect_oem_cp() {
+
+  // detect oem cp from system locale
+
+  oem_cp = 437; // default
+
+  char *lc = setlocale(LC_CTYPE, "");
+  if (!lc) { return; }
+  int lc_len;
+  for (lc_len = 0; lc[lc_len] != '.' && lc[lc_len] != '\0'; ++lc_len)
+    ;
+  lc[lc_len] = 0;
+
+  if (!strcmp(lc, "af_ZA")) { oem_cp = 850; }  if (!strcmp(lc, "ar_SA")) { oem_cp = 720; }
+  if (!strcmp(lc, "ar_LB")) { oem_cp = 720; }  if (!strcmp(lc, "ar_EG")) { oem_cp = 720; }
+  if (!strcmp(lc, "ar_DZ")) { oem_cp = 720; }  if (!strcmp(lc, "ar_BH")) { oem_cp = 720; }
+  if (!strcmp(lc, "ar_IQ")) { oem_cp = 720; }  if (!strcmp(lc, "ar_JO")) { oem_cp = 720; }
+  if (!strcmp(lc, "ar_KW")) { oem_cp = 720; }  if (!strcmp(lc, "ar_LY")) { oem_cp = 720; }
+  if (!strcmp(lc, "ar_MA")) { oem_cp = 720; }  if (!strcmp(lc, "ar_OM")) { oem_cp = 720; }
+  if (!strcmp(lc, "ar_QA")) { oem_cp = 720; }  if (!strcmp(lc, "ar_SY")) { oem_cp = 720; }
+  if (!strcmp(lc, "ar_TN")) { oem_cp = 720; }  if (!strcmp(lc, "ar_AE")) { oem_cp = 720; }
+  if (!strcmp(lc, "ar_YE")) { oem_cp = 720; }  if (!strcmp(lc, "ast_ES")) { oem_cp = 850; }
+  if (!strcmp(lc, "az_AZ")) { oem_cp = 866; }  if (!strcmp(lc, "az_AZ")) { oem_cp = 857; }
+  if (!strcmp(lc, "be_BY")) { oem_cp = 866; }  if (!strcmp(lc, "bg_BG")) { oem_cp = 866; }
+  if (!strcmp(lc, "br_FR")) { oem_cp = 850; }  if (!strcmp(lc, "ca_ES")) { oem_cp = 850; }
+  if (!strcmp(lc, "zh_CN")) { oem_cp = 936; }  if (!strcmp(lc, "zh_TW")) { oem_cp = 950; }
+  if (!strcmp(lc, "kw_GB")) { oem_cp = 850; }  if (!strcmp(lc, "cs_CZ")) { oem_cp = 852; }
+  if (!strcmp(lc, "cy_GB")) { oem_cp = 850; }  if (!strcmp(lc, "da_DK")) { oem_cp = 850; }
+  if (!strcmp(lc, "de_AT")) { oem_cp = 850; }  if (!strcmp(lc, "de_LI")) { oem_cp = 850; }
+  if (!strcmp(lc, "de_LU")) { oem_cp = 850; }  if (!strcmp(lc, "de_CH")) { oem_cp = 850; }
+  if (!strcmp(lc, "de_DE")) { oem_cp = 850; }  if (!strcmp(lc, "el_GR")) { oem_cp = 737; }
+  if (!strcmp(lc, "en_AU")) { oem_cp = 850; }  if (!strcmp(lc, "en_CA")) { oem_cp = 850; }
+  if (!strcmp(lc, "en_GB")) { oem_cp = 850; }  if (!strcmp(lc, "en_IE")) { oem_cp = 850; }
+  if (!strcmp(lc, "en_JM")) { oem_cp = 850; }  if (!strcmp(lc, "en_BZ")) { oem_cp = 850; }
+  if (!strcmp(lc, "en_PH")) { oem_cp = 437; }  if (!strcmp(lc, "en_ZA")) { oem_cp = 437; }
+  if (!strcmp(lc, "en_TT")) { oem_cp = 850; }  if (!strcmp(lc, "en_US")) { oem_cp = 437; }
+  if (!strcmp(lc, "en_ZW")) { oem_cp = 437; }  if (!strcmp(lc, "en_NZ")) { oem_cp = 850; }
+  if (!strcmp(lc, "es_PA")) { oem_cp = 850; }  if (!strcmp(lc, "es_BO")) { oem_cp = 850; }
+  if (!strcmp(lc, "es_CR")) { oem_cp = 850; }  if (!strcmp(lc, "es_DO")) { oem_cp = 850; }
+  if (!strcmp(lc, "es_SV")) { oem_cp = 850; }  if (!strcmp(lc, "es_EC")) { oem_cp = 850; }
+  if (!strcmp(lc, "es_GT")) { oem_cp = 850; }  if (!strcmp(lc, "es_HN")) { oem_cp = 850; }
+  if (!strcmp(lc, "es_NI")) { oem_cp = 850; }  if (!strcmp(lc, "es_CL")) { oem_cp = 850; }
+  if (!strcmp(lc, "es_MX")) { oem_cp = 850; }  if (!strcmp(lc, "es_ES")) { oem_cp = 850; }
+  if (!strcmp(lc, "es_CO")) { oem_cp = 850; }  if (!strcmp(lc, "es_ES")) { oem_cp = 850; }
+  if (!strcmp(lc, "es_PE")) { oem_cp = 850; }  if (!strcmp(lc, "es_AR")) { oem_cp = 850; }
+  if (!strcmp(lc, "es_PR")) { oem_cp = 850; }  if (!strcmp(lc, "es_VE")) { oem_cp = 850; }
+  if (!strcmp(lc, "es_UY")) { oem_cp = 850; }  if (!strcmp(lc, "es_PY")) { oem_cp = 850; }
+  if (!strcmp(lc, "et_EE")) { oem_cp = 775; }  if (!strcmp(lc, "eu_ES")) { oem_cp = 850; }
+  if (!strcmp(lc, "fa_IR")) { oem_cp = 720; }  if (!strcmp(lc, "fi_FI")) { oem_cp = 850; }
+  if (!strcmp(lc, "fo_FO")) { oem_cp = 850; }  if (!strcmp(lc, "fr_FR")) { oem_cp = 850; }
+  if (!strcmp(lc, "fr_BE")) { oem_cp = 850; }  if (!strcmp(lc, "fr_CA")) { oem_cp = 850; }
+  if (!strcmp(lc, "fr_LU")) { oem_cp = 850; }  if (!strcmp(lc, "fr_MC")) { oem_cp = 850; }
+  if (!strcmp(lc, "fr_CH")) { oem_cp = 850; }  if (!strcmp(lc, "ga_IE")) { oem_cp = 437; }
+  if (!strcmp(lc, "gd_GB")) { oem_cp = 850; }  if (!strcmp(lc, "gv_IM")) { oem_cp = 850; }
+  if (!strcmp(lc, "gl_ES")) { oem_cp = 850; }  if (!strcmp(lc, "he_IL")) { oem_cp = 862; }
+  if (!strcmp(lc, "hr_HR")) { oem_cp = 852; }  if (!strcmp(lc, "hu_HU")) { oem_cp = 852; }
+  if (!strcmp(lc, "id_ID")) { oem_cp = 850; }  if (!strcmp(lc, "is_IS")) { oem_cp = 850; }
+  if (!strcmp(lc, "it_IT")) { oem_cp = 850; }  if (!strcmp(lc, "it_CH")) { oem_cp = 850; }
+  if (!strcmp(lc, "iv_IV")) { oem_cp = 437; }  if (!strcmp(lc, "ja_JP")) { oem_cp = 932; }
+  if (!strcmp(lc, "kk_KZ")) { oem_cp = 866; }  if (!strcmp(lc, "ko_KR")) { oem_cp = 949; }
+  if (!strcmp(lc, "ky_KG")) { oem_cp = 866; }  if (!strcmp(lc, "lt_LT")) { oem_cp = 775; }
+  if (!strcmp(lc, "lv_LV")) { oem_cp = 775; }  if (!strcmp(lc, "mk_MK")) { oem_cp = 866; }
+  if (!strcmp(lc, "mn_MN")) { oem_cp = 866; }  if (!strcmp(lc, "ms_BN")) { oem_cp = 850; }
+  if (!strcmp(lc, "ms_MY")) { oem_cp = 850; }  if (!strcmp(lc, "nl_BE")) { oem_cp = 850; }
+  if (!strcmp(lc, "nl_NL")) { oem_cp = 850; }  if (!strcmp(lc, "nl_SR")) { oem_cp = 850; }
+  if (!strcmp(lc, "nn_NO")) { oem_cp = 850; }  if (!strcmp(lc, "nb_NO")) { oem_cp = 850; }
+  if (!strcmp(lc, "pl_PL")) { oem_cp = 852; }  if (!strcmp(lc, "pt_BR")) { oem_cp = 850; }
+  if (!strcmp(lc, "pt_PT")) { oem_cp = 850; }  if (!strcmp(lc, "rm_CH")) { oem_cp = 850; }
+  if (!strcmp(lc, "ro_RO")) { oem_cp = 852; }  if (!strcmp(lc, "ru_RU")) { oem_cp = 866; }
+  if (!strcmp(lc, "sk_SK")) { oem_cp = 852; }  if (!strcmp(lc, "sl_SI")) { oem_cp = 852; }
+  if (!strcmp(lc, "sq_AL")) { oem_cp = 852; }  if (!strcmp(lc, "sr_RS")) { oem_cp = 855; }
+  if (!strcmp(lc, "sr_RS")) { oem_cp = 852; }  if (!strcmp(lc, "sv_SE")) { oem_cp = 850; }
+  if (!strcmp(lc, "sv_FI")) { oem_cp = 850; }  if (!strcmp(lc, "sw_KE")) { oem_cp = 437; }
+  if (!strcmp(lc, "th_TH")) { oem_cp = 874; }  if (!strcmp(lc, "tr_TR")) { oem_cp = 857; }
+  if (!strcmp(lc, "tt_RU")) { oem_cp = 866; }  if (!strcmp(lc, "uk_UA")) { oem_cp = 866; }
+  if (!strcmp(lc, "ur_PK")) { oem_cp = 720; }  if (!strcmp(lc, "uz_UZ")) { oem_cp = 866; }
+  if (!strcmp(lc, "uz_UZ")) { oem_cp = 857; }  if (!strcmp(lc, "vi_VN")) { oem_cp = 1258; }
+  if (!strcmp(lc, "wa_BE")) { oem_cp = 850; }  if (!strcmp(lc, "zh_HK")) { oem_cp = 950; }
+  if (!strcmp(lc, "zh_SG")) { oem_cp = 936; }  if (!strcmp(lc, "zh_MO")) { oem_cp = 950; }
 }

--- a/multiarc/src/MultiArc.cpp
+++ b/multiarc/src/MultiArc.cpp
@@ -2,6 +2,7 @@
 #include "marclng.hpp"
 #include <string>
 #include <unistd.h>
+#include <locale.h>
 
 #if defined(__GNUC__)
 #ifdef __cplusplus

--- a/multiarc/src/MultiArc.hpp
+++ b/multiarc/src/MultiArc.hpp
@@ -367,3 +367,5 @@ void WINAPI UnixTimeToFileTime(DWORD UnixTime,FILETIME *FileTime);
 #endif
 
 #endif // __MULTIARC_HPP__
+
+void detect_oem_cp();

--- a/multiarc/src/formats/zip/zip.cpp
+++ b/multiarc/src/formats/zip/zip.cpp
@@ -64,6 +64,8 @@ static ULARGE_INTEGER SFXSize,NextPosition,FileSize;
 static int ArcComment,FirstRecord;
 static bool bTruncated;
 
+extern int oem_cp;
+
 struct ZipHeader
 {
   DWORD Signature;
@@ -315,7 +317,7 @@ int WINAPI _export ZIP_GetArcItem(struct PluginPanelItem *Item,struct ArcItemInf
   } else if (ZipHeader.PackOS==11 && ZipHeader.PackVer>20 && ZipHeader.PackVer<25)
     CPToUTF8(CP_ACP, Item->FindData.cFileName,Item->FindData.cFileName, ARRAYSIZE(Item->FindData.cFileName));
   else if (ZipHeader.PackOS==11 || ZipHeader.PackOS==0)
-    CPToUTF8(CP_OEMCP, Item->FindData.cFileName, Item->FindData.cFileName, ARRAYSIZE(Item->FindData.cFileName));
+    CPToUTF8(oem_cp, Item->FindData.cFileName, Item->FindData.cFileName, ARRAYSIZE(Item->FindData.cFileName));
 
   Info->UnpVer=(ZipHeader.UnpVer/10)*256+(ZipHeader.UnpVer%10);
   Info->DictSize=32;


### PR DESCRIPTION
It's better to select code page for OEM .zip archives based on system locale instead of always using code page 866.

That is exectly how Windows internal "zip folders" tool works. Locale-to-CP translation table taken from Wine sources.
See https://github.com/elfmz/far2l/issues/753 for details

