### PR TITLE
Fix the C9 custom column

### DIFF
--- a/far2l/src/mix/panelmix.cpp
+++ b/far2l/src/mix/panelmix.cpp
@@ -48,7 +48,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "lang.hpp"
 #include "datetime.hpp"
 
-int ColumnTypeWidth[]={0, 6, 6, 8, 5, 14, 14, 14, 14, 10, 0, 0, 3, 3, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+int ColumnTypeWidth[]={0, 6, 6, 8, 5, 14, 14, 14, 14, 10, 0, 0, 3, 3, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
 static const wchar_t *ColumnSymbol[]={L"N",L"S",L"P",L"D",L"T",L"DM",L"DC",L"DA",L"DE",L"A",L"Z",L"O",L"U",L"LN",L"F",L"G",L"C0",L"C1",L"C2",L"C3",L"C4",L"C5",L"C6",L"C7",L"C8",L"C9"};
 


### PR DESCRIPTION
При открытии панели плагина, содержащего кастомные колонки, код ширины которых "0", всё было нормально, пока количество колонок было < 10. Если колонок было 10, то вместо равномерного распределения ширин, первые 9 были шириной в 1 символ, а последняя занимала всё остальное место.

Не вдаваясь в детали механизма бага - его суть в том, что массив `ColumnTypeWidth[]` был на один элемент короче массива `ColumnSymbol[]`.