### PR TITLE
Trying different keyboard layout[s] on FastFind fail

### DIFF
--- a/far2l/bootstrap/CMakeLists.txt
+++ b/far2l/bootstrap/CMakeLists.txt
@@ -111,4 +111,5 @@ add_custom_command(TARGET bootstrap
 add_custom_command(TARGET bootstrap
    POST_BUILD
    COMMAND "cp" "${CMAKE_CURRENT_SOURCE_DIR}/*.sh" "${INSTALL_DIR}"
+   COMMAND "cp" "${CMAKE_CURRENT_SOURCE_DIR}/*.ini" "${INSTALL_DIR}"
 )

--- a/far2l/bootstrap/kblayouts.ini
+++ b/far2l/bootstrap/kblayouts.ini
@@ -1,0 +1,3 @@
+[ru]
+Latin=q w e r t y u i o p [ ] a s d f g h j k l ; ' z x c v b n m , . `
+Local=й ц у к е н г ш щ з х ъ ф ы в а п р о л д ж э я ч с м и т ь б ю ё

--- a/far2l/src/filelist.cpp
+++ b/far2l/src/filelist.cpp
@@ -3128,6 +3128,54 @@ bool FileList::FileInFilter(long idxItem)
 	return false;
 }
 
+// Just as FindPartName(), but with retry support through keyboard layout translation, specially for FastFind
+int FileList::FindPartName2(const wchar_t *Name,int Next,int Direct,int ExcludeSets)
+{
+    bool res = FindPartName(Name, Next, Direct, ExcludeSets);
+    if (!res) {
+
+        // FastFind retry keyboard layout translation
+
+        wchar_t *out = (wchar_t*)malloc((wcslen(Name) + 1)*sizeof(wchar_t));
+        bzero(out, (wcslen(Name) + 1)*sizeof(wchar_t));
+
+        wchar_t *TrOutBuf = (wchar_t*)malloc(strlen(KbLayoutsTrOut.c_str())*sizeof(wchar_t));
+        int converted = WINPORT(MultiByteToWideChar)(CP_UTF8, 0,
+            KbLayoutsTrOut.c_str(), -1,
+            TrOutBuf, strlen(KbLayoutsTrOut.c_str())*sizeof(wchar_t));
+
+        if (converted > 0) {
+            for (int i = 0; i<wcslen(Name); i++) {
+
+                out[i] = Name[i];
+
+
+                for (int j = 0; j < strlen(KbLayoutsTrIn.c_str()); j+=2) {
+                    if (TrOutBuf[j] && KbLayoutsTrIn.at(j)) {
+                        // forward translation
+                        if (Name[i] == KbLayoutsTrIn.at(j)) {
+                            out[i] = TrOutBuf[j];
+                        }
+
+                        // reverse translation
+                        if (Name[i] == TrOutBuf[j]) {
+                            out[i] = KbLayoutsTrIn.at(j);
+                        }
+                    }
+                }
+            }
+        }
+
+
+        res = FindPartName(out, Next, Direct, ExcludeSets);
+
+        free(TrOutBuf);
+        free(out);
+    }
+
+    return res;
+}
+
 // $ 02.08.2000 IG  Wish.Mix #21 - при нажатии '/' или '\' в QuickSerach переходим на директорию
 int FileList::FindPartName(const wchar_t *Name,int Next,int Direct,int ExcludeSets)
 {

--- a/far2l/src/filelist.hpp
+++ b/far2l/src/filelist.hpp
@@ -353,6 +353,7 @@ class FileList:public Panel
 		virtual int GetFileName(FARString &strName,int Pos,DWORD &FileAttr);
 		virtual int GetCurrentPos();
 		virtual int FindPartName(const wchar_t *Name,int Next,int Direct=1,int ExcludeSets=0);
+    	virtual int FindPartName2(const wchar_t *Name,int Next,int Direct=1,int ExcludeSets=0);
 		long FindFile(const char *Name,BOOL OnlyPartName=FALSE);
 
 		virtual int GoToFile(long idxItem);

--- a/far2l/src/global.cpp
+++ b/far2l/src/global.cpp
@@ -63,6 +63,9 @@ clock_t StartIdleTime=0;
 FARString g_strFarModuleName;
 FARString g_strFarPath;
 
+std::string KbLayoutsTrIn;
+std::string KbLayoutsTrOut;
+
 FARString strGlobalSearchString;
 int GlobalSearchCase=FALSE;
 int GlobalSearchWholeWords=FALSE; // значение "Whole words" для поиска

--- a/far2l/src/global.hpp
+++ b/far2l/src/global.hpp
@@ -44,6 +44,9 @@ extern int WaitInFastFind;
 extern FARString g_strFarModuleName;
 extern FARString g_strFarPath;
 
+extern std::string KbLayoutsTrIn;
+extern std::string KbLayoutsTrOut;
+
 extern FARString strGlobalSearchString;
 extern int GlobalSearchCase;
 extern int GlobalSearchWholeWords; // значение "Whole words" для поиска

--- a/far2l/src/main.cpp
+++ b/far2l/src/main.cpp
@@ -584,6 +584,19 @@ int FarAppMain(int argc, char **argv)
 		}
 	}
 
+
+    std::unique_ptr<KeyFileHelper> KeyboardLayouts;
+    wchar_t *far2l_path = (wchar_t*)g_strFarPath.CPtr();
+    std::string kblo_path = StrPrintf("%lskblayouts.ini", far2l_path);
+    KeyboardLayouts.reset(new KeyFileHelper(kblo_path.c_str()));
+
+    const char *lc = setlocale(LC_CTYPE, NULL);
+    char LangCode[3]; LangCode[0] = lc[0]; LangCode[1] = lc[1]; LangCode[2] = 0;
+    
+    KbLayoutsTrIn = KeyboardLayouts->GetString(LangCode, "Latin");
+    KbLayoutsTrOut = KeyboardLayouts->GetString(LangCode, "Local");
+
+
 	//Настройка OEM сортировки. Должна быть после CopyGlobalSettings и перед InitKeysArray!
 	//LocalUpperInit();
 	//InitLCIDSort();

--- a/far2l/src/panel.cpp
+++ b/far2l/src/panel.cpp
@@ -922,7 +922,7 @@ void Panel::FastFindProcessName(Edit *FindEdit,const wchar_t *Src,FARString &str
 				break;
 			}
 
-			if (FindPartName(Ptr,FALSE,1,1))
+			if (FindPartName2(Ptr,FALSE,1,1))
 			{
 //				Key=*(EndPtr-1);
 				*EndPtr=0;
@@ -1085,13 +1085,13 @@ void Panel::FastFind(int FirstKey)
 				}
 				case KEY_CTRLNUMENTER:
 				case KEY_CTRLENTER:
-					FindPartName(strName,TRUE,1,1);
+					FindPartName2(strName,TRUE,1,1);
 					FindEdit.Show();
 					FastFindShow(FindX,FindY);
 					break;
 				case KEY_CTRLSHIFTNUMENTER:
 				case KEY_CTRLSHIFTENTER:
-					FindPartName(strName,TRUE,-1,1);
+					FindPartName2(strName,TRUE,-1,1);
 					FindEdit.Show();
 					FastFindShow(FindX,FindY);
 					break;
@@ -1132,7 +1132,7 @@ void Panel::FastFind(int FirstKey)
 							FindEdit.SetString(strName);
 						}
 
-						if (FindPartName(strName,FALSE,1,1))
+						if (FindPartName2(strName,FALSE,1,1))
 						{
 							strLastName = strName;
 						}

--- a/far2l/src/panel.hpp
+++ b/far2l/src/panel.hpp
@@ -202,7 +202,7 @@ class Panel:public ScreenObject
 		virtual void UpdateIfRequired() {};
 
 		virtual void CloseChangeNotification() {};
-		virtual int FindPartName(const wchar_t *Name,int Next,int Direct=1,int ExcludeSets=0) {return FALSE;}
+		virtual int FindPartName2(const wchar_t *Name,int Next,int Direct=1,int ExcludeSets=0) {return FALSE;}
 
 		virtual int GoToFile(long idxItem) {return TRUE;};
 		virtual int GoToFile(const wchar_t *Name,BOOL OnlyPartName=FALSE) {return TRUE;};


### PR DESCRIPTION
Solution for #780. Adopted for current master

Layout[s] translation table[s] configurable via .ini file, locale-dependent