### PR TITLE
better charset detection

### DIFF
--- a/far2l/src/locale/DetectCodepage.cpp
+++ b/far2l/src/locale/DetectCodepage.cpp
@@ -33,6 +33,9 @@ static int TranslateUDCharset(const char *cs)
 		return atoi(cs + 2);
 	}
 
+    if (strncasecmp(cs, "IBM", 3) == 0 && IsDecimalNumber(cs + 3)) {
+		return atoi(cs + 3);
+	}
 
 	if (!strcasecmp(cs, "UTF16-LE") || !strcasecmp(cs, "UTF16"))
 		return CP_UTF16LE;
@@ -46,10 +49,10 @@ static int TranslateUDCharset(const char *cs)
 		return CP_UTF8;
 	if (!strcasecmp(cs, "UTF-7"))
 		return CP_UTF7;
-	if (!strcasecmp(cs, "IBM855"))
-		return 855;
-	if (!strcasecmp(cs, "IBM866"))
-		return 866;
+//	if (!strcasecmp(cs, "IBM855"))
+//		return 855;
+//	if (!strcasecmp(cs, "IBM866"))
+//		return 866;
 	if (!strcasecmp(cs, "KOI8-R"))
 		return 20866;
 	if (!strcasecmp(cs, "KOI8-U"))

--- a/far2l/src/locale/DetectCodepage.cpp
+++ b/far2l/src/locale/DetectCodepage.cpp
@@ -33,7 +33,7 @@ static int TranslateUDCharset(const char *cs)
 		return atoi(cs + 2);
 	}
 
-    if (strncasecmp(cs, "IBM", 3) == 0 && IsDecimalNumber(cs + 3)) {
+	if (strncasecmp(cs, "IBM", 3) == 0 && IsDecimalNumber(cs + 3)) {
 		return atoi(cs + 3);
 	}
 


### PR DESCRIPTION
In Ubuntu 22.04 uchardet returns IBM852 on some source code files with pseudographic chars in comments. While not being perfect (it should be CP437), this guess is far better then WINDOWS-1252 (as in Ubuntu 20.04 on the same files) or UTF-8 (as if far2l do not understand uchardet return string).

This PR fixes far2l's understanding of uchardet return values like this.
