### PR TITLE
allow WM to select window position, and restore possibility to set window size in chars

### DIFF
--- a/WinPort/src/Backend/WX/wxMain.cpp
+++ b/WinPort/src/Backend/WX/wxMain.cpp
@@ -310,10 +310,10 @@ WinPortFrame::WinPortFrame(const wxString& title)
 	if (_win_state.pos.y + _win_state.size.GetHeight() > rc.GetBottom()) {
 		_win_state.pos.y = rc.GetBottom() - _win_state.size.GetHeight();
 	}
-	if (_win_state.pos.x < rc.GetLeft()) {
+	if (_win_state.pos.x >= 0 && _win_state.pos.x < rc.GetLeft()) {
 		_win_state.pos.x = rc.GetLeft();
 	}
-	if (_win_state.pos.y < rc.GetTop()) {
+	if (_win_state.pos.y >= 0 && _win_state.pos.y < rc.GetTop()) {
 		_win_state.pos.y = rc.GetTop();
 	}
 

--- a/WinPort/src/Backend/WX/wxMain.cpp
+++ b/WinPort/src/Backend/WX/wxMain.cpp
@@ -182,6 +182,16 @@ WinState::WinState()
 	pos.x = atoi(str.c_str());
 	getline(is, str);
 	pos.y = atoi(str.c_str());
+
+	std::ifstream isconsize;
+	isconsize.open(InMyConfig("consolesize").c_str());
+	if (isconsize.is_open()) {
+		std::string str;
+		getline (isconsize, str);
+		charSize.x = atoi(str.c_str());
+		getline (isconsize, str);
+		charSize.y = atoi(str.c_str());
+	}
 }
 
 void WinState::Save()
@@ -348,6 +358,7 @@ void WinPortFrame::OnInitialized()
 		// workaround for #1483 (wrong initial size on Lubuntu's LXQt DE)
 		SetSize(_win_state.pos.x, _win_state.pos.y,
 			_win_state.size.GetWidth(), _win_state.size.GetHeight());
+		if(_win_state.charSize.x > 0 && _win_state.charSize.y > 0) _panel->SetClientCharSize(_win_state.charSize.x, _win_state.charSize.y);
 	}
 }
 
@@ -550,6 +561,11 @@ void WinPortPanel::GetAlignmentGaps(int &horz, int &vert)
 	const unsigned int font_height = _paint_context.FontHeight();
 	horz = (width % font_width);
 	vert = (height % font_height);
+}
+
+void WinPortPanel::SetClientCharSize(int cw, int ch)
+{
+	_frame->SetClientSize(cw*_paint_context.FontWidth(), ch*_paint_context.FontHeight());
 }
 
 void WinPortPanel::OnInitialized( wxCommandEvent& event )

--- a/WinPort/src/Backend/WX/wxMain.h
+++ b/WinPort/src/Backend/WX/wxMain.h
@@ -169,7 +169,7 @@ public:
 
 struct WinState
 {
-	wxPoint pos {40, 40};
+	wxPoint pos = wxDefaultPosition;
 	wxSize size {800, 440};
 	bool maximized{false};
 	bool fullscreen{false};

--- a/WinPort/src/Backend/WX/wxMain.h
+++ b/WinPort/src/Backend/WX/wxMain.h
@@ -163,6 +163,7 @@ public:
 	void GetAlignmentGaps(int &horz, int &vert);
 	void OnChar( wxKeyEvent& event );
 	virtual void OnTouchbarKey(bool alternate, int index);
+	void SetClientCharSize(int cw, int ch);
 };
 
 ///////////////////////////////////////////
@@ -171,6 +172,7 @@ struct WinState
 {
 	wxPoint pos = wxDefaultPosition;
 	wxSize size {800, 440};
+	wxSize charSize {-1,-1};
 	bool maximized{false};
 	bool fullscreen{false};
 


### PR DESCRIPTION
- first commit uses wxDefaultPosition for WinState::pos
  to allow window manger to select startup position if winstate file contains -1 for x/y positions
  (always using fixed position is not always desirable)

- second commit restores functionality to set windows size in characters if consolesize file is present
  (i use same config for size of windows in chars across different machines,
  and size in pixel is not good enough, also because it is difficult to resize window to get rid of black padding
  if size is not multiple of chars) 

possible modification (if requested):
- move consolesize values to winstate (but consolesize was already present in past versions)
