### PR TITLE
TTY backend traffic optimization

### DIFF
--- a/NetRocks/src/Op/OpExecute.cpp
+++ b/NetRocks/src/Op/OpExecute.cpp
@@ -67,7 +67,7 @@ SHAREDSYMBOL int OpExecute_Shell(int argc, char *argv[])
 	try {
 		int fd_stdin = 0, fd_stdout = 1, fd_stderr = 2;
 
-		TTYRawMode tty_raw_mode(fd_stdout);
+		TTYRawMode tty_raw_mode(fd_stdin, fd_stdout);
 
 		FDScope fd_err(open((fifo + ".err").c_str(), O_RDONLY));
 		FDScope fd_out(open((fifo + ".out").c_str(), O_RDONLY));

--- a/WinPort/src/Backend/TTY/TTYBackend.cpp
+++ b/WinPort/src/Backend/TTY/TTYBackend.cpp
@@ -254,6 +254,7 @@ void TTYBackend::WriterThread()
 				DispatchFar2lInterract(tty_out);
 
 			tty_out.Flush();
+			tcdrain(_stdout);
 		}
 
 	} catch (const std::exception &e) {

--- a/WinPort/src/Backend/TTY/TTYBackend.cpp
+++ b/WinPort/src/Backend/TTY/TTYBackend.cpp
@@ -269,7 +269,11 @@ void TTYBackend::WriterThread()
 void TTYBackend::DispatchTermResized(TTYOutput &tty_out)
 {
 	struct winsize w = {};
-	if (ioctl(_stdout, TIOCGWINSZ, &w) == 0) {
+	int r = ioctl(_stdout, TIOCGWINSZ, &w);
+	if (r != 0) {
+		r = ioctl(_stdin, TIOCGWINSZ, &w);
+	}
+	if (r == 0) {
 		if (_cur_width != w.ws_col || _cur_height != w.ws_row) {
 			_cur_width = w.ws_col;
 			_cur_height = w.ws_row;

--- a/WinPort/src/Backend/TTY/TTYOutput.h
+++ b/WinPort/src/Backend/TTY/TTYOutput.h
@@ -30,12 +30,14 @@ class TTYOutput
 	} _attr;
 
 	int _out;
-	unsigned int _pending_spaces = 0;
 	std::vector<char> _rawbuf;
-	void WriteReally(const char *str, int len);
+	struct {
+		char ch = 0;
+		unsigned int count = 0;
+	} _same_chars;
 
-	void Space();
-	void FinalizeSpaces();
+	void WriteReally(const char *str, int len);
+	void FinalizeSameChars();
 	void Write(const char *str, int len);
 	void Format(const char *fmt, ...);
 public:
@@ -46,7 +48,8 @@ public:
 
 	void ChangeCursor(bool visible, bool force = false);
 	inline bool ShouldMoveCursor(unsigned int y, unsigned int x) const { return x != _cursor.x || y != _cursor.y; }
-	void MoveCursor(unsigned int y, unsigned int x);
+	void MoveCursorStrict(unsigned int y, unsigned int x);
+	void MoveCursorLazy(unsigned int y, unsigned int x);
 	void WriteLine(const CHAR_INFO *ci, unsigned int cnt);
 	void ChangeKeypad(bool app);
 	void ChangeMouse(bool enable);

--- a/WinPort/src/Backend/TTY/TTYOutput.h
+++ b/WinPort/src/Backend/TTY/TTYOutput.h
@@ -30,9 +30,12 @@ class TTYOutput
 	} _attr;
 
 	int _out;
+	unsigned int _pending_spaces = 0;
 	std::vector<char> _rawbuf;
 	void WriteReally(const char *str, int len);
 
+	void Space();
+	void FinalizeSpaces();
 	void Write(const char *str, int len);
 	void Format(const char *fmt, ...);
 public:

--- a/WinPort/src/Backend/WinPortMain.cpp
+++ b/WinPort/src/Backend/WinPortMain.cpp
@@ -137,7 +137,7 @@ public:
 	void Revert()
 	{
 		if (_raw && !_tty_raw_mode) {
-			_tty_raw_mode.reset(new TTYRawMode(_std_out));
+			_tty_raw_mode.reset(new TTYRawMode(_std_in, _std_out));
 		}
 
 		if (_far2l_tty && !_far2l_tty_actual) {
@@ -331,7 +331,7 @@ extern "C" int WinPortMain(int argc, char **argv, int(*AppMain)(int argc, char *
 
 //	tcgetattr(std_out, &g_ts_tstp);
 
-	std::unique_ptr<TTYRawMode> tty_raw_mode(new TTYRawMode(std_out));
+	std::unique_ptr<TTYRawMode> tty_raw_mode(new TTYRawMode(std_in, std_out));
 	if (!arg_opts.nodetect) {
 //		tty_raw_mode.reset(new TTYRawMode(std_out));
 		if (tty_raw_mode->Applied()) {
@@ -371,7 +371,7 @@ extern "C" int WinPortMain(int argc, char **argv, int(*AppMain)(int argc, char *
 
 	if (arg_opts.tty) {
 		if (!tty_raw_mode) {
-			tty_raw_mode.reset(new TTYRawMode(std_out));
+			tty_raw_mode.reset(new TTYRawMode(std_in, std_out));
 		}
 		if (arg_opts.mortal) {
 			SudoAskpassImpl askass_impl;

--- a/far2l/AnsiEsc.cpp
+++ b/far2l/AnsiEsc.cpp
@@ -253,8 +253,11 @@ int Printer::Length(const wchar_t *str)
 		const wchar_t *end_of_esc = tmp_parser.Parse(ch);
 		if (end_of_esc) {
 			ch = end_of_esc;
-			if (tmp_parser.suffix == L'C') {
-				out+= tmp_parser.args[0];
+			if (tmp_parser.suffix == L'C') { // skip N chars
+				out+= tmp_parser.args[0] ? tmp_parser.args[0] : 1;
+			}
+			else if (tmp_parser.suffix == L'b') { // repeate last char N times
+				out+= tmp_parser.args[0] ? tmp_parser.args[0] : 1;
 			}
 		} else {
 			++ch;
@@ -289,9 +292,15 @@ void Printer::Print(int skip_len, int print_len, const wchar_t *str)
 				break;
 			}
 			if (suffix == L'C') {
-				for (int i = 0; i < args[0]; ++i, ++processed ) {
+				for (int i = 0; i < args[0] || i < 1; ++i, ++processed ) {
 				    if (processed >= skip_len && processed < skip_len + print_len) {
 						Text(L" ", 1);
+					}
+				}
+			} else if (suffix == L'b') {
+				for (int i = 0; i < args[0] || i < 1; ++i, ++processed ) {
+				    if (processed >= skip_len && processed < skip_len + print_len) {
+						Text(&_last_char, 1);
 					}
 				}
 			} else if (suffix == L'm') {
@@ -302,6 +311,7 @@ void Printer::Print(int skip_len, int print_len, const wchar_t *str)
 		}
 		else
 		{
+			_last_char = *ch;
 			++ch;
 		}
 	}

--- a/far2l/AnsiEsc.hpp
+++ b/far2l/AnsiEsc.hpp
@@ -38,5 +38,6 @@ namespace AnsiEsc
 	private:
 		FontState _font_state;
 		WORD _initial_attr;
+		wchar_t _last_char = L' ';
 	};
 }

--- a/utils/include/TTYRawMode.h
+++ b/utils/include/TTYRawMode.h
@@ -4,12 +4,11 @@
 class TTYRawMode
 {
 	termios _ts{};
-	bool _applied = false;
-	int _fd;
+	int _fd = -1;
 
 public:
-	TTYRawMode(int fd);
+	TTYRawMode(int std_in, int std_out);
 	~TTYRawMode();
 
-	bool Applied() const {return _applied; }
+	bool Applied() const { return _fd != -1; }
 };

--- a/utils/src/TTYRawMode.cpp
+++ b/utils/src/TTYRawMode.cpp
@@ -1,21 +1,30 @@
 #include <stdio.h>
 #include "TTYRawMode.h"
 
-TTYRawMode::TTYRawMode(int fd)
-	: _fd(fd)
+TTYRawMode::TTYRawMode(int std_in, int std_out)
 {
-	if (tcgetattr(_fd, &_ts) == 0) {
-		struct termios ts_ne = _ts;
-		cfmakeraw(&ts_ne);
-		if (tcsetattr( _fd, TCSADRAIN, &ts_ne ) == 0) {
-			_applied = true;
+	// try first stdout, but if it fails - try stdin
+	// this helps to work with specific cases of redirected
+	// output, like working with tee
+	if (tcgetattr(std_out, &_ts) != 0) {
+		if (tcgetattr(std_in, &_ts) != 0) {
+			return;
 		}
+		_fd = std_in;
+	} else {
+		_fd = std_out;
+	}
+
+	struct termios ts_ne = _ts;
+	cfmakeraw(&ts_ne);
+	if (tcsetattr( _fd, TCSADRAIN, &ts_ne ) != 0) {
+		_fd = -1;
 	}
 }
 
 TTYRawMode::~TTYRawMode()
 {
-	if (_applied) {
+	if (_fd != -1) {
 		if (tcsetattr(_fd, TCSADRAIN, &_ts) != 0) {
 			perror("~TTYRawMode - tcsetattr");
 		}


### PR DESCRIPTION
Measurements:
terminal1: socat -v TCP-LISTEN:2222,fork TCP:127.0.0.1:22 2>ssh.log 
terminal2: ssh -p 2222 127.0.0.1
terminal2: ...password...
terminal2: far2l
terminal2: Ctrl+O 6 times (3 times hide/show panels)
terminal2: F10
terminal2: exit
terminal1: Ctrl+C
terminal1: du -bs ssh.log

Results shown twice traffic reduction:
old far2l: log size ~80KB
new far2l: log size ~40KB
also to compare, same test with mc instead of far2l produces ~70KB log size.
