### PR TITLE
ma: support QCOW2 format

### DIFF
--- a/multiarc/configs/plug/custom.ini
+++ b/multiarc/configs/plug/custom.ini
@@ -43,6 +43,9 @@ ID10Pos=0
 ;CHM (LZH) archive
 ID11=49 54 53 46
 ID11Pos=0
+; QCOW2 disk image
+ID12=51 46 49 FB
+ID12Pos=0
 ;
 IDOnly=1
 ToolNotFound=Please install 7z utility to open this archive


### PR DESCRIPTION
Allow browsing QEMU disk images (QCOW2).
Not too helpful, because allows extracting only disk partitions as *.img, but better than nothing.