### PR TITLE
Поддержка RightCtrl в макросах #1323

### DIFF
--- a/WinPort/src/Backend/WX/wxWinTranslations.cpp
+++ b/WinPort/src/Backend/WX/wxWinTranslations.cpp
@@ -12,6 +12,8 @@
 #  include "Mac/touchbar.h"
 
 /*
+  kVK_Escape                    = 0x35,
+  kVK_RightCommand              = 0x36,
   kVK_Command                   = 0x37,
   kVK_Shift                     = 0x38,
   kVK_CapsLock                  = 0x39,

--- a/far2l/bootstrap/scripts/farlang.templ.m4
+++ b/far2l/bootstrap/scripts/farlang.templ.m4
@@ -2077,6 +2077,16 @@ ConfigPgUpChangeDisk
 "Usar Ctrl-Pg&Up para cambiar unidad"
 "Використовувати Ctrl-PgUp для в&ибору диска"
 
+ConfigSeparateRCtrl
+"Обрабатывать &RCtrl отдельно от Ctrl"
+"Separate the Ctrl and &RCtrl keys"
+upd:"Separate the Ctrl and &RCtrl keys"
+upd:"Separate the Ctrl and &RCtrl keys"
+upd:"Separate the Ctrl and &RCtrl keys"
+upd:"Separate the Ctrl and &RCtrl keys"
+upd:"Separate the Ctrl and &RCtrl keys"
+upd:"Separate the Ctrl and &RCtrl keys"
+
 ConfigWindowTitle
 "Заголовок окна FAR:"
 "FAR window title:"

--- a/far2l/src/cfg/config.cpp
+++ b/far2l/src/cfg/config.cpp
@@ -341,6 +341,7 @@ void InterfaceSettings()
 		Builder.AddCheckbox(Msg::ConfigCopyTimeRule, &Opt.CMOpt.CopyTimeRule);
 		Builder.AddCheckbox(Msg::ConfigDeleteTotal, &Opt.DelOpt.DelShowTotal);
 		Builder.AddCheckbox(Msg::ConfigPgUpChangeDisk, &Opt.PgUpChangeDisk);
+		Builder.AddCheckbox(Msg::ConfigSeparateRCtrl, &Opt.SeparateRCtrl);
 		
 		
 		const DWORD supported_tweaks = ApplyConsoleTweaks();

--- a/far2l/src/cfg/config.hpp
+++ b/far2l/src/cfg/config.hpp
@@ -540,6 +540,7 @@ struct Options
 	int SubstNameRule;
 
 	int PgUpChangeDisk;
+	int SeparateRCtrl;
 	int ShowCheckingFile;
 
 	DWORD LCIDSort;

--- a/far2l/src/console/keyboard.cpp
+++ b/far2l/src/console/keyboard.cpp
@@ -2790,9 +2790,10 @@ DWORD CalcKeyCode(INPUT_RECORD *rec,int RealKey,int *NotMacros)
 
 		_SVS(if (KeyCode!=VK_CONTROL) SysLog(L"Ctrl -> |%ls|%ls|",_VK_KEY_ToName(KeyCode),_INPUT_RECORD_Dump(rec)));
 
+		const bool RCtrl = Opt.SeparateRCtrl && RightCtrlPressed;
+		auto const ctrl = RCtrl ? KEY_RCTRL : KEY_CTRL;
 		if (KeyCode>='0' && KeyCode<='9')
-			return((RightCtrlPressed ? KEY_RCTRL0 : KEY_CTRL0)+KeyCode-'0');
-		auto const ctrl = Opt.SeparateRCtrl && RightCtrlPressed ? KEY_RCTRL : KEY_CTRL;
+			return((RCtrl ? KEY_RCTRL0 : KEY_CTRL0)+KeyCode-'0');
 		if (KeyCode>='A' && KeyCode<='Z')
 			return(ctrl+KeyCode);
 

--- a/far2l/src/console/keyboard.cpp
+++ b/far2l/src/console/keyboard.cpp
@@ -2791,56 +2791,56 @@ DWORD CalcKeyCode(INPUT_RECORD *rec,int RealKey,int *NotMacros)
 		_SVS(if (KeyCode!=VK_CONTROL) SysLog(L"Ctrl -> |%ls|%ls|",_VK_KEY_ToName(KeyCode),_INPUT_RECORD_Dump(rec)));
 
 		if (KeyCode>='0' && KeyCode<='9')
-			return(KEY_CTRL0+KeyCode-'0');
-
+			return((RightCtrlPressed ? KEY_RCTRL0 : KEY_CTRL0)+KeyCode-'0');
+		auto const ctrl = RightCtrlPressed ? KEY_RCTRL : KEY_CTRL;
 		if (KeyCode>='A' && KeyCode<='Z')
-			return(KEY_CTRL+KeyCode);
+			return(ctrl+KeyCode);
 
 		switch (KeyCode)
 		{
 			case VK_OEM_COMMA:
-				return(KEY_CTRLCOMMA);
+				return(ctrl+KEY_COMMA);
 			case VK_OEM_PERIOD:
-				return(KEY_CTRLDOT);
+				return(ctrl+KEY_DOT);
 			case VK_OEM_2:
-				return(KEY_CTRLSLASH);
+				return(ctrl+KEY_SLASH);
 			case VK_OEM_4:
-				return(KEY_CTRLBRACKET);
+				return(ctrl+KEY_BRACKET);
 			case VK_OEM_5:
-				return(KEY_CTRLBACKSLASH);
+				return(ctrl+KEY_BACKSLASH);
 			case VK_OEM_6:
-				return(KEY_CTRLBACKBRACKET);
+				return(ctrl+KEY_BACKBRACKET);
 			case VK_OEM_7:
-				return(KEY_CTRL+'\''); // KEY_QUOTE
+				return(ctrl+'\''); // KEY_QUOTE
 			case VK_MULTIPLY:
-				return(KEY_CTRL|KEY_MULTIPLY);
+				return(ctrl|KEY_MULTIPLY);
 			case VK_DIVIDE:
-				return(KEY_CTRL|KEY_DIVIDE);
+				return(ctrl|KEY_DIVIDE);
 			case VK_PAUSE:
 
 				if (CtrlState&ENHANCED_KEY)
-					return KEY_CTRL|KEY_NUMLOCK;
+					return ctrl|KEY_NUMLOCK;
 
 				return(KEY_BREAK);
 			case VK_SLEEP:
-				return KEY_CTRL|KEY_STANDBY;
+				return ctrl|KEY_STANDBY;
 			case VK_SNAPSHOT:
-				return KEY_CTRL|KEY_PRNTSCRN;
+				return ctrl|KEY_PRNTSCRN;
 			case VK_OEM_102: // <> \|
- 				return KEY_CTRL|KEY_BACKSLASH;
+ 				return ctrl|KEY_BACKSLASH;
 		}
 
 		if (Opt.ShiftsKeyRules) //???
 			switch (KeyCode)
 			{
 				case VK_OEM_3:
-					return(KEY_CTRL+'`');
+					return(ctrl+'`');
 				case VK_OEM_MINUS:
-					return(KEY_CTRL+'-');
+					return(ctrl+'-');
 				case VK_OEM_PLUS:
-					return(KEY_CTRL+'=');
+					return(ctrl+'=');
 				case VK_OEM_1:
-					return(KEY_CTRL+KEY_SEMICOLON);
+					return(ctrl+KEY_SEMICOLON);
 			}
 
 		if (KeyCode)
@@ -2848,7 +2848,7 @@ DWORD CalcKeyCode(INPUT_RECORD *rec,int RealKey,int *NotMacros)
 			if (!RealKey && KeyCode==VK_CONTROL)
 				return(KEY_NONE);
 
-			return(KEY_CTRL+KeyCode);
+			return(ctrl+KeyCode);
 		}
 	}
 

--- a/far2l/src/console/keyboard.cpp
+++ b/far2l/src/console/keyboard.cpp
@@ -2792,7 +2792,7 @@ DWORD CalcKeyCode(INPUT_RECORD *rec,int RealKey,int *NotMacros)
 
 		if (KeyCode>='0' && KeyCode<='9')
 			return((RightCtrlPressed ? KEY_RCTRL0 : KEY_CTRL0)+KeyCode-'0');
-		auto const ctrl = RightCtrlPressed ? KEY_RCTRL : KEY_CTRL;
+		auto const ctrl = Opt.SeparateRCtrl && RightCtrlPressed ? KEY_RCTRL : KEY_CTRL;
 		if (KeyCode>='A' && KeyCode<='Z')
 			return(ctrl+KeyCode);
 


### PR DESCRIPTION
#1323 
Частичная поддержка, сочетания с `Alt`, `Shift` всё ещё не работают.
Также неизвестно, как оно работает с терминалами.