### PR TITLE
improvements for mounts.sh

### DIFF
--- a/far2l/Mounts.cpp
+++ b/far2l/Mounts.cpp
@@ -49,7 +49,8 @@ namespace Mounts
 					}
 					if (e.path == L"/") {
 						has_rootfs = true;
-						e.info+= " &/";
+						size_t l;
+						if(!e.info.Pos(l, L'&')) e.info+= " &/";
 					} else {
 						e.unmountable = true;
 					}

--- a/far2l/bootstrap/mounts.sh
+++ b/far2l/bootstrap/mounts.sh
@@ -17,6 +17,11 @@
 #   $3 - optional 'force' flag
 ##########################################################
 
+# Optional per-user script
+if [ -x ~/.config/far2l/mounts.sh ]; then
+. ~/.config/far2l/mounts.sh
+fi
+
 ##########################################################
 # This optional file may contain per-user extra values added to df output,
 # its content must be looking like:


### PR DESCRIPTION
- allow for an optional user script `~/.config/far2l/mounts.sh`
    - this is similar to other scripts (open.sh, etc.)
    - also allows for complete customization of drive select menu (see example below)
- only add shortcut for rootfs (`/`) if the shortcut is not already set

example of mounts.sh:
```
exec \
cat << EOF
/run/media/$USER	&M
$HOME	&H
/	&/
EOF
```
note the `exec` which allows to skip other code from standard `mounts.sh`
