### PR TITLE
Save chars that are invalid in UTF-8 in 56448..56575 code space as Far3 does

### DIFF
--- a/utils/include/ww898/cp_utf16.hpp
+++ b/utils/include/ww898/cp_utf16.hpp
@@ -53,8 +53,8 @@ struct utf16 final
     static char_type const min_surrogate_low = 0xDC00;
     static char_type const max_surrogate_low = 0xDFFF;
 
-    template<typename ReadFn>
-    static uint32_t read(ReadFn && read_fn)
+    template<typename ReadFn, typename BackFn>
+    static uint32_t read(ReadFn && read_fn, BackFn && back_fn)
     {
         char_type const ch0 = read_fn();
         if (ch0 < 0xD800) // [0x0000‥0xD7FF]

--- a/utils/include/ww898/cp_utf32.hpp
+++ b/utils/include/ww898/cp_utf32.hpp
@@ -39,8 +39,8 @@ struct utf32 final
 
     using char_type = uint32_t;
 
-    template<typename ReadFn>
-    static uint32_t read(ReadFn && read_fn)
+    template<typename ReadFn, typename BackFn>
+    static uint32_t read(ReadFn && read_fn, BackFn && back_fn)
     {
         char_type const ch = std::forward<ReadFn>(read_fn)();
         if (ch < 0x80000000)

--- a/utils/include/ww898/utf_converters.hpp
+++ b/utils/include/ww898/utf_converters.hpp
@@ -48,6 +48,7 @@ struct conv_strategy final
     bool operator()(It &it, It const eit, Oit &oit) const
     {
         auto tmp = it;
+        auto const back_fn = [&tmp] { tmp--; };
         bool read_ended = false;
         auto const read_fn = [&tmp, &eit, &read_ended]
             {
@@ -63,7 +64,7 @@ struct conv_strategy final
         while (tmp != eit) {
             if (oit.fully_filled())
                 return false;
-            auto const cp = Utf::read(read_fn);
+            auto const cp = Utf::read(read_fn, back_fn);
             if (read_ended || cp == (uint32_t)-1)
                 return false;
             Outf::write(cp, write_fn);
@@ -84,6 +85,7 @@ struct conv_strategy<Utf, Outf, It, Oit, conv_impl::random_interator> final
     bool operator()(It &it, It const eit, Oit &oit) const
     {
         auto tmp = it;
+        auto const back_fn = [&tmp] { tmp--; };
         auto const write_fn = [&oit] (typename Outf::char_type const ch) { oit.push_back(ch); };
         if (eit - tmp >= static_cast<typename std::iterator_traits<It>::difference_type>(Utf::max_supported_symbol_size))
         {
@@ -92,7 +94,7 @@ struct conv_strategy<Utf, Outf, It, Oit, conv_impl::random_interator> final
                while (tmp < fast_eit) {
                 if (oit.fully_filled())
                        return false;
-                   auto const cp = Utf::read(fast_read_fn);
+                   auto const cp = Utf::read(fast_read_fn, back_fn);
                       if (cp == (uint32_t)-1)
                        return false;
                    Outf::write(cp, write_fn);
@@ -111,7 +113,7 @@ struct conv_strategy<Utf, Outf, It, Oit, conv_impl::random_interator> final
         while (tmp != eit) {
             if (oit.fully_filled())
                 return false;
-            auto const cp = Utf::read(read_fn);
+            auto const cp = Utf::read(read_fn, back_fn);
             if (read_ended || cp == (uint32_t)-1)
                 return false;
             Outf::write(cp, write_fn);


### PR DESCRIPTION
Save chars that are invalid in UTF-8 in 56448..56575 unicode code space as Far3 does to avoid data loss on treating ANSI/OEM files as UTF-8 ones

Fixes #1233