### PR TITLE
Fix crash with ANSI plugins that call DefDlgProc

### DIFF
--- a/far2l/src/plug/wrap.cpp
+++ b/far2l/src/plug/wrap.cpp
@@ -931,7 +931,7 @@ int WINAPI ConvertNameToRealA(const char *Src,char *Dest,int DestSize)
 
 int WINAPI FarGetReparsePointInfoA(const char *Src,char *Dest,int DestSize)
 {
-	
+
 	/*if (Src && *Src)
 	{
 		FARString strSrc(Src);
@@ -1878,6 +1878,12 @@ LONG_PTR WINAPI DlgProcA(HANDLE hDlg, int Msg, int Param1, LONG_PTR Param2)
 
 LONG_PTR WINAPI FarDefDlgProcA(HANDLE hDlg, int Msg, int Param1, LONG_PTR Param2)
 {
+	if (Msg == DN_DRAWDLGITEM || Msg == DN_EDITCHANGE)
+	{
+		FarDialogItem* di = CurrentDialogItem(hDlg, Param1);
+		if (di)
+			Param2 = (LONG_PTR)di;
+	}
 	return FarDefDlgProc(hDlg, Msg, Param1, Param2);
 }
 


### PR DESCRIPTION
Это фикс для #1267, но не начального крэша, а того, который описан внизу #1267  (GitHub не позволил мне переоткрыть этот issue).
### Краткое описание:
ANSI-плагины используют ту же функцию `DefDlgProc`, что и юникодные плагины.
Но в сообщениях `DN_DRAWDLGITEM` и `DN_EDITCHANGE` Param2 является указателем на DialogItem, в результате `DefDlgProc` получает указатель на DialogItem, в котором Data - это `char*`, а не `wchar_t*`.
Сама функция `DefDlgProc` ничего не делает с этим указателем, но если есть плагин, обрабатывающий `ProcessDialogEvent`, то функция `DefDlgProc` вызывает этот `ProcessDialogEvent`, передаёт ему ANSI DialogItem, и далее может произойти крэш, ибо плагин такой засады не ожидает.