### PR TITLE
Allow far2l tools location to be overridden when configuring build.

### DIFF
--- a/far2l/bootstrap/CMakeLists.txt
+++ b/far2l/bootstrap/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required (VERSION 3.0.2)
 
+# Make TOOLS folder overridable in command line when configuring build.
+# This will allow specifying host far2l tools location when doing cross-platform builds.
+# Cross compile of far2l requires tools to be pre-compiled for host architecture.
 set(TOOLS "${CMAKE_BINARY_DIR}/tools" CACHE STRING "")
 set(FARLNGTOOL "${TOOLS}/farlng")
 


### PR DESCRIPTION
Hi.
This change implement an option to override tools location from command line when configuring far2l build.
When you are doing cross-compile of far2l for different architecture you still need tools built for your host (langs etc.).
Typical workflow for this case would be to build far2l for host arch then start building it for target arch overriding tools location to point to host arch tools.
If you don't use host arch tools, your build for target arch will fail processing languages (at least).
This opens far2l builds in buildroot/yocto.
Thanks and best of luck.