### PR TITLE
update mounts.sh to include free / total usage

### DIFF
--- a/far2l/bootstrap/mounts.sh
+++ b/far2l/bootstrap/mounts.sh
@@ -45,7 +45,7 @@ else
 
 	sysname=`uname`
 	if [ "$sysname" == "Linux" ] || [ "$sysname" == "FreeBSD" ]; then
-		dfcmd='df -T | awk "-F " '\''{n=NF; while (n>5 && ! ($n ~ "/")) n--; for (;n<NF;n++) printf "%s ", $n; print $n "\t" $2 }'\'
+		dfcmd='df -T -m | awk "-F " '\''{n=NF; while (n>5 && ! ($n ~ "/")) n--; for (;n<NF;n++) printf "%s ", $n; printf "%s\t%5s/%5sM %8s", $n, $5, $3, $2; print "" }'\'
 	else
 		dfcmd='df -t | awk "-F " '\''{n=NF; while (n>5 && ! ($n ~ "/")) n--; for (;n<NF;n++) printf "%s ", $n; print $n "\t" $1 }'\'
 	fi

--- a/far2l/bootstrap/mounts.sh
+++ b/far2l/bootstrap/mounts.sh
@@ -41,9 +41,9 @@ if [ "$1" == 'umount' ]; then
 
 ##########################################################
 else
-	#FIXME: pathes that contain repeated continuos spaces
+	#FIXME: paths that contain repeated continuos spaces
 
-	sysname=`uname`
+	sysname="$(uname)"
 	if [ "$sysname" == "Linux" ] || [ "$sysname" == "FreeBSD" ]; then
 		dfcmd='df -T -m | awk "-F " '\''{n=NF; while (n>5 && ! ($n ~ "/")) n--; for (;n<NF;n++) printf "%s ", $n; printf "%s\t%5s/%5sM %8s", $n, $5, $3, $2; print "" }'\'
 	else


### PR DESCRIPTION
before

```
$ dfcmd='df -T | awk "-F " '\''{n=NF; while (n>5 && ! ($n ~ "/")) n--; for (;n<NF;n++) printf "%s ", $n; print $n "\t" $2 }'\' ; eval "$dfcmd" ;

Available Use% Mounted on	Type

/	ext4

/dev	devtmpfs

```

after

```
$ dfcmd='df -T -m | awk "-F " '\''{n=NF; while (n>5 && ! ($n ~ "/")) n--; for (;n<NF;n++) printf "%s ", $n; printf "%s\t%5s/%5sM %8s", $n, $5, $3, $2; print "" }'\' ; eval "$dfcmd" ;

Available Use% Mounted on	Available/1M-blocksM     Type

/	 2637/ 9816M     ext4

/dev	  445/  445M devtmpfs
```