### PR TITLE
add forward slash

### DIFF
--- a/far2l/pathmix.cpp
+++ b/far2l/pathmix.cpp
@@ -558,6 +558,7 @@ FARString LookupExecutable(const char *file)
 		out = LookupExecutableInEnvPath(file);
 		if (out.IsEmpty()) {
 			apiGetCurrentDirectory(out);
+			out+= GOOD_SLASH;
 			out+= file;
 		}
 	}


### PR DESCRIPTION
Fixes an issue on FreeBSD (and maybe other systems) where if argv[0] was a relative path, g_strFarModuleName would be missing a directory slash, resulting in far2l failing to find its language data.