### PR TITLE
minimal fix for ctrl+non_latin_keys on latest wx3.0

### DIFF
--- a/WinPort/src/Backend/WX/wxMain.cpp
+++ b/WinPort/src/Backend/WX/wxMain.cpp
@@ -1063,6 +1063,25 @@ void WinPortPanel::OnKeyDown( wxKeyEvent& event )
 	if (alt_nonlatin_workaround) {
 		ir.Event.KeyEvent.wVirtualKeyCode = VK_UNASSIGNED;
 	}
+
+	if (event.ControlDown() && !event.GetKeyCode()) {
+		switch (event.GetRawKeyFlags()) {
+			// Hardware key codes are defined in /usr/share/X11/xkb/keycodes/xfree86
+			case 20: ir.Event.KeyEvent.wVirtualKeyCode = VK_OEM_MINUS; break;
+			case 21: ir.Event.KeyEvent.wVirtualKeyCode = VK_OEM_PLUS; break;
+			case 34: ir.Event.KeyEvent.wVirtualKeyCode = VK_OEM_4; break;
+			case 35: ir.Event.KeyEvent.wVirtualKeyCode = VK_OEM_6; break;
+			case 47: ir.Event.KeyEvent.wVirtualKeyCode = VK_OEM_1; break;
+			case 48: ir.Event.KeyEvent.wVirtualKeyCode = VK_OEM_7; break;
+			case 49: ir.Event.KeyEvent.wVirtualKeyCode = VK_OEM_3; break;
+			case 51: ir.Event.KeyEvent.wVirtualKeyCode = VK_OEM_5; break;
+			case 59: ir.Event.KeyEvent.wVirtualKeyCode = VK_OEM_COMMA; break;
+			case 60: ir.Event.KeyEvent.wVirtualKeyCode = VK_OEM_PERIOD; break;
+			case 61: ir.Event.KeyEvent.wVirtualKeyCode = VK_OEM_2; break;
+		}
+		g_winport_con_in->Enqueue(&ir, 1);
+		_last_keydown_enqueued = true;
+	}
 #endif
 
 	if ( (dwMods != 0 && event.GetUnicodeKey() < 32)
@@ -1072,12 +1091,6 @@ void WinPortPanel::OnKeyDown( wxKeyEvent& event )
 		g_winport_con_in->Enqueue(&ir, 1);
 		_last_keydown_enqueued = true;
 	} 
-
-#ifdef WX_ALT_NONLATIN
-	if (alt_nonlatin_workaround) {
-		OnChar(event);
-	}
-#endif
 
 	event.Skip();
 }

--- a/WinPort/src/Backend/WX/wxMain.cpp
+++ b/WinPort/src/Backend/WX/wxMain.cpp
@@ -52,6 +52,7 @@ enum
 
 bool WinPortClipboard_IsBusy();
 
+bool ctrl_hack_enabled = false;
 
 static void NormalizeArea(SMALL_RECT &area)
 {
@@ -397,10 +398,14 @@ wxEND_EVENT_TABLE()
 
 void WinPortFrame::OnShow(wxShowEvent &show)
 {
+    struct stat s;
+    if (stat(InMyConfig("ctrlhack").c_str(), &s)==0) {
+        ctrl_hack_enabled = true;
+    }
+
 // create accelerators to handle hotkeys (like Ctrl-O) when using non-latin layouts under Linux
 // under osx acceleratos seems not needed and only causes bugs
 #ifndef __APPLE__
-	struct stat s;
 	if (stat(InMyConfig("nomenu").c_str(), &s)!=0) {
 		//workaround for non-working with non-latin input language Ctrl+? hotkeys 
 		_menu_bar = new wxMenuBar(wxMB_DOCKABLE);
@@ -1068,7 +1073,7 @@ void WinPortPanel::OnKeyDown( wxKeyEvent& event )
 	// for non-latin unicode keycode pressed with Ctrl key together
 	// especially for keys not used as accelerators
 	// detect correct keycode by raw key code and enqueue keypress
-	if (event.ControlDown() && !event.GetKeyCode()) {
+	if (event.ControlDown() && !event.GetKeyCode() && ctrl_hack_enabled) {
 		bool go = false;
 		switch (event.GetRawKeyFlags()) {
 			// Hardware key codes are defined in /usr/share/X11/xkb/keycodes/xfree86

--- a/WinPort/src/Backend/WX/wxMain.cpp
+++ b/WinPort/src/Backend/WX/wxMain.cpp
@@ -1064,6 +1064,7 @@ void WinPortPanel::OnKeyDown( wxKeyEvent& event )
 		ir.Event.KeyEvent.wVirtualKeyCode = VK_UNASSIGNED;
 	}
 
+#ifdef __WXGTK__
 	if (event.ControlDown() && !event.GetKeyCode()) {
 		switch (event.GetRawKeyFlags()) {
 			// Hardware key codes are defined in /usr/share/X11/xkb/keycodes/xfree86
@@ -1082,6 +1083,7 @@ void WinPortPanel::OnKeyDown( wxKeyEvent& event )
 		g_winport_con_in->Enqueue(&ir, 1);
 		_last_keydown_enqueued = true;
 	}
+#endif
 #endif
 
 	if ( (dwMods != 0 && event.GetUnicodeKey() < 32)

--- a/WinPort/src/Backend/WX/wxMain.cpp
+++ b/WinPort/src/Backend/WX/wxMain.cpp
@@ -1065,6 +1065,9 @@ void WinPortPanel::OnKeyDown( wxKeyEvent& event )
 	}
 
 #ifdef __WXGTK__
+	// for non-latin unicode keycode pressed with Ctrl key together
+	// especially for keys not used as accelerators
+	// detect correct keycode by raw key code and enqueue keypress
 	if (event.ControlDown() && !event.GetKeyCode()) {
 		switch (event.GetRawKeyFlags()) {
 			// Hardware key codes are defined in /usr/share/X11/xkb/keycodes/xfree86

--- a/WinPort/src/Backend/WX/wxMain.cpp
+++ b/WinPort/src/Backend/WX/wxMain.cpp
@@ -1069,22 +1069,25 @@ void WinPortPanel::OnKeyDown( wxKeyEvent& event )
 	// especially for keys not used as accelerators
 	// detect correct keycode by raw key code and enqueue keypress
 	if (event.ControlDown() && !event.GetKeyCode()) {
+		bool go = false;
 		switch (event.GetRawKeyFlags()) {
 			// Hardware key codes are defined in /usr/share/X11/xkb/keycodes/xfree86
-			case 20: ir.Event.KeyEvent.wVirtualKeyCode = VK_OEM_MINUS; break;
-			case 21: ir.Event.KeyEvent.wVirtualKeyCode = VK_OEM_PLUS; break;
-			case 34: ir.Event.KeyEvent.wVirtualKeyCode = VK_OEM_4; break;
-			case 35: ir.Event.KeyEvent.wVirtualKeyCode = VK_OEM_6; break;
-			case 47: ir.Event.KeyEvent.wVirtualKeyCode = VK_OEM_1; break;
-			case 48: ir.Event.KeyEvent.wVirtualKeyCode = VK_OEM_7; break;
-			case 49: ir.Event.KeyEvent.wVirtualKeyCode = VK_OEM_3; break;
-			case 51: ir.Event.KeyEvent.wVirtualKeyCode = VK_OEM_5; break;
-			case 59: ir.Event.KeyEvent.wVirtualKeyCode = VK_OEM_COMMA; break;
-			case 60: ir.Event.KeyEvent.wVirtualKeyCode = VK_OEM_PERIOD; break;
-			case 61: ir.Event.KeyEvent.wVirtualKeyCode = VK_OEM_2; break;
+			case 20: ir.Event.KeyEvent.wVirtualKeyCode = VK_OEM_MINUS;	go = true; break;
+			case 21: ir.Event.KeyEvent.wVirtualKeyCode = VK_OEM_PLUS;	go = true; break;
+			case 34: ir.Event.KeyEvent.wVirtualKeyCode = VK_OEM_4;		go = true; break;
+			case 35: ir.Event.KeyEvent.wVirtualKeyCode = VK_OEM_6;		go = true; break;
+			case 47: ir.Event.KeyEvent.wVirtualKeyCode = VK_OEM_1;		go = true; break;
+			case 48: ir.Event.KeyEvent.wVirtualKeyCode = VK_OEM_7;		go = true; break;
+			case 49: ir.Event.KeyEvent.wVirtualKeyCode = VK_OEM_3;		go = true; break;
+			case 51: ir.Event.KeyEvent.wVirtualKeyCode = VK_OEM_5; 		go = true; break;
+			case 59: ir.Event.KeyEvent.wVirtualKeyCode = VK_OEM_COMMA;	go = true; break;
+			case 60: ir.Event.KeyEvent.wVirtualKeyCode = VK_OEM_PERIOD;	go = true; break;
+			case 61: ir.Event.KeyEvent.wVirtualKeyCode = VK_OEM_2;		go = true; break;
 		}
-		g_winport_con_in->Enqueue(&ir, 1);
-		_last_keydown_enqueued = true;
+		if (go) {
+			g_winport_con_in->Enqueue(&ir, 1);
+			_last_keydown_enqueued = true;
+		}
 	}
 #endif
 #endif


### PR DESCRIPTION
1. Implemented minimal fix for `Ctrl`+`б` `ю` `ж` `э` `х` `ъ` and possibly other non latin letters
2. Removed actually unneeded OnChar() call

Finally fixes #1211