### PR TITLE
fixes #1241: wrong escape codes for arrow keys

### DIFF
--- a/far2l/src/vt/vtshell_translation.cpp
+++ b/far2l/src/vt/vtshell_translation.cpp
@@ -282,18 +282,18 @@ const char *VT_TranslateSpecialKey(const WORD key, bool ctrl, bool alt, bool shi
         Up       Alt       \x1b[1;3A
         Up       Ctrl      \x1b[5A
         Up       Ctrl      \x1b[1;5A */
-			if (keypad == 1) {
+//			if (keypad == 1) {
 				if (ctrl && shift) return "\x1b[1;6A";
 				if (shift) return "\x1b[1;2A";
 				if (alt) return "\x1b[1;3A";
 				if (ctrl) return "\x1b[1;5A";
-				return "\x1bOA";
-			}
-			if (ctrl && shift) return "\x1b[6A";
-			if (shift) return "\x1b[2A";
-			if (alt) return "\x1b[3A";
-			if (ctrl) return "\x1b[5A";
-			return "\x1b[A";
+				return "\x1b[A";
+//			}
+//			if (ctrl && shift) return "\x1b[6A";
+//			if (shift) return "\x1b[2A";
+//			if (alt) return "\x1b[3A";
+//			if (ctrl) return "\x1b[5A";
+//			return "\x1b[A";
 		
 		case VK_DOWN: /*
         Down               \x1bOB
@@ -304,18 +304,18 @@ const char *VT_TranslateSpecialKey(const WORD key, bool ctrl, bool alt, bool shi
         Down     Alt       \x1b[1;3B
         Down     Ctrl      \x1b[5B
         Down     Ctrl      \x1b[1;5B */
-			if (keypad == 1) {
+//			if (keypad == 1) {
 				if (ctrl && shift) return "\x1b[1;6B";
 				if (shift) return "\x1b[1;2B";
 				if (alt) return "\x1b[1;3B";
 				if (ctrl) return "\x1b[1;5B";
-				return "\x1bOB";
-			}
-			if (ctrl && shift) return "\x1b[6B";
-			if (shift) return "\x1b[2B";
-			if (alt) return "\x1b[3B";
-			if (ctrl) return "\x1b[5B";
-			return "\x1b[B";
+				return "\x1b[B";
+//			}
+//			if (ctrl && shift) return "\x1b[6B";
+//			if (shift) return "\x1b[2B";
+//			if (alt) return "\x1b[3B";
+//			if (ctrl) return "\x1b[5B";
+//			return "\x1b[B";
 
 		case VK_LEFT: /*
         Left               \x1bOD
@@ -326,18 +326,18 @@ const char *VT_TranslateSpecialKey(const WORD key, bool ctrl, bool alt, bool shi
         Left     Alt       \x1b[1;3D
         Left     Ctrl      \x1b[5D
         Left     Ctrl      \x1b[1;5D */
-			if (keypad == 1) {
+//			if (keypad == 1) {
 				if (ctrl && shift) return "\x1b[1;6D";
 				if (shift) return "\x1b[1;2D";
 				if (alt) return "\x1b[1;3D";
 				if (ctrl) return "\x1b[1;5D";
-				return "\x1bOD";
-			}
-			if (ctrl && shift) return "\x1b[6D";
-			if (shift) return "\x1b[2D";
-			if (alt) return "\x1b[3D";
-			if (ctrl) return "\x1b[5D";
-			return "\x1b[D";
+				return "\x1b[D";
+//			}
+//			if (ctrl && shift) return "\x1b[6D";
+//			if (shift) return "\x1b[2D";
+//			if (alt) return "\x1b[3D";
+//			if (ctrl) return "\x1b[5D";
+//			return "\x1b[D";
 
 		case VK_RIGHT: /*
         Right              \x1bOC
@@ -348,18 +348,18 @@ const char *VT_TranslateSpecialKey(const WORD key, bool ctrl, bool alt, bool shi
         Right    Alt       \x1b[1;3C
         Right    Ctrl      \x1b[5C
         Right    Ctrl      \x1b[1;5C */
-			if (keypad == 1) {
+//			if (keypad == 1) {
 				if (ctrl && shift) return "\x1b[1;6C";
 				if (shift) return "\x1b[1;2C";
 				if (alt) return "\x1b[1;3C";
 				if (ctrl) return "\x1b[1;5C";
-				return "\x1bOC";
-			}
-			if (ctrl && shift) return "\x1b[6C";
-			if (shift) return "\x1b[2C";
-			if (alt) return "\x1b[3C";
-			if (ctrl) return "\x1b[5C";
-			return "\x1b[C";
+				return "\x1b[C";
+//			}
+//			if (ctrl && shift) return "\x1b[6C";
+//			if (shift) return "\x1b[2C";
+//			if (alt) return "\x1b[3C";
+//			if (ctrl) return "\x1b[5C";
+//			return "\x1b[C";
 	}
 
 	if (ctrl && !alt && !shift) {		

--- a/far2l/src/vt/vtshell_translation.cpp
+++ b/far2l/src/vt/vtshell_translation.cpp
@@ -282,18 +282,19 @@ const char *VT_TranslateSpecialKey(const WORD key, bool ctrl, bool alt, bool shi
         Up       Alt       \x1b[1;3A
         Up       Ctrl      \x1b[5A
         Up       Ctrl      \x1b[1;5A */
-//			if (keypad == 1) {
-				if (ctrl && shift) return "\x1b[1;6A";
-				if (shift) return "\x1b[1;2A";
-				if (alt) return "\x1b[1;3A";
-				if (ctrl) return "\x1b[1;5A";
-				return "\x1b[A";
-//			}
+			if (ctrl && shift) return "\x1b[1;6A";
+			if (shift) return "\x1b[1;2A";
+			if (alt) return "\x1b[1;3A";
+			if (ctrl) return "\x1b[1;5A";
+    		if (keypad == 1) {
+				return "\x1bOA";
+			}
+//          breaks free pascal ide
 //			if (ctrl && shift) return "\x1b[6A";
 //			if (shift) return "\x1b[2A";
 //			if (alt) return "\x1b[3A";
 //			if (ctrl) return "\x1b[5A";
-//			return "\x1b[A";
+    		return "\x1b[A";
 		
 		case VK_DOWN: /*
         Down               \x1bOB
@@ -304,18 +305,19 @@ const char *VT_TranslateSpecialKey(const WORD key, bool ctrl, bool alt, bool shi
         Down     Alt       \x1b[1;3B
         Down     Ctrl      \x1b[5B
         Down     Ctrl      \x1b[1;5B */
-//			if (keypad == 1) {
-				if (ctrl && shift) return "\x1b[1;6B";
-				if (shift) return "\x1b[1;2B";
-				if (alt) return "\x1b[1;3B";
-				if (ctrl) return "\x1b[1;5B";
-				return "\x1b[B";
-//			}
+			if (ctrl && shift) return "\x1b[1;6B";
+			if (shift) return "\x1b[1;2B";
+			if (alt) return "\x1b[1;3B";
+			if (ctrl) return "\x1b[1;5B";
+			if (keypad == 1) {
+				return "\x1bOB";
+			}
+//          breaks free pascal ide
 //			if (ctrl && shift) return "\x1b[6B";
 //			if (shift) return "\x1b[2B";
 //			if (alt) return "\x1b[3B";
 //			if (ctrl) return "\x1b[5B";
-//			return "\x1b[B";
+			return "\x1b[B";
 
 		case VK_LEFT: /*
         Left               \x1bOD
@@ -326,18 +328,19 @@ const char *VT_TranslateSpecialKey(const WORD key, bool ctrl, bool alt, bool shi
         Left     Alt       \x1b[1;3D
         Left     Ctrl      \x1b[5D
         Left     Ctrl      \x1b[1;5D */
-//			if (keypad == 1) {
-				if (ctrl && shift) return "\x1b[1;6D";
-				if (shift) return "\x1b[1;2D";
-				if (alt) return "\x1b[1;3D";
-				if (ctrl) return "\x1b[1;5D";
-				return "\x1b[D";
-//			}
+			if (ctrl && shift) return "\x1b[1;6D";
+			if (shift) return "\x1b[1;2D";
+			if (alt) return "\x1b[1;3D";
+			if (ctrl) return "\x1b[1;5D";
+    		if (keypad == 1) {
+				return "\x1bOD";
+			}
+//          breaks free pascal ide
 //			if (ctrl && shift) return "\x1b[6D";
 //			if (shift) return "\x1b[2D";
 //			if (alt) return "\x1b[3D";
 //			if (ctrl) return "\x1b[5D";
-//			return "\x1b[D";
+			return "\x1b[D";
 
 		case VK_RIGHT: /*
         Right              \x1bOC
@@ -348,18 +351,19 @@ const char *VT_TranslateSpecialKey(const WORD key, bool ctrl, bool alt, bool shi
         Right    Alt       \x1b[1;3C
         Right    Ctrl      \x1b[5C
         Right    Ctrl      \x1b[1;5C */
-//			if (keypad == 1) {
-				if (ctrl && shift) return "\x1b[1;6C";
-				if (shift) return "\x1b[1;2C";
-				if (alt) return "\x1b[1;3C";
-				if (ctrl) return "\x1b[1;5C";
-				return "\x1b[C";
-//			}
+			if (ctrl && shift) return "\x1b[1;6C";
+			if (shift) return "\x1b[1;2C";
+			if (alt) return "\x1b[1;3C";
+			if (ctrl) return "\x1b[1;5C";
+    		if (keypad == 1) {
+				return "\x1bOC";
+			}
+//          breaks free pascal ide
 //			if (ctrl && shift) return "\x1b[6C";
 //			if (shift) return "\x1b[2C";
 //			if (alt) return "\x1b[3C";
 //			if (ctrl) return "\x1b[5C";
-//			return "\x1b[C";
+			return "\x1b[C";
 	}
 
 	if (ctrl && !alt && !shift) {		


### PR DESCRIPTION
updated vt translations to mimic GNOME Terminal's escape seqs