### PR TITLE
Work around Enter not working after Alt-letter quicksearch on Mac.

### DIFF
--- a/WinPort/src/Backend/WX/wxMain.cpp
+++ b/WinPort/src/Backend/WX/wxMain.cpp
@@ -1020,7 +1020,7 @@ void WinPortPanel::OnKeyDown( wxKeyEvent& event )
 #endif
 
 	if ( (event.HasModifiers() && event.GetUnicodeKey() < 32) || _right_control || 
-		_pressed_keys.simulate_alt() || event.GetKeyCode() == WXK_DELETE ||
+		_pressed_keys.simulate_alt() || event.GetKeyCode() == WXK_DELETE || event.GetKeyCode() == WXK_RETURN ||
 		(event.GetUnicodeKey()==WXK_NONE && !IsForcedCharTranslation(event.GetKeyCode()) )) {
 
 		_pressed_keys.insert(event.GetKeyCode());


### PR DESCRIPTION
Fixes #364, at least, on Mac.