### PR TITLE
Fix ECTL_SAVEFILE with invalid code page (see #1287)

### DIFF
--- a/far2l/src/fileedit.cpp
+++ b/far2l/src/fileedit.cpp
@@ -1932,7 +1932,9 @@ int FileEditor::SaveFile(const wchar_t *Name,int Ask, bool bSaveAs, int TextForm
 				if (TextFormat&&*EndSeq)
 					EndSeq=m_editor->GlobalEOL;
 
-				WINPORT(WideCharToMultiByte)(codepage,WC_NO_BEST_FIT_CHARS,EndSeq,StrLength(EndSeq),nullptr,0,nullptr,&UsedDefaultCharEOL);
+				int EndSeqLen = StrLength(EndSeq);
+				if (EndSeqLen && !WINPORT(WideCharToMultiByte)(codepage,WC_NO_BEST_FIT_CHARS,EndSeq,EndSeqLen,nullptr,0,nullptr,&UsedDefaultCharEOL))
+					return SAVEFILE_ERROR;
 
 				if (!BadSaveConfirmed && (UsedDefaultCharStr||UsedDefaultCharEOL))
 				{

--- a/far2l/src/fileedit.cpp
+++ b/far2l/src/fileedit.cpp
@@ -1036,7 +1036,7 @@ int FileEditor::ReProcessKey(int Key,int CalledFromControl)
 					if (SaveAs)
 					{
 						FARString strSaveAsName = Flags.Check(FFILEEDIT_SAVETOSAVEAS)?strFullFileName:strFileName;
-						
+
 						bool AddSignature = DecideAboutSignature();
 						if (!dlgSaveFileAs(strSaveAsName, SaveAsTextFormat, codepage, AddSignature))
 							return FALSE;
@@ -1923,7 +1923,8 @@ int FileEditor::SaveFile(const wchar_t *Name,int Ask, bool bSaveAs, int TextForm
 				int Length;
 				CurPtr->GetBinaryString(&SaveStr,&EndSeq,Length);
 				BOOL UsedDefaultCharStr=FALSE,UsedDefaultCharEOL=FALSE;
-				WINPORT(WideCharToMultiByte)(codepage,WC_NO_BEST_FIT_CHARS,SaveStr,Length,nullptr,0,nullptr,&UsedDefaultCharStr);
+				if (Length && !WINPORT(WideCharToMultiByte)(codepage,WC_NO_BEST_FIT_CHARS,SaveStr,Length,nullptr,0,nullptr,&UsedDefaultCharStr))
+					return SAVEFILE_ERROR;
 
 				if (!*EndSeq && CurPtr->m_next)
 					EndSeq=*m_editor->GlobalEOL?m_editor->GlobalEOL:DOS_EOL_fmt;


### PR DESCRIPTION
Это фикс для #1287.
При вызове `EditorControl(ECTL_SAVEFILE)`, если передана невалидная кодовая страница, возвращает `FALSE`.
В отсутствие данного фикса возвращается `TRUE`, а файл сохраняется пустым (ноль байт).