### PR TITLE
fallback to ANSI code page automatically if opening file in editor as UTF-8 fails

### DIFF
--- a/far2l/bootstrap/scripts/farlang.templ.m4
+++ b/far2l/bootstrap/scripts/farlang.templ.m4
@@ -7693,6 +7693,16 @@ MEditorSaveNotRecommended
 "No se recomienda guardar este archivo."
 "Не рекомендується зберігати файл."
 
+MEditorFallbackCP
+"Файл открыт в кодовой странице ANSI"
+"File is opened in ANSI code page"
+upd:"File is opened in ANSI code page"
+upd:"File is opened in ANSI code page"
+upd:"File is opened in ANSI code page"
+upd:"File is opened in ANSI code page"
+upd:"File is opened in ANSI code page"
+"Файл відкритий у кодовій сторінці ANSI "
+
 MEditorSaveCPWarnShow
 "Показать"
 "Show"


### PR DESCRIPTION
yet another approach to minimize #1233's discomforts

why ANSI? ok, it can be made configurable. at least, it is 1-byte encoding which is guaranteed not to make any harm to users data

