### PR TITLE
Do not hide menu title when autofilter is enabled...

### DIFF
--- a/far2l/src/vmenu.cpp
+++ b/far2l/src/vmenu.cpp
@@ -1713,7 +1713,7 @@ void VMenu::DrawTitles()
 
 		if (bFilterEnabled)
 		{
-			if (bFilterLocked)
+			if (bFilterLocked || strFilter.IsEmpty())
 				strDisplayTitle += L" ";
 			else
 				strDisplayTitle.Clear();


### PR DESCRIPTION
...and the search string is empty.

For a long time I have been using the [SmartMenuFilter](https://forum.farmanager.com/viewtopic.php?f=15&t=8463) macro for the Far 3 on Windows and find it very handy. Using it with the command/folders/edit & view history is so convenient that one of the first things I did when I started using far2l was to turn the autofilter on for the aforementioned history menus using the following macros:
```
[KeyMacros/Shell/AltF8]
Sequence=AltF8 CtrlAltF

[KeyMacros/Shell/AltF11]
Sequence=AltF11 CtrlAltF

[KeyMacros/Shell/AltF12]
Sequence=AltF12 CtrlAltF
```
Some inconvenience while using the above macros is that we don't see the menu titles after invoking the corresponding menu (autofilter, being turned on, replaces the menu title with the `[]`). That is not happened when the aforementioned SmartFilterMenu macro is being used with the Far 3 for Windows. I thought it is an autofilter behavior change introduced with the Far 3, and tried to find out the corresponding code parts in the Far 3 codebase. But it turns out (being a great surprise to me) that the autofilter behavior hasn't changed since the Far 2. In fact it is the macro that restores the menu title when the autofilter string is empty. However, when a far2l macro which turns on the autofilter for some menus (like shown above) is used, it is very handy to see the menu title too (at least to be sure you are not mistaken and invoke the right menu). Fortunately, a very minimal code change is needed to do the same thing (preserving the menu title when the autofilter is turned on yet the autofilter search string is empty), so I'm proposing to add this functionality into the far2l code.

Before:
![menu_title_hidden](https://user-images.githubusercontent.com/17809980/152656129-6a6604e9-b2e3-4620-9512-4b8fba9412cd.png)
After:
![menu_title_visible](https://user-images.githubusercontent.com/17809980/152656141-74e3256f-4ac1-4938-90b2-51d18dacf4df.png)