### PR TITLE
Compilation fix with recent gcc/clang versions

### DIFF
--- a/NetRocks/src/Protocol/FTP/FTPParseMLST.cpp
+++ b/NetRocks/src/Protocol/FTP/FTPParseMLST.cpp
@@ -1,5 +1,6 @@
 #include <string.h>
 #include <stdlib.h>
+#include <time.h>
 
 #include "FTPParseMLST.h"
 #include "../../Erroring.h"

--- a/far2l/src/base/SafeMMap.cpp
+++ b/far2l/src/base/SafeMMap.cpp
@@ -4,6 +4,7 @@
 #include <signal.h>
 #include <unistd.h>
 #include <string.h>
+#include <time.h>
 
 #if !defined(__FreeBSD__) && !defined(__MUSL__) // todo: pass to linker -lexecinfo under BSD and then may remove this ifndef
 # include <execinfo.h>

--- a/far2l/src/vt/vtcompletor.cpp
+++ b/far2l/src/vt/vtcompletor.cpp
@@ -12,6 +12,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <string>
+#include <time.h>
 #include <utils.h>
 #include "vtcompletor.h"
 


### PR DESCRIPTION
This simple PR fixes `error: ‘time’ was not declared in this scope` compilation errors with recent versions of gcc/clang/glibc.
