### PR TITLE
CtrlF12 dlg fix (save the wrong collation)

### DIFF
--- a/far2l/filelist.cpp
+++ b/far2l/filelist.cpp
@@ -4281,7 +4281,7 @@ void FileList::SelectSortMode()
 								NumericSort=1;
 								break;
 							case BY_CUSTOMDATA+3:
-								NumericSort=1;
+								CaseSensitiveSort=1;
 								break;
 							case BY_CUSTOMDATA+4:
 								SortGroups=1;


### PR DESCRIPTION
В диалоге параметров сортировки файлов (по Ctrl-F12) по клавише "-" на "Use case sensitive sort" меняется значение у параметра "Numeric sort".