### PR TITLE
Simplify build instructions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -125,5 +125,5 @@ before_install:
 script:
   - mkdir build
   - cd build
-  - cmake -G Ninja .. && ninja -j4 -v
+  - cmake -G Ninja .. && cmake --build .
   - cd install && zip -r ../far2l-${TRAVIS_COMMIT}.zip * && cd -


### PR DESCRIPTION
Notes: 
* `cmake --build` calls `make` with all available cores by default. 
* Same for `-G Ninja` or direct call to `ninja`. Actually `ninja`'s `-j` parameter is intended to _limit_ parallel jobs.

Signed-off-by: Yurii Kolesnykov <root@yurikoles.com>
