### PR TITLE
Fix text corruption in displaying help files

### DIFF
--- a/far2l/src/help.cpp
+++ b/far2l/src/help.cpp
@@ -402,14 +402,11 @@ int Help::ReadHelp(const wchar_t *Mask)
 
 		if (!strCtrlStartPosChar.IsEmpty() && wcsstr(strReadStr, strCtrlStartPosChar))
 		{
-			FARString strLine;
-			ReadStr = strReadStr.GetBuffer();
-			int Length = (int)(wcsstr(ReadStr, strCtrlStartPosChar)-ReadStr);
-			strLine = ReadStr;
+			int Length = (int)(wcsstr(strReadStr, strCtrlStartPosChar)-strReadStr);
+			FARString strLine = strReadStr;
 			strLine.Truncate(Length);
 			LastStartPos = StringLen(strLine);
-			wcscpy(ReadStr+Length, ReadStr+Length+strCtrlStartPosChar.GetLength());
-			strReadStr.ReleaseBuffer();
+			strReadStr = strReadStr.SubStr(0,Length) + strReadStr.SubStr(Length+strCtrlStartPosChar.GetLength());
 		}
 
 		if (TopicFound)


### PR DESCRIPTION
Некорректная обработка `.Options CtrlStartPosChar` приводила к искажениям отображаемого текста, причём эти искажения изменялись при изменении размеров окна справки. Вот пример этих искажений:
![Clipboard01](https://user-images.githubusercontent.com/344558/162641373-5933624c-1d7b-4908-a27b-adae61ae689b.png)
