### PR TITLE
use last command line parameter, not first

### DIFF
--- a/far2l/src/main.cpp
+++ b/far2l/src/main.cpp
@@ -445,7 +445,7 @@ int FarAppMain(int argc, char **argv)
 	if (strstr(argv[0], "far2ledit") != NULL) {
 		Opt.OnlyEditorViewerUsed = Options::ONLY_EDITOR;
 		if (argc > 1) {
-			strEditViewArg = argv[1];
+			strEditViewArg = argv[argc - 1]; // use last argument
 		} else {
 			strEditViewArg = "NewFile.txt";
 		}


### PR DESCRIPTION
allows things like "far2ledit -an file.txt"