### PR TITLE
Make indentation more consistent throughtout MA; misc .editorconfig fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,5 +6,5 @@ end_of_line = lf
 indent_style = tab
 indent_size = 4
 
-[**CMakeLists.txt]
+[CMakeLists.txt]
 indent_style = space

--- a/NetRocks/.editorconfig
+++ b/NetRocks/.editorconfig
@@ -1,0 +1,3 @@
+[*.hlf]
+indent_style = space
+indent_size = 2

--- a/SimpleIndent/.editorconfig
+++ b/SimpleIndent/.editorconfig
@@ -1,3 +1,6 @@
 [*]
 indent_style = space
 indent_size = 2
+
+[CMakeLists.txt]
+indent_size = 4

--- a/align/.editorconfig
+++ b/align/.editorconfig
@@ -1,3 +1,6 @@
 [*]
 indent_style = space
 indent_size = 2
+
+[CMakeLists.txt]
+indent_size = 4

--- a/autowrap/.editorconfig
+++ b/autowrap/.editorconfig
@@ -1,3 +1,6 @@
 [*]
 indent_style = space
 indent_size = 2
+
+[CMakeLists.txt]
+indent_size = 4

--- a/calc/.editorconfig
+++ b/calc/.editorconfig
@@ -9,3 +9,6 @@ indent_size = 4
 
 [src/shared/mathexpression/*]
 indent_size = 2
+
+[CMakeLists.txt]
+indent_size = 4

--- a/calc/.editorconfig
+++ b/calc/.editorconfig
@@ -10,5 +10,11 @@ indent_size = 4
 [src/shared/mathexpression/*]
 indent_size = 2
 
+[*.csr]
+indent_size = 2
+
+[*.hlf]
+indent_size = 2
+
 [CMakeLists.txt]
 indent_size = 4

--- a/colorer/.editorconfig
+++ b/colorer/.editorconfig
@@ -1,3 +1,6 @@
 [*]
 indent_style = space
 indent_size = 2
+
+[CMakeLists.txt]
+indent_size = 4

--- a/compare/.editorconfig
+++ b/compare/.editorconfig
@@ -1,3 +1,6 @@
 [*]
 indent_style = space
 indent_size = 2
+
+[CMakeLists.txt]
+indent_size = 4

--- a/drawline/.editorconfig
+++ b/drawline/.editorconfig
@@ -1,3 +1,6 @@
 [*]
 indent_style = space
 indent_size = 2
+
+[CMakeLists.txt]
+indent_size = 4

--- a/editcase/.editorconfig
+++ b/editcase/.editorconfig
@@ -1,3 +1,6 @@
 [*]
 indent_style = space
 indent_size = 2
+
+[CMakeLists.txt]
+indent_size = 4

--- a/editorcomp/.editorconfig
+++ b/editorcomp/.editorconfig
@@ -1,2 +1,3 @@
 [*]
 indent_style = space
+indent_size = 4

--- a/editorcomp/.editorconfig
+++ b/editorcomp/.editorconfig
@@ -1,3 +1,2 @@
 [*]
 indent_style = space
-indent_size = 4

--- a/far2l/.editorconfig
+++ b/far2l/.editorconfig
@@ -1,0 +1,7 @@
+[*.awk]
+indent_style = space
+indent_size = 2
+
+[*.m4]
+indent_style = space
+indent_size = 2

--- a/farftp/.editorconfig
+++ b/farftp/.editorconfig
@@ -1,0 +1,3 @@
+[*.def]
+indent_style = space
+indent_size = 2

--- a/farftp/.editorconfig
+++ b/farftp/.editorconfig
@@ -1,3 +1,7 @@
 [*.def]
 indent_style = space
 indent_size = 2
+
+[*.hlf]
+indent_style = space
+indent_size = 2

--- a/filecase/.editorconfig
+++ b/filecase/.editorconfig
@@ -1,3 +1,6 @@
 [*]
 indent_style = space
 indent_size = 2
+
+[CMakeLists.txt]
+indent_size = 4

--- a/incsrch/.editorconfig
+++ b/incsrch/.editorconfig
@@ -1,2 +1,3 @@
 [*]
 indent_style = space
+indent_size = 4

--- a/incsrch/.editorconfig
+++ b/incsrch/.editorconfig
@@ -1,3 +1,2 @@
 [*]
 indent_style = space
-indent_size = 4

--- a/inside/.editorconfig
+++ b/inside/.editorconfig
@@ -1,2 +1,0 @@
-[*]
-indent_style = space

--- a/multiarc/.editorconfig
+++ b/multiarc/.editorconfig
@@ -9,6 +9,9 @@ indent_size = 4
 indent_style = tab
 indent_size = 4
 
+[src/formats/rar/unrar/makefile]
+indent_style = tab
+
 [CMakeLists.txt]
 indent_style = space
 indent_size = 4

--- a/multiarc/.editorconfig
+++ b/multiarc/.editorconfig
@@ -2,22 +2,10 @@
 indent_style = space
 indent_size = 2
 
-[src/formats/7z/7z.cpp]
-indent_style = tab
-indent_size = 2
-
-[src/formats/custom/custom.cpp]
-indent_style = space
-indent_size = 4
-
 [src/formats/ha/ha/*]
 indent_style = space
 indent_size = 4
 
 [src/formats/libarch/*]
-indent_style = tab
-indent_size = 4
-
-[src/formats/rar/rarmainstub.cpp]
 indent_style = tab
 indent_size = 4

--- a/multiarc/.editorconfig
+++ b/multiarc/.editorconfig
@@ -1,11 +1,14 @@
-[src/**]
+[*]
 indent_style = space
 indent_size = 2
 
 [src/formats/ha/ha/*]
-indent_style = space
 indent_size = 4
 
 [src/formats/libarch/*]
 indent_style = tab
+indent_size = 4
+
+[CMakeLists.txt]
+indent_style = space
 indent_size = 4

--- a/multiarc/src/formats/7z/7z.cpp
+++ b/multiarc/src/formats/7z/7z.cpp
@@ -31,14 +31,14 @@ using namespace oldfar;
 #include "./C/7zCrc.h"
 
 #if defined(__BORLANDC__)
-  #pragma option -a1
+#pragma option -a1
 #elif defined(__GNUC__) || (defined(__WATCOMC__) && (__WATCOMC__ < 1100)) || defined(__LCC__)
-  #pragma pack(1)
+#pragma pack(1)
 #else
-  #pragma pack(push,1)
-  #if _MSC_VER
-    #define _export
-  #endif
+#pragma pack(push,1)
+#if _MSC_VER
+#define _export
+#endif
 #endif
 
 
@@ -53,131 +53,131 @@ static ISzAlloc g_alloc_imp = { SzAlloc, SzFree };
 
 class Traverser
 {
-	CSzArEx _db;
-	CFileInStream _file_stream;
-	CLookToRead2 _look_stream;
-	std::wstring _tmp_str;
-	
-	ISzAlloc _alloc_imp, _alloc_temp_imp;
-	UInt16 *_temp;
-	size_t _temp_size;
-	unsigned int _index;
-	bool _opened, _valid;
-	
+  CSzArEx _db;
+  CFileInStream _file_stream;
+  CLookToRead2 _look_stream;
+  std::wstring _tmp_str;
+
+  ISzAlloc _alloc_imp, _alloc_temp_imp;
+  UInt16 *_temp;
+  size_t _temp_size;
+  unsigned int _index;
+  bool _opened, _valid;
+
 public:
-	Traverser(const char *path) : _temp(nullptr), _temp_size(0), _index(0), _opened(false), _valid(false)
-	{
-		if (InFile_Open(&_file_stream.file, path))
-			return;
-		_opened = true;
-		
-		_alloc_imp.Alloc = SzAlloc;
-		_alloc_imp.Free = SzFree;
-			
-		_alloc_temp_imp.Alloc = SzAllocTemp;
-		_alloc_temp_imp.Free = SzFreeTemp;
+  Traverser(const char *path) : _temp(nullptr), _temp_size(0), _index(0), _opened(false), _valid(false)
+  {
+    if (InFile_Open(&_file_stream.file, path))
+      return;
+    _opened = true;
 
-		FileInStream_CreateVTable(&_file_stream);
-		LookToRead2_CreateVTable(&_look_stream, False);
+    _alloc_imp.Alloc = SzAlloc;
+    _alloc_imp.Free = SzFree;
 
-		const size_t inbuf_len = 0x2000;
-		_look_stream.buf = (Byte *)ISzAlloc_Alloc(&_alloc_imp, inbuf_len);
-		if (!_look_stream.buf)
-			return;
+    _alloc_temp_imp.Alloc = SzAllocTemp;
+    _alloc_temp_imp.Free = SzFreeTemp;
 
-		_look_stream.bufSize = inbuf_len;
-		_look_stream.realStream = &_file_stream.vt;
-		LookToRead2_Init(&_look_stream);
-		
-		static volatile int i = (CrcGenerateTable(), 0);
-		i;
-		
-		SzArEx_Init(&_db);
-			
-		if (SzArEx_Open(&_db, &_look_stream.vt, &_alloc_imp, &_alloc_temp_imp)==SZ_OK) 
-			_valid = true;
-	}
-	
-	~Traverser()
-	{
-		if (_opened) {
-			SzArEx_Free(&_db, &g_alloc_imp);
-			SzFree(NULL, _temp);
-			ISzAlloc_Free(&_alloc_imp, _look_stream.buf);
-			File_Close(&_file_stream.file);
-		}
-	}
-	
-	bool Valid() const
-	{
-		return _valid;
-	}
-	
-	int Next(struct ArcItemInfo *Info)
-	{
-		if (!_valid)
-			return GETARC_READERROR;
-			
-		if (_index >= _db.NumFiles )
-			return GETARC_EOF;
-        
-        unsigned is_dir = SzArEx_IsDir(&_db, _index);
-        size_t len = SzArEx_GetFileNameUtf16(&_db, _index, NULL);
-		if (len > _temp_size)
-		{
-			SzFree(NULL, _temp);
-			_temp_size = len + 16;
-			_temp = (UInt16 *)SzAlloc(NULL, _temp_size * sizeof(_temp[0]));
-			if (!_temp) {
-				_temp_size = 0;
-				return GETARC_READERROR;
-			}
-		}
-		
-        SzArEx_GetFileNameUtf16(&_db, _index, _temp);
-		_tmp_str.clear();
-		_tmp_str.reserve(len);
-		for (size_t i = 0; i < len; ++i) {
-			_tmp_str+= (wchar_t)(uint16_t)_temp[i];
-		}
-		const std::string &name = StrWide2MB(_tmp_str);
-		
-		
-		DWORD attribs = SzBitWithVals_Check(&_db.Attribs, _index) ? _db.Attribs.Vals[_index] : 0;
-		DWORD crc32 = SzBitWithVals_Check(&_db.CRCs, _index) ? _db.CRCs.Vals[_index] : 0;
-		UInt64 file_size = SzArEx_GetFileSize(&_db, _index);
-		UInt64 packed_size = SzArEx_GetFilePackedSize(&_db, _index);
-		
-		FILETIME ftm = {}, ftc = {};
-		if (SzBitWithVals_Check(&_db.MTime, _index)) {
-			memcpy(&ftm, &_db.MTime.Vals[_index], sizeof(ftm));
-		}
-		if (SzBitWithVals_Check(&_db.CTime, _index)) {
-			memcpy(&ftc, &_db.CTime.Vals[_index], sizeof(ftc));
-		}
-		
-		++_index;
-		
-		attribs&=~ (FILE_ATTRIBUTE_BROKEN | FILE_ATTRIBUTE_EXECUTABLE);
-		Info->PathName = name;
-		Info->dwFileAttributes = attribs;
-		Info->dwUnixMode = is_dir ? 0755 : 0644;
-		Info->nFileSize = file_size;
-		Info->nPhysicalSize = packed_size;
-		Info->CRC32 = crc32;
-		
-		Info->ftLastWriteTime = ftm;
-		Info->ftCreationTime = ftc;
-		
+    FileInStream_CreateVTable(&_file_stream);
+    LookToRead2_CreateVTable(&_look_stream, False);
 
-		Info->Solid = 0;
-		Info->Comment = 0;
-		Info->Encrypted = 0;
-		Info->DictSize = 0;
-		Info->UnpVer = 0;		
-		
-		return GETARC_SUCCESS;
-	}
+    const size_t inbuf_len = 0x2000;
+    _look_stream.buf = (Byte *)ISzAlloc_Alloc(&_alloc_imp, inbuf_len);
+    if (!_look_stream.buf)
+      return;
+
+    _look_stream.bufSize = inbuf_len;
+    _look_stream.realStream = &_file_stream.vt;
+    LookToRead2_Init(&_look_stream);
+
+    static volatile int i = (CrcGenerateTable(), 0);
+    i;
+
+    SzArEx_Init(&_db);
+
+    if (SzArEx_Open(&_db, &_look_stream.vt, &_alloc_imp, &_alloc_temp_imp)==SZ_OK)
+      _valid = true;
+  }
+
+  ~Traverser()
+  {
+    if (_opened) {
+      SzArEx_Free(&_db, &g_alloc_imp);
+      SzFree(NULL, _temp);
+      ISzAlloc_Free(&_alloc_imp, _look_stream.buf);
+      File_Close(&_file_stream.file);
+    }
+  }
+
+  bool Valid() const
+  {
+    return _valid;
+  }
+
+  int Next(struct ArcItemInfo *Info)
+  {
+    if (!_valid)
+      return GETARC_READERROR;
+
+    if (_index >= _db.NumFiles )
+      return GETARC_EOF;
+
+    unsigned is_dir = SzArEx_IsDir(&_db, _index);
+    size_t len = SzArEx_GetFileNameUtf16(&_db, _index, NULL);
+    if (len > _temp_size)
+    {
+      SzFree(NULL, _temp);
+      _temp_size = len + 16;
+      _temp = (UInt16 *)SzAlloc(NULL, _temp_size * sizeof(_temp[0]));
+      if (!_temp) {
+        _temp_size = 0;
+        return GETARC_READERROR;
+      }
+    }
+
+    SzArEx_GetFileNameUtf16(&_db, _index, _temp);
+    _tmp_str.clear();
+    _tmp_str.reserve(len);
+    for (size_t i = 0; i < len; ++i) {
+      _tmp_str+= (wchar_t)(uint16_t)_temp[i];
+    }
+    const std::string &name = StrWide2MB(_tmp_str);
+
+
+    DWORD attribs = SzBitWithVals_Check(&_db.Attribs, _index) ? _db.Attribs.Vals[_index] : 0;
+    DWORD crc32 = SzBitWithVals_Check(&_db.CRCs, _index) ? _db.CRCs.Vals[_index] : 0;
+    UInt64 file_size = SzArEx_GetFileSize(&_db, _index);
+    UInt64 packed_size = SzArEx_GetFilePackedSize(&_db, _index);
+
+    FILETIME ftm = {}, ftc = {};
+    if (SzBitWithVals_Check(&_db.MTime, _index)) {
+      memcpy(&ftm, &_db.MTime.Vals[_index], sizeof(ftm));
+    }
+    if (SzBitWithVals_Check(&_db.CTime, _index)) {
+      memcpy(&ftc, &_db.CTime.Vals[_index], sizeof(ftc));
+    }
+
+    ++_index;
+
+    attribs&=~ (FILE_ATTRIBUTE_BROKEN | FILE_ATTRIBUTE_EXECUTABLE);
+    Info->PathName = name;
+    Info->dwFileAttributes = attribs;
+    Info->dwUnixMode = is_dir ? 0755 : 0644;
+    Info->nFileSize = file_size;
+    Info->nPhysicalSize = packed_size;
+    Info->CRC32 = crc32;
+
+    Info->ftLastWriteTime = ftm;
+    Info->ftCreationTime = ftc;
+
+
+    Info->Solid = 0;
+    Info->Comment = 0;
+    Info->Encrypted = 0;
+    Info->DictSize = 0;
+    Info->UnpVer = 0;
+
+    return GETARC_SUCCESS;
+  }
 };
 
 ///////////////////////////////////
@@ -188,46 +188,46 @@ static const unsigned char s_magic_of_7z[] = {'7', 'z', 0xBC, 0xAF, 0x27, 0x1C, 
 
 BOOL WINAPI _export SEVENZ_IsArchive(const char *Name,const unsigned char *Data,int DataSize)
 {
-	if (DataSize < (int)sizeof(s_magic_of_7z) || memcmp(Data, s_magic_of_7z, sizeof(s_magic_of_7z))!=0) {
-		return FALSE;
-	}
+  if (DataSize < (int)sizeof(s_magic_of_7z) || memcmp(Data, s_magic_of_7z, sizeof(s_magic_of_7z))!=0) {
+    return FALSE;
+  }
 
-	return TRUE;
+  return TRUE;
 }
 
 
 BOOL WINAPI _export SEVENZ_OpenArchive(const char *Name,int *Type,bool Silent)
 {
-	Traverser *t = new Traverser(Name);
-	if (!t->Valid()) {
-		delete t;
-		return FALSE;
-	}
-	
-	delete s_selected_traverser;
-	s_selected_traverser = t;
-	return TRUE;
+  Traverser *t = new Traverser(Name);
+  if (!t->Valid()) {
+    delete t;
+    return FALSE;
+  }
+
+  delete s_selected_traverser;
+  s_selected_traverser = t;
+  return TRUE;
 }
 
 
 
 int WINAPI _export SEVENZ_GetArcItem(struct ArcItemInfo *Info)
 {
-	if (!s_selected_traverser)
-		return GETARC_READERROR;
-		
-	return s_selected_traverser->Next(Info);
+  if (!s_selected_traverser)
+    return GETARC_READERROR;
+
+  return s_selected_traverser->Next(Info);
 }
 
 
 BOOL WINAPI _export SEVENZ_CloseArchive(struct ArcInfo *Info)
 {
-	if (!s_selected_traverser)
-		return FALSE;
-		
-	delete s_selected_traverser;
-	s_selected_traverser = NULL;
-	return TRUE;
+  if (!s_selected_traverser)
+    return FALSE;
+
+  delete s_selected_traverser;
+  s_selected_traverser = NULL;
+  return TRUE;
 }
 
 
@@ -249,22 +249,22 @@ BOOL WINAPI _export SEVENZ_GetDefaultCommands(int Type,int Command,char *Dest)
 {
   if (Type==0)
   {
-    static const char *Commands[]={
-    /*Extract               */"^7z x %%A %%FMq*4096",
-    /*Extract without paths */"^7z e %%A %%FMq*4096",
-    /*Test                  */"^7z t %%A",
-    /*Delete                */"7z d {-p%%P} %%A @%%LN",
-    /*Comment archive       */"",
-    /*Comment files         */"",
-    /*Convert to SFX        */"",
-    /*Lock archive          */"",
-    /*Protect archive       */"",
-    /*Recover archive       */"",
-    /*Add files             */"7z a -y {-p%%P} %%A @%%LN",
-    /*Move files            */"7z a -y -sdel {-p%%P} %%A @%%LN",
-    /*Add files and folders */"7z a -y -r {-p%%P} %%A @%%LN",
-    /*Move files and folders*/"7z a -y -r -sdel {-p%%P} %%A @%%LN",
-    /*"All files" mask      */"*"
+    static const char *Commands[]= {
+      /*Extract               */"^7z x %%A %%FMq*4096",
+      /*Extract without paths */"^7z e %%A %%FMq*4096",
+      /*Test                  */"^7z t %%A",
+      /*Delete                */"7z d {-p%%P} %%A @%%LN",
+      /*Comment archive       */"",
+      /*Comment files         */"",
+      /*Convert to SFX        */"",
+      /*Lock archive          */"",
+      /*Protect archive       */"",
+      /*Recover archive       */"",
+      /*Add files             */"7z a -y {-p%%P} %%A @%%LN",
+      /*Move files            */"7z a -y -sdel {-p%%P} %%A @%%LN",
+      /*Add files and folders */"7z a -y -r {-p%%P} %%A @%%LN",
+      /*Move files and folders*/"7z a -y -r -sdel {-p%%P} %%A @%%LN",
+      /*"All files" mask      */"*"
     };
     if (Command<(int)(ARRAYSIZE(Commands)))
     {

--- a/multiarc/src/formats/custom/custom.cpp
+++ b/multiarc/src/formats/custom/custom.cpp
@@ -28,14 +28,14 @@ using namespace oldfar;
 using namespace PCRE;
 
 #if defined(__BORLANDC__)
-    #pragma option -a1
+#pragma option -a1
 #elif defined(__GNUC__) || (defined(__WATCOMC__) && (__WATCOMC__ < 1100)) || defined(__LCC__)
-    #pragma pack(1)
+#pragma pack(1)
 #else
-    #pragma pack(push,1)
-    #if _MSC_VER
-        #define _export
-    #endif
+#pragma pack(push,1)
+#if _MSC_VER
+#define _export
+#endif
 #endif
 
 
@@ -69,11 +69,11 @@ static void MakeFiletime(SYSTEMTIME st, SYSTEMTIME syst, LPFILETIME pft);
 static int StringToInt(const char *str);
 static int64_t StringToInt64(const char *str);
 static void ParseListingItemRegExp(Match match,
-     struct ArcItemInfo *Info,
-    SYSTEMTIME &stModification, SYSTEMTIME &stCreation, SYSTEMTIME &stAccess);
+                                   struct ArcItemInfo *Info,
+                                   SYSTEMTIME &stModification, SYSTEMTIME &stCreation, SYSTEMTIME &stAccess);
 static void ParseListingItemPlain(const char *CurFormat, const char *CurStr,
-     struct ArcItemInfo *Info,
-    SYSTEMTIME &stModification, SYSTEMTIME &stCreation, SYSTEMTIME &stAccess);
+                                  struct ArcItemInfo *Info,
+                                  SYSTEMTIME &stModification, SYSTEMTIME &stCreation, SYSTEMTIME &stAccess);
 
 ///////////////////////////////////////////////////////////////////////////////
 // Constants
@@ -87,47 +87,47 @@ enum { PROF_STR_LEN = 256 };
 class CustomStringList
 {
 public:
-    CustomStringList()
-        :   pNext(0)
-    {
-        str[0] = '\0';
-    }
+  CustomStringList()
+    :   pNext(0)
+  {
+    str[0] = '\0';
+  }
 
-    ~CustomStringList()
-    {
-        if (pNext)
-            delete pNext;
-    }
+  ~CustomStringList()
+  {
+    if (pNext)
+      delete pNext;
+  }
 
-    CustomStringList *Add()
-    {
-        if (pNext)
-            delete pNext;
-        pNext = new CustomStringList;
-        return pNext;
-    }
+  CustomStringList *Add()
+  {
+    if (pNext)
+      delete pNext;
+    pNext = new CustomStringList;
+    return pNext;
+  }
 
-    CustomStringList *Next()
-    {
-        return pNext;
-    }
+  CustomStringList *Next()
+  {
+    return pNext;
+  }
 
-    char *Str()
-    {
-        return str;
-    }
+  char *Str()
+  {
+    return str;
+  }
 
-    void Empty()
-    {
-        if (pNext)
-            delete pNext;
-        pNext = 0;
-        str[0] = '\0';
-    }
+  void Empty()
+  {
+    if (pNext)
+      delete pNext;
+    pNext = 0;
+    str[0] = '\0';
+  }
 
 protected:
-    char str[PROF_STR_LEN];
-    CustomStringList *pNext;
+  char str[PROF_STR_LEN];
+  CustomStringList *pNext;
 };
 
 
@@ -136,162 +136,162 @@ protected:
 
 class MetaReplacer
 {
-    std::string m_command;
-    std::string m_fileName;
+  std::string m_command;
+  std::string m_fileName;
 
-    class Meta
+  class Meta
+  {
+  public:
+    enum Type
     {
-    public:
-        enum Type
-        {
-            invalidType = -1,
-            archiveName,
-            shortArchiveName
-        };
-
-        enum Flags
-        {
-            quoteWithSpaces = 1,
-            quoteAll = 2,
-            useForwardSlashes = 4,
-            useNameOnly = 8,
-            usePathOnly = 16,
-            useANSI = 32
-        };
-
-    private:
-        bool m_isValid;
-        Type m_type;
-        unsigned int m_flags;
-        int m_length;
-
-    public:
-        Meta(const char *start)
-            :   m_isValid(false), m_type(invalidType), m_flags(0), m_length(0)
-        {
-            if((start[0] != '%') || (start[1] != '%'))
-                return;
-
-            char typeChars[] = { 'A', 'a' };
-            char flagChars[] = { 'Q', 'q', 'S', 'W', 'P', 'A' };
-
-            for(size_t i = 0; i < sizeof(typeChars); ++i)
-                if(start[2] == typeChars[i])
-                    m_type = (Type) i;
-
-            if(m_type == invalidType)
-                return;
-
-            const char *p = start + 3;
-
-            for(; *p; ++p)
-            {
-                bool isFlagChar = false;
-                for(size_t i = 0; i < sizeof(flagChars); ++i)
-                    if(*p == flagChars[i])
-                    {
-                        m_flags |= 1 << i;
-                        isFlagChar = true;
-                    }
-
-                if(!isFlagChar)
-                    break;
-            }
-
-            m_length = (int)(p - start);
-
-            m_isValid = true;
-
-        }
-
-        bool isValidMeta() const
-        {
-            return m_isValid;
-        }
-
-        Type getType() const
-        {
-            return m_type;
-        }
-
-        unsigned int getFlags() const
-        {
-            return m_flags;
-        }
-
-        int getLength() const
-        {
-            return m_length;
-        }
+      invalidType = -1,
+      archiveName,
+      shortArchiveName
     };
 
+    enum Flags
+    {
+      quoteWithSpaces = 1,
+      quoteAll = 2,
+      useForwardSlashes = 4,
+      useNameOnly = 8,
+      usePathOnly = 16,
+      useANSI = 32
+    };
+
+  private:
+    bool m_isValid;
+    Type m_type;
+    unsigned int m_flags;
+    int m_length;
 
   public:
-    MetaReplacer(const std::string &command, const char *arcName)
-        :   m_command(command), m_fileName(arcName)
+    Meta(const char *start)
+      :   m_isValid(false), m_type(invalidType), m_flags(0), m_length(0)
     {
+      if((start[0] != '%') || (start[1] != '%'))
+        return;
+
+      char typeChars[] = { 'A', 'a' };
+      char flagChars[] = { 'Q', 'q', 'S', 'W', 'P', 'A' };
+
+      for(size_t i = 0; i < sizeof(typeChars); ++i)
+        if(start[2] == typeChars[i])
+          m_type = (Type) i;
+
+      if(m_type == invalidType)
+        return;
+
+      const char *p = start + 3;
+
+      for(; *p; ++p)
+      {
+        bool isFlagChar = false;
+        for(size_t i = 0; i < sizeof(flagChars); ++i)
+          if(*p == flagChars[i])
+          {
+            m_flags |= 1 << i;
+            isFlagChar = true;
+          }
+
+        if(!isFlagChar)
+          break;
+      }
+
+      m_length = (int)(p - start);
+
+      m_isValid = true;
+
     }
 
-    virtual ~MetaReplacer()
+    bool isValidMeta() const
     {
+      return m_isValid;
     }
 
-    void replaceTo(std::string &out)
+    Type getType() const
     {
-        out.clear();
-        bool bReplacedSomething = false;
-        std::string var;
-
-        for(const char *command = m_command.c_str(); *command;)
-        {
-            Meta m(command);
-
-            if(!m.isValidMeta())
-            {
-                out+= *command++;
-                continue;
-            }
-
-            command+= m.getLength();
-            bReplacedSomething = true;
-
-            size_t lastSlash = m_fileName.rfind('/');
-            if(lastSlash != std::string::npos && (m.getFlags() & Meta::useNameOnly) != 0)
-            {
-                var.assign(m_fileName.c_str() + lastSlash + 1);
-            }
-            else if(lastSlash != std::string::npos && (m.getFlags() & Meta::usePathOnly) != 0)
-            {
-                var.assign(m_fileName.c_str(), lastSlash);
-            }
-            else
-            {
-                var.assign(m_fileName);
-            }
-
-            bool bQuote = (m.getFlags() & Meta::quoteAll)
-                || ((m.getFlags() & Meta::quoteWithSpaces) && var.find(' ') != std::string::npos);
-
-            if(bQuote)
-                out+= '\"';
-
-            out+= var;
-
-            if(bQuote)
-                out+= '\"';
-
-            if(m.getFlags() & Meta::useForwardSlashes)
-            {
-            }
-        }
-
-        if(!bReplacedSomething) // there were no meta-symbols, should use old-style method
-        {
-            out+= ' ';
-            out+= m_fileName;
-        }
-
+      return m_type;
     }
+
+    unsigned int getFlags() const
+    {
+      return m_flags;
+    }
+
+    int getLength() const
+    {
+      return m_length;
+    }
+  };
+
+
+public:
+  MetaReplacer(const std::string &command, const char *arcName)
+    :   m_command(command), m_fileName(arcName)
+  {
+  }
+
+  virtual ~MetaReplacer()
+  {
+  }
+
+  void replaceTo(std::string &out)
+  {
+    out.clear();
+    bool bReplacedSomething = false;
+    std::string var;
+
+    for(const char *command = m_command.c_str(); *command;)
+    {
+      Meta m(command);
+
+      if(!m.isValidMeta())
+      {
+        out+= *command++;
+        continue;
+      }
+
+      command+= m.getLength();
+      bReplacedSomething = true;
+
+      size_t lastSlash = m_fileName.rfind('/');
+      if(lastSlash != std::string::npos && (m.getFlags() & Meta::useNameOnly) != 0)
+      {
+        var.assign(m_fileName.c_str() + lastSlash + 1);
+      }
+      else if(lastSlash != std::string::npos && (m.getFlags() & Meta::usePathOnly) != 0)
+      {
+        var.assign(m_fileName.c_str(), lastSlash);
+      }
+      else
+      {
+        var.assign(m_fileName);
+      }
+
+      bool bQuote = (m.getFlags() & Meta::quoteAll)
+                    || ((m.getFlags() & Meta::quoteWithSpaces) && var.find(' ') != std::string::npos);
+
+      if(bQuote)
+        out+= '\"';
+
+      out+= var;
+
+      if(bQuote)
+        out+= '\"';
+
+      if(m.getFlags() & Meta::useForwardSlashes)
+      {
+      }
+    }
+
+    if(!bReplacedSomething) // there were no meta-symbols, should use old-style method
+    {
+      out+= ' ';
+      out+= m_fileName;
+    }
+
+  }
 };
 
 
@@ -328,398 +328,398 @@ static INT_PTR             FarModuleNumber = 0;
 
 void WINAPI _export CUSTOM_SetFarInfo(const struct PluginStartupInfo *Info)
 {
-	MkTemp = Info->FSF->MkTemp;
-	FarMessage = Info->Message;
-	FarModuleNumber = Info->ModuleNumber;
+  MkTemp = Info->FSF->MkTemp;
+  FarMessage = Info->Message;
+  FarModuleNumber = Info->ModuleNumber;
 }
 
 DWORD WINAPI _export CUSTOM_LoadFormatModule(const char *ModuleName)
 {
-	std::string s = ModuleName;
-	size_t p = s.rfind(GOOD_SLASH);
-	if (p != std::string::npos) {
-		s.resize(p + 1);
-		s+= "custom.ini";
-		FormatFileNameKFH.emplace_back(std::make_pair(s, nullptr));
+  std::string s = ModuleName;
+  size_t p = s.rfind(GOOD_SLASH);
+  if (p != std::string::npos) {
+    s.resize(p + 1);
+    s+= "custom.ini";
+    FormatFileNameKFH.emplace_back(std::make_pair(s, nullptr));
 
-		if (TranslateInstallPath_Lib2Share(s)) {
-			FormatFileNameKFH.emplace_back(std::make_pair(s, nullptr));
-		}
-	}
+    if (TranslateInstallPath_Lib2Share(s)) {
+      FormatFileNameKFH.emplace_back(std::make_pair(s, nullptr));
+    }
+  }
 
-	FormatFileNameKFH.emplace_back(
-		std::make_pair(InMyConfig("plugins/multiarc/custom.ini", false), nullptr));
+  FormatFileNameKFH.emplace_back(
+    std::make_pair(InMyConfig("plugins/multiarc/custom.ini", false), nullptr));
 
-	CheckIniFiles();
-	return (0);
+  CheckIniFiles();
+  return (0);
 }
 
 
 static bool CheckID(const std::vector<unsigned char> &ID, int IDPos, const unsigned char *Data, int DataSize)
 {
-	if (IDPos >= 0)
-		return (IDPos <= DataSize - (int)ID.size()) && (memcmp(Data + IDPos, &ID[0], (int)ID.size()) == 0);
+  if (IDPos >= 0)
+    return (IDPos <= DataSize - (int)ID.size()) && (memcmp(Data + IDPos, &ID[0], (int)ID.size()) == 0);
 
-	for (int I = 0; I <= DataSize - (int)ID.size(); I++)
-	{
-		if (memcmp(Data + I, &ID[0], ID.size()) == 0)
-			return true;
-	}
+  for (int I = 0; I <= DataSize - (int)ID.size(); I++)
+  {
+    if (memcmp(Data + I, &ID[0], ID.size()) == 0)
+      return true;
+  }
 
-	return false;
+  return false;
 }
 
 BOOL WINAPI _export CUSTOM_IsArchive(const char *FName, const unsigned char *Data, int DataSize)
 {
-	if (!CheckIniFiles())
-		return FALSE;
+  if (!CheckIniFiles())
+    return FALSE;
 
-    char *Dot = strrchr((char *) FName, '.');
+  char *Dot = strrchr((char *) FName, '.');
 
-	std::string TypeName, Name, Ext;
-	char IDName[32];
-	std::vector<unsigned char> ID;
+  std::string TypeName, Name, Ext;
+  char IDName[32];
+  std::vector<unsigned char> ID;
 
-    for (int I = 0;; I++)
+  for (int I = 0;; I++)
+  {
+    const KeyFileValues *Values = GetSection(I, TypeName);
+    if (!Values)
+      break;
+
+    Name = Values->GetString(Str_TypeName, TypeName.c_str());
+
+    if (Name.empty())
+      continue;
+
+    bool SpecifiedID = false, FoundID = false;
+    for (unsigned int J = 0; J != (unsigned int)-1; ++J)
     {
-		const KeyFileValues *Values = GetSection(I, TypeName);
-		if (!Values)
-			break;
+      if (J != 0)
+        sprintf(IDName, "ID%u", J);
+      else
+        strcpy(IDName, "ID");
 
-		Name = Values->GetString(Str_TypeName, TypeName.c_str());
+      if (!Values->GetBytes(ID, IDName) || ID.empty()) {
+        break;
+      }
+      SpecifiedID = true;
 
-        if (Name.empty())
-            continue;
+      strcat(IDName, "Pos");
+      int IDPos = Values->GetInt(IDName, -1);
 
-		bool SpecifiedID = false, FoundID = false;
-		for (unsigned int J = 0; J != (unsigned int)-1; ++J)
-		{
-			if (J != 0)
-				sprintf(IDName, "ID%u", J);
-			else
-				strcpy(IDName, "ID");
-
-	        if (!Values->GetBytes(ID, IDName) || ID.empty()) {
-				break;
-			}
-			SpecifiedID = true;
-
-			strcat(IDName, "Pos");
-			int IDPos = Values->GetInt(IDName, -1);
-
-			FoundID = CheckID(ID, IDPos, Data, DataSize);
-			if (FoundID)
-				break;
-		}
-
-		if (SpecifiedID)
-		{
-			if (!FoundID)
-				continue;
-
-			if (Values->GetInt("IDOnly", 0))
-			{
-				CurTypeIndex = I;
-				return (TRUE);
-			}
-		}
-
-		Ext = Values->GetString("Extension", "");
-
-        if(Dot != NULL && !Ext.empty() && strcasecmp(Dot + 1, Ext.c_str()) == 0)
-        {
-            CurTypeIndex = I;
-            return (TRUE);
-        }
+      FoundID = CheckID(ID, IDPos, Data, DataSize);
+      if (FoundID)
+        break;
     }
-    return (FALSE);
+
+    if (SpecifiedID)
+    {
+      if (!FoundID)
+        continue;
+
+      if (Values->GetInt("IDOnly", 0))
+      {
+        CurTypeIndex = I;
+        return (TRUE);
+      }
+    }
+
+    Ext = Values->GetString("Extension", "");
+
+    if(Dot != NULL && !Ext.empty() && strcasecmp(Dot + 1, Ext.c_str()) == 0)
+    {
+      CurTypeIndex = I;
+      return (TRUE);
+    }
+  }
+  return (FALSE);
 }
 
 DWORD WINAPI _export CUSTOM_GetSFXPos(void)
 {
-    return 0;
+  return 0;
 }
 
 
 BOOL WINAPI _export CUSTOM_OpenArchive(const char *Name, int *Type, bool Silent)
 {
-    std::string TypeName;
-	const KeyFileValues *Values = GetSection(CurTypeIndex, TypeName);
-    if (!Values)
-        return (FALSE);
+  std::string TypeName;
+  const KeyFileValues *Values = GetSection(CurTypeIndex, TypeName);
+  if (!Values)
+    return (FALSE);
 
-    std::string Command = Values->GetString("List", "");
+  std::string Command = Values->GetString("List", "");
 
-    if (Command.empty())
-        return (FALSE);
+  if (Command.empty())
+    return (FALSE);
 
-    IgnoreErrors = Values->GetInt("IgnoreErrors", 0);
-    *Type = CurTypeIndex;
+  IgnoreErrors = Values->GetInt("IgnoreErrors", 0);
+  *Type = CurTypeIndex;
 
-    ArcChapters = -1;
+  ArcChapters = -1;
 
-    MetaReplacer meta(Command, Name);
+  MetaReplacer meta(Command, Name);
 
-    meta.replaceTo(Command);
+  meta.replaceTo(Command);
 
-    char TempName[NM];
-    if(MkTemp(TempName, "FAR") == NULL)
-        return (FALSE);
-    sdc_remove(TempName);
-		
+  char TempName[NM];
+  if(MkTemp(TempName, "FAR") == NULL)
+    return (FALSE);
+  sdc_remove(TempName);
+
 
 
 //    HANDLE OutHandle = WINPORT(CreateFile)(MB2Wide(TempName).c_str(), GENERIC_READ | GENERIC_WRITE,
   //                                FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, CREATE_ALWAYS,
-    //                              FILE_ATTRIBUTE_TEMPORARY | FILE_FLAG_DELETE_ON_CLOSE, NULL);
+  //                              FILE_ATTRIBUTE_TEMPORARY | FILE_FLAG_DELETE_ON_CLOSE, NULL);
 
-    DWORD ConsoleMode;
+  DWORD ConsoleMode;
 
-    WINPORT(GetConsoleMode)(NULL, &ConsoleMode);
-    WINPORT(SetConsoleMode)(NULL, ENABLE_PROCESSED_INPUT | ENABLE_LINE_INPUT |
-                   ENABLE_ECHO_INPUT | ENABLE_MOUSE_INPUT);
-    WCHAR SaveTitle[512]{};
+  WINPORT(GetConsoleMode)(NULL, &ConsoleMode);
+  WINPORT(SetConsoleMode)(NULL, ENABLE_PROCESSED_INPUT | ENABLE_LINE_INPUT |
+                          ENABLE_ECHO_INPUT | ENABLE_MOUSE_INPUT);
+  WCHAR SaveTitle[512] {};
 
-    WINPORT(GetConsoleTitle)(SaveTitle, ARRAYSIZE(SaveTitle) - 1);
-    WINPORT(SetConsoleTitle)(StrMB2Wide(Command).c_str());
+  WINPORT(GetConsoleTitle)(SaveTitle, ARRAYSIZE(SaveTitle) - 1);
+  WINPORT(SetConsoleTitle)(StrMB2Wide(Command).c_str());
 
-    //char ExpandedCmd[512];
+  //char ExpandedCmd[512];
 
-    //WINPORT(Environment::ExpandString)(Command, ExpandedCmd, sizeof(ExpandedCmd));
-    std::string cmd = Command;
-    cmd+= "  >"; //2>/dev/null
-    cmd+= TempName;
-    DWORD ExitCode = system(cmd.c_str());
-	if (ExitCode && !CurSilent)
-	{
-		const auto &ToolNotFoundMsg = Values->GetString("ToolNotFound", "");
-		if (!ToolNotFoundMsg.empty())
-		{
-			size_t trim_pos = cmd.find_first_of("|>");
-			if (trim_pos != std::string::npos) {
-				cmd.resize(trim_pos);
-			}
-			cmd.insert(0, "command -v ");
-			if (system(cmd.c_str()) != 0)
-			{
-				std::string title = "MultiArc: ";
-				title+= TypeName;
-				const char *MsgItems[] = { title.c_str(), ToolNotFoundMsg.c_str() };
-				FarMessage(FarModuleNumber, FMSG_WARNING | FMSG_MB_OK, NULL, MsgItems, ARRAYSIZE(MsgItems), 0);
-			}
-		}
-	}
-
-
-    if(ExitCode)
+  //WINPORT(Environment::ExpandString)(Command, ExpandedCmd, sizeof(ExpandedCmd));
+  std::string cmd = Command;
+  cmd+= "  >"; //2>/dev/null
+  cmd+= TempName;
+  DWORD ExitCode = system(cmd.c_str());
+  if (ExitCode && !CurSilent)
+  {
+    const auto &ToolNotFoundMsg = Values->GetString("ToolNotFound", "");
+    if (!ToolNotFoundMsg.empty())
     {
-        ExitCode = (ExitCode < Values->GetUInt("Errorlevel", 1000));
-    } else {
-        ExitCode = 1;
+      size_t trim_pos = cmd.find_first_of("|>");
+      if (trim_pos != std::string::npos) {
+        cmd.resize(trim_pos);
+      }
+      cmd.insert(0, "command -v ");
+      if (system(cmd.c_str()) != 0)
+      {
+        std::string title = "MultiArc: ";
+        title+= TypeName;
+        const char *MsgItems[] = { title.c_str(), ToolNotFoundMsg.c_str() };
+        FarMessage(FarModuleNumber, FMSG_WARNING | FMSG_MB_OK, NULL, MsgItems, ARRAYSIZE(MsgItems), 0);
+      }
+    }
+  }
+
+
+  if(ExitCode)
+  {
+    ExitCode = (ExitCode < Values->GetUInt("Errorlevel", 1000));
+  } else {
+    ExitCode = 1;
+  }
+
+  if(ExitCode)
+  {
+    OutData = NULL;
+    int fd = sdc_open(TempName, O_RDONLY);
+    if (fd!=-1) {
+      OutDataSize = OutDataPos = 0;
+      struct stat s = {0};
+      sdc_fstat(fd, &s);
+      if (s.st_size > 0) {
+        OutData = (char *) calloc(s.st_size + 1, 1);
+        if (OutData) {
+          for (OutDataSize = 0; OutDataSize < s.st_size;) {
+            int piece = (s.st_size - OutDataSize < 0x10000) ? s.st_size - OutDataSize : 0x10000;
+            int r = sdc_read(fd, OutData + OutDataSize, piece);
+            if (r<=0) break;
+            OutDataSize+= r;
+          }
+        }
+      }
+      sdc_close(fd);
     }
 
-    if(ExitCode)
-    {
-        OutData = NULL;
-		int fd = sdc_open(TempName, O_RDONLY);
-		if (fd!=-1) {
-			OutDataSize = OutDataPos = 0;
-			struct stat s = {0};
-			sdc_fstat(fd, &s);
-			if (s.st_size > 0) {
-				OutData = (char *) calloc(s.st_size + 1, 1);
-				if (OutData) {
-					for (OutDataSize = 0; OutDataSize < s.st_size;) {
-						int piece = (s.st_size - OutDataSize < 0x10000) ? s.st_size - OutDataSize : 0x10000;
-						int r = sdc_read(fd, OutData + OutDataSize, piece);
-						if (r<=0) break;
-						OutDataSize+= r;
-					}
-				}
-			}
-			sdc_close(fd);
-		}
-		
-        if(OutData == NULL)
-            ExitCode = 0;
-    }
+    if(OutData == NULL)
+      ExitCode = 0;
+  }
 //	fprintf(stderr, "OutData: '%s'\n", OutData);
 
-    WINPORT(SetConsoleTitle)(SaveTitle);
-    WINPORT(SetConsoleMode)(NULL, ConsoleMode);
+  WINPORT(SetConsoleTitle)(SaveTitle);
+  WINPORT(SetConsoleMode)(NULL, ConsoleMode);
 
-	sdc_remove(TempName);
-    FillFormat(Values);
+  sdc_remove(TempName);
+  FillFormat(Values);
 
-    if(ExitCode && OutDataSize == 0)
-    {
-        free(OutData);
-		OutData = nullptr;
-    }
+  if(ExitCode && OutDataSize == 0)
+  {
+    free(OutData);
+    OutData = nullptr;
+  }
 
-	CurSilent = Silent;
-	
-    return (ExitCode);
+  CurSilent = Silent;
+
+  return (ExitCode);
 }
 
 
 int WINAPI _export CUSTOM_GetArcItem( struct ArcItemInfo *Info)
 {
-    char Str[512];
-    CustomStringList *CurFormatNode = Format;
-    SYSTEMTIME stModification, stCreation, stAccess, syst;
+  char Str[512];
+  CustomStringList *CurFormatNode = Format;
+  SYSTEMTIME stModification, stCreation, stAccess, syst;
 
-    ZeroFill(stModification);
-    ZeroFill(stCreation);
-    ZeroFill(stAccess);
-    WINPORT(GetSystemTime)(&syst);
+  ZeroFill(stModification);
+  ZeroFill(stCreation);
+  ZeroFill(stAccess);
+  WINPORT(GetSystemTime)(&syst);
 
-    while(GetString(Str, sizeof(Str)))
+  while(GetString(Str, sizeof(Str)))
+  {
+    RegExp re;
+
+    if(!StartText.empty())
     {
-        RegExp re;
-
-        if(!StartText.empty())
+      if(re.compile(StartText.c_str()))
+      {
+        if(re.match(Str))
+          StartText.clear();
+      }
+      else
+      {
+        if((StartText[0] == '^' && strncmp(Str, StartText.c_str() + 1, StartText.size() - 1) == 0) ||
+            (StartText[0] != '^' && strstr(Str, StartText.c_str()) != NULL))
         {
-            if(re.compile(StartText.c_str()))
-            {
-                if(re.match(Str))
-                    StartText.clear();
-            }
-            else
-            {
-                if((StartText[0] == '^' && strncmp(Str, StartText.c_str() + 1, StartText.size() - 1) == 0) ||
-                   (StartText[0] != '^' && strstr(Str, StartText.c_str()) != NULL))
-                {
-                    StartText.clear();
-                }
-            }
-            continue;
+          StartText.clear();
         }
-
-        if(!EndText.empty())
-        {
-            if(re.compile(EndText.c_str()))
-            {
-                if(re.match(Str))
-                    break;
-            }
-            else if(EndText[0] == '^')
-            {
-                if(strncmp(Str, EndText.c_str() + 1, EndText.size() - 1) == 0)
-                    break;
-            }
-            else if(strstr(Str, EndText.c_str()) != NULL)
-                break;
-
-        }
-
-        bool bFoundIgnoreString = false;
-        for(CustomStringList * CurIgnoreString = IgnoreStrings; CurIgnoreString->Next(); CurIgnoreString = CurIgnoreString->Next())
-        {
-            if(re.compile(CurIgnoreString->Str()))
-            {
-                if(re.match(Str))
-                    bFoundIgnoreString = true;
-            }
-            else if(*CurIgnoreString->Str() == '^')
-            {
-                if(strncmp(Str, CurIgnoreString->Str() + 1, strlen(CurIgnoreString->Str() + 1)) == 0)
-                    bFoundIgnoreString = true;
-            }
-            else if(strstr(Str, CurIgnoreString->Str()) != NULL)
-                bFoundIgnoreString = true;
-        }
-
-        if(bFoundIgnoreString)
-            continue;
-
-        if(re.compile(CurFormatNode->Str()))
-        {
-            if(Match match = re.match(Str))
-                ParseListingItemRegExp(match, Info, stModification, stCreation, stAccess);
-        }
-        else
-            ParseListingItemPlain(CurFormatNode->Str(), Str, Info, stModification, stCreation, stAccess);
-
-        CurFormatNode = CurFormatNode->Next();
-        if(!CurFormatNode || !CurFormatNode->Next())
-        {
-            MakeFiletime(stModification, syst, &Info->ftLastWriteTime);
-            MakeFiletime(stCreation, syst, &Info->ftCreationTime);
-            MakeFiletime(stAccess, syst, &Info->ftLastAccessTime);
-            while (!Info->PathName.empty() && isspace(Info->PathName.back()))
-				Info->PathName.pop_back();
-
-            return (GETARC_SUCCESS);
-        }
+      }
+      continue;
     }
 
-    return (GETARC_EOF);
+    if(!EndText.empty())
+    {
+      if(re.compile(EndText.c_str()))
+      {
+        if(re.match(Str))
+          break;
+      }
+      else if(EndText[0] == '^')
+      {
+        if(strncmp(Str, EndText.c_str() + 1, EndText.size() - 1) == 0)
+          break;
+      }
+      else if(strstr(Str, EndText.c_str()) != NULL)
+        break;
+
+    }
+
+    bool bFoundIgnoreString = false;
+    for(CustomStringList * CurIgnoreString = IgnoreStrings; CurIgnoreString->Next(); CurIgnoreString = CurIgnoreString->Next())
+    {
+      if(re.compile(CurIgnoreString->Str()))
+      {
+        if(re.match(Str))
+          bFoundIgnoreString = true;
+      }
+      else if(*CurIgnoreString->Str() == '^')
+      {
+        if(strncmp(Str, CurIgnoreString->Str() + 1, strlen(CurIgnoreString->Str() + 1)) == 0)
+          bFoundIgnoreString = true;
+      }
+      else if(strstr(Str, CurIgnoreString->Str()) != NULL)
+        bFoundIgnoreString = true;
+    }
+
+    if(bFoundIgnoreString)
+      continue;
+
+    if(re.compile(CurFormatNode->Str()))
+    {
+      if(Match match = re.match(Str))
+        ParseListingItemRegExp(match, Info, stModification, stCreation, stAccess);
+    }
+    else
+      ParseListingItemPlain(CurFormatNode->Str(), Str, Info, stModification, stCreation, stAccess);
+
+    CurFormatNode = CurFormatNode->Next();
+    if(!CurFormatNode || !CurFormatNode->Next())
+    {
+      MakeFiletime(stModification, syst, &Info->ftLastWriteTime);
+      MakeFiletime(stCreation, syst, &Info->ftCreationTime);
+      MakeFiletime(stAccess, syst, &Info->ftLastAccessTime);
+      while (!Info->PathName.empty() && isspace(Info->PathName.back()))
+        Info->PathName.pop_back();
+
+      return (GETARC_SUCCESS);
+    }
+  }
+
+  return (GETARC_EOF);
 }
 
 
 BOOL WINAPI _export CUSTOM_CloseArchive(struct ArcInfo * Info)
 {
-    if(IgnoreErrors)
-        Info->Flags |= AF_IGNOREERRORS;
+  if(IgnoreErrors)
+    Info->Flags |= AF_IGNOREERRORS;
 
-    if(ArcChapters < 0)
-        ArcChapters = 0;
-    Info->Chapters = ArcChapters;
+  if(ArcChapters < 0)
+    ArcChapters = 0;
+  Info->Chapters = ArcChapters;
 
-    free(OutData);
-	OutData = nullptr;
+  free(OutData);
+  OutData = nullptr;
 
-    delete Format;
-    delete IgnoreStrings;
-    Format = 0;
-    IgnoreStrings = 0;
-	CurTypeIndex = -1;
+  delete Format;
+  delete IgnoreStrings;
+  Format = 0;
+  IgnoreStrings = 0;
+  CurTypeIndex = -1;
 
-    return (TRUE);
+  return (TRUE);
 }
 
 
 BOOL WINAPI _export CUSTOM_GetFormatName(int Type, char *FormatName, char *DefaultExt)
 {
-    std::string TypeName;
-    const KeyFileValues *Values = GetSection(Type, TypeName);
+  std::string TypeName;
+  const KeyFileValues *Values = GetSection(Type, TypeName);
 
-    if(!Values)
-        return (FALSE);
+  if(!Values)
+    return (FALSE);
 
-    Values->GetChars(FormatName, 64, Str_TypeName, TypeName.c_str());
-    Values->GetChars(DefaultExt, NM, "Extension", "");
-    return (*FormatName != 0);
+  Values->GetChars(FormatName, 64, Str_TypeName, TypeName.c_str());
+  Values->GetChars(DefaultExt, NM, "Extension", "");
+  return (*FormatName != 0);
 }
 
 
 BOOL WINAPI _export CUSTOM_GetDefaultCommands(int Type, int Command, char *Dest)
 {
-	std::string TypeName, FormatName;
+  std::string TypeName, FormatName;
 
-	const KeyFileValues *Values = GetSection(Type, TypeName);
+  const KeyFileValues *Values = GetSection(Type, TypeName);
 
-    if (!Values)
-        return (FALSE);
-
-    FormatName = Values->GetString(Str_TypeName, TypeName.c_str());
-
-    if (FormatName.empty())
-        return (FALSE);
-
-    static const char *CmdNames[] = { "Extract", "ExtractWithoutPath", "Test", "Delete",
-        "Comment", "CommentFiles", "SFX", "Lock", "Protect", "Recover",
-        "Add", "Move", "AddRecurse", "MoveRecurse", "AllFilesMask"
-    };
-
-    if(Command < (int)(ARRAYSIZE(CmdNames)))
-    {
-        Values->GetChars(Dest, 512, CmdNames[Command], "");
-        return (TRUE);
-    }
-
+  if (!Values)
     return (FALSE);
+
+  FormatName = Values->GetString(Str_TypeName, TypeName.c_str());
+
+  if (FormatName.empty())
+    return (FALSE);
+
+  static const char *CmdNames[] = { "Extract", "ExtractWithoutPath", "Test", "Delete",
+                                    "Comment", "CommentFiles", "SFX", "Lock", "Protect", "Recover",
+                                    "Add", "Move", "AddRecurse", "MoveRecurse", "AllFilesMask"
+                                  };
+
+  if(Command < (int)(ARRAYSIZE(CmdNames)))
+  {
+    Values->GetChars(Dest, 512, CmdNames[Command], "");
+    return (TRUE);
+  }
+
+  return (FALSE);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -727,565 +727,611 @@ BOOL WINAPI _export CUSTOM_GetDefaultCommands(int Type, int Command, char *Dest)
 
 static const KeyFileValues *GetSection(int Num, std::string &Name)
 {
-	if (Num < 0) {
-		return nullptr;
-	}
-	for (const auto &i : FormatFileNameKFH) if (i.second) {
-		const auto &sections = i.second->EnumSections();
-		if (Num < (int)sections.size()) {
-			return i.second->GetSectionValues(sections[Num]);
-		}
-		Num-= (int)sections.size();
-	}
-	return nullptr;
+  if (Num < 0) {
+    return nullptr;
+  }
+  for (const auto &i : FormatFileNameKFH) if (i.second) {
+      const auto &sections = i.second->EnumSections();
+      if (Num < (int)sections.size()) {
+        return i.second->GetSectionValues(sections[Num]);
+      }
+      Num-= (int)sections.size();
+    }
+  return nullptr;
 }
 
 static bool CheckIniFiles()
 {
-	bool out = false;
+  bool out = false;
 
-	for (auto &i : FormatFileNameKFH) {
-		struct stat s{};
-		if (stat(i.first.c_str(), &s) == -1) {
-			i.second.reset();
+  for (auto &i : FormatFileNameKFH) {
+    struct stat s {};
+    if (stat(i.first.c_str(), &s) == -1) {
+      i.second.reset();
 
-		} else {
-			out = true;
-			if (i.second) {
-				const auto &ls = i.second->LoadedFileStat();
-				if (s.st_ino == ls.st_ino
-						&& s.st_mtime == ls.st_mtime
-						&& s.st_size == ls.st_size) {
-					continue;
-				}
-				i.second.reset();
-			}
-			i.second.reset(new KeyFileReadHelper(i.first));
-		}
-	}
+    } else {
+      out = true;
+      if (i.second) {
+        const auto &ls = i.second->LoadedFileStat();
+        if (s.st_ino == ls.st_ino
+            && s.st_mtime == ls.st_mtime
+            && s.st_size == ls.st_size) {
+          continue;
+        }
+        i.second.reset();
+      }
+      i.second.reset(new KeyFileReadHelper(i.first));
+    }
+  }
 
-	return out;
+  return out;
 }
 
 static void FillFormat(const KeyFileValues *Values)
 {
-    StartText = Values->GetString("Start", "");
-    EndText = Values->GetString("End", "");
+  StartText = Values->GetString("Start", "");
+  EndText = Values->GetString("End", "");
 
-    int FormatNumber = 0;
+  int FormatNumber = 0;
 
-    delete Format;
-    Format = new CustomStringList;
-    for(CustomStringList * CurFormat = Format;; CurFormat = CurFormat->Add())
-    {
-        char FormatName[100];
+  delete Format;
+  Format = new CustomStringList;
+  for(CustomStringList * CurFormat = Format;; CurFormat = CurFormat->Add())
+  {
+    char FormatName[100];
 
-        sprintf(FormatName, "Format%d", FormatNumber++);
-        Values->GetChars(CurFormat->Str(), PROF_STR_LEN, FormatName, "");
-        if(*CurFormat->Str() == 0)
-            break;
-    }
+    sprintf(FormatName, "Format%d", FormatNumber++);
+    Values->GetChars(CurFormat->Str(), PROF_STR_LEN, FormatName, "");
+    if(*CurFormat->Str() == 0)
+      break;
+  }
 
-    int Number = 0;
+  int Number = 0;
 
-    delete IgnoreStrings;
-    IgnoreStrings = new CustomStringList;
-    for(CustomStringList * CurIgnoreString = IgnoreStrings;; CurIgnoreString = CurIgnoreString->Add())
-    {
-        char Name[100];
+  delete IgnoreStrings;
+  IgnoreStrings = new CustomStringList;
+  for(CustomStringList * CurIgnoreString = IgnoreStrings;; CurIgnoreString = CurIgnoreString->Add())
+  {
+    char Name[100];
 
-        sprintf(Name, "IgnoreString%d", Number++);
-        Values->GetChars(CurIgnoreString->Str(), PROF_STR_LEN, Name, "");
-        if(*CurIgnoreString->Str() == 0)
-            break;
-    }
+    sprintf(Name, "IgnoreString%d", Number++);
+    Values->GetChars(CurIgnoreString->Str(), PROF_STR_LEN, Name, "");
+    if(*CurIgnoreString->Str() == 0)
+      break;
+  }
 }
 
 static int GetString(char *Str, int MaxSize)
 {
-    if(OutDataPos >= OutDataSize)
-        return (FALSE);
+  if(OutDataPos >= OutDataSize)
+    return (FALSE);
 
-    int StartPos = OutDataPos;
+  int StartPos = OutDataPos;
 
-    while(OutDataPos < OutDataSize)
-    {
-        int Ch = OutData[OutDataPos];
+  while(OutDataPos < OutDataSize)
+  {
+    int Ch = OutData[OutDataPos];
 
-        if(Ch == '\r' || Ch == '\n')
-            break;
-        OutDataPos++;
-    }
+    if(Ch == '\r' || Ch == '\n')
+      break;
+    OutDataPos++;
+  }
 
-    int Length = OutDataPos - StartPos;
-    int DestLength = Length >= MaxSize ? MaxSize - 1 : Length;
+  int Length = OutDataPos - StartPos;
+  int DestLength = Length >= MaxSize ? MaxSize - 1 : Length;
 
-    memcpy(Str, OutData + StartPos, DestLength);
-	Str[DestLength] = 0;
+  memcpy(Str, OutData + StartPos, DestLength);
+  Str[DestLength] = 0;
 
-    while(OutDataPos < OutDataSize)
-    {
-        int Ch = OutData[OutDataPos];
+  while(OutDataPos < OutDataSize)
+  {
+    int Ch = OutData[OutDataPos];
 
-        if(Ch != '\r' && Ch != '\n')
-            break;
-        OutDataPos++;
-    }
+    if(Ch != '\r' && Ch != '\n')
+      break;
+    OutDataPos++;
+  }
 
-    return (TRUE);
+  return (TRUE);
 }
 
 static void MakeFiletime(SYSTEMTIME st, SYSTEMTIME syst, LPFILETIME pft)
 {
-    if(st.wDay == 0)
-        st.wDay = syst.wDay;
-    if(st.wMonth == 0)
-        st.wMonth = syst.wMonth;
-    if(st.wYear == 0)
-        st.wYear = syst.wYear;
-    else
-    {
-        if(st.wYear < 50)
-            st.wYear += 2000;
-        else if(st.wYear < 100)
-            st.wYear += 1900;
-    }
+  if(st.wDay == 0)
+    st.wDay = syst.wDay;
+  if(st.wMonth == 0)
+    st.wMonth = syst.wMonth;
+  if(st.wYear == 0)
+    st.wYear = syst.wYear;
+  else
+  {
+    if(st.wYear < 50)
+      st.wYear += 2000;
+    else if(st.wYear < 100)
+      st.wYear += 1900;
+  }
 
-    FILETIME ft;
+  FILETIME ft;
 
-    if(WINPORT(SystemTimeToFileTime)(&st, &ft))
-    {
-        WINPORT(LocalFileTimeToFileTime)(&ft, pft);
-    }
+  if(WINPORT(SystemTimeToFileTime)(&st, &ft))
+  {
+    WINPORT(LocalFileTimeToFileTime)(&ft, pft);
+  }
 }
 
 static int StringToInt(const char *str)
 {
-    int i = 0;
-    for(const char *p = str; p && *p; ++p)
-        if(isdigit(*p))
-            i = i * 10 + (*p - '0');
-    return i;
+  int i = 0;
+  for(const char *p = str; p && *p; ++p)
+    if(isdigit(*p))
+      i = i * 10 + (*p - '0');
+  return i;
 }
 
 static int64_t StringToInt64(const char *str)
 {
-    int64_t i = 0;
-    for(const char *p = str; p && *p; ++p)
-        if(isdigit(*p))
-            i = i * 10 + (*p - '0');
-    return i;
+  int64_t i = 0;
+  for(const char *p = str; p && *p; ++p)
+    if(isdigit(*p))
+      i = i * 10 + (*p - '0');
+  return i;
 }
 
 static int StringToIntHex(const char *str)
 {
-    int i = 0;
-    for(const char *p = str; p && *p; ++p)
-        if(isxdigit(*p))
-        {
-            char dig_sub = (*p >= 'a' ? 'a' : (*p >= 'A' ? 'A' : '0'));
-            i = i * 16 + (*p - dig_sub);
-        }
-    return i;
+  int i = 0;
+  for(const char *p = str; p && *p; ++p)
+    if(isxdigit(*p))
+    {
+      char dig_sub = (*p >= 'a' ? 'a' : (*p >= 'A' ? 'A' : '0'));
+      i = i * 16 + (*p - dig_sub);
+    }
+  return i;
 }
 
 static void ParseListingItemRegExp(Match match,
-     struct ArcItemInfo *Info,
-    SYSTEMTIME &stModification, SYSTEMTIME &stCreation, SYSTEMTIME &stAccess)
+                                   struct ArcItemInfo *Info,
+                                   SYSTEMTIME &stModification, SYSTEMTIME &stCreation, SYSTEMTIME &stAccess)
 {
-    if(const char *p = match["name"])
-        Info->PathName = p;
-    if(const char *p = match["description"])
-        Info->Description.reset(new std::string(p));
+  if(const char *p = match["name"])
+    Info->PathName = p;
+  if(const char *p = match["description"])
+    Info->Description.reset(new std::string(p));
 
-    Info->nFileSize     = StringToInt64(match["size"]);
-    Info->nPhysicalSize   = StringToInt64(match["packedSize"]);
+  Info->nFileSize     = StringToInt64(match["size"]);
+  Info->nPhysicalSize   = StringToInt64(match["packedSize"]);
 
-    for(const char *p = match["attr"]; p && *p; ++p)
+  for(const char *p = match["attr"]; p && *p; ++p)
+  {
+    switch(*p)
     {
-        switch(*p)
-        {
-            case 'd': case 'D': Info->dwFileAttributes |= FILE_ATTRIBUTE_DIRECTORY;  break;
-            case 'h': case 'H': Info->dwFileAttributes |= FILE_ATTRIBUTE_HIDDEN;     break;
-            case 'a': case 'A': Info->dwFileAttributes |= FILE_ATTRIBUTE_ARCHIVE;    break;
-            case 'r': case 'R': Info->dwFileAttributes |= FILE_ATTRIBUTE_READONLY;   break;
-            case 's': case 'S': Info->dwFileAttributes |= FILE_ATTRIBUTE_SYSTEM;     break;
-            case 'c': case 'C': Info->dwFileAttributes |= FILE_ATTRIBUTE_COMPRESSED; break;
-            case 'x': case 'X': Info->dwFileAttributes |= FILE_ATTRIBUTE_EXECUTABLE; break;
-        }
+    case 'd':
+    case 'D':
+      Info->dwFileAttributes |= FILE_ATTRIBUTE_DIRECTORY;
+      break;
+    case 'h':
+    case 'H':
+      Info->dwFileAttributes |= FILE_ATTRIBUTE_HIDDEN;
+      break;
+    case 'a':
+    case 'A':
+      Info->dwFileAttributes |= FILE_ATTRIBUTE_ARCHIVE;
+      break;
+    case 'r':
+    case 'R':
+      Info->dwFileAttributes |= FILE_ATTRIBUTE_READONLY;
+      break;
+    case 's':
+    case 'S':
+      Info->dwFileAttributes |= FILE_ATTRIBUTE_SYSTEM;
+      break;
+    case 'c':
+    case 'C':
+      Info->dwFileAttributes |= FILE_ATTRIBUTE_COMPRESSED;
+      break;
+    case 'x':
+    case 'X':
+      Info->dwFileAttributes |= FILE_ATTRIBUTE_EXECUTABLE;
+      break;
     }
+  }
 
-    stModification.wYear    = StringToInt(match["mYear"]);
-    stModification.wDay     = StringToInt(match["mDay"]);
-    stModification.wMonth   = StringToInt(match["mMonth"]);
+  stModification.wYear    = StringToInt(match["mYear"]);
+  stModification.wDay     = StringToInt(match["mDay"]);
+  stModification.wMonth   = StringToInt(match["mMonth"]);
 
-    if(const char *p = match["mMonthA"])
+  if(const char *p = match["mMonthA"])
+  {
+    static const char *Months[12] = { "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+                                      "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
+                                    };
+
+    for(size_t I = 0; I < sizeof(Months) / sizeof(Months[0]); I++)
+      if(strncasecmp(p, Months[I], 3) == 0)
+      {
+        stModification.wMonth = (WORD)(I + 1);
+        break;
+      }
+  }
+
+  stModification.wHour    = StringToInt(match["mHour"]);
+
+  if(const char *p = match["mAMPM"])
+  {
+    switch(*p)
     {
-        static const char *Months[12] = { "Jan", "Feb", "Mar", "Apr", "May", "Jun",
-            "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
-        };
-
-        for(size_t I = 0; I < sizeof(Months) / sizeof(Months[0]); I++)
-            if(strncasecmp(p, Months[I], 3) == 0)
-            {
-                stModification.wMonth = (WORD)(I + 1);
-                break;
-            }
+    case 'A':
+    case 'a':
+      if(stModification.wHour == 12)
+        stModification.wHour -= 12;
+      break;
+    case 'P':
+    case 'p':
+      if(stModification.wHour < 12)
+        stModification.wHour += 12;
+      break;
     }
+  }
 
-    stModification.wHour    = StringToInt(match["mHour"]);
+  stModification.wMinute  = StringToInt(match["mMin"]);
+  stModification.wSecond  = StringToInt(match["mSec"]);
 
-    if(const char *p = match["mAMPM"])
-    {
-        switch(*p)
-        {
-        case 'A': case 'a':
-            if(stModification.wHour == 12)
-                stModification.wHour -= 12;
-            break;
-        case 'P': case 'p':
-            if(stModification.wHour < 12)
-                stModification.wHour += 12;
-            break;
-        }
-    }
+  stAccess.wDay           = StringToInt(match["aDay"]);
+  stAccess.wMonth         = StringToInt(match["aMonth"]);
+  stAccess.wYear          = StringToInt(match["aYear"]);
+  stAccess.wHour          = StringToInt(match["aHour"]);
+  stAccess.wMinute        = StringToInt(match["aMin"]);
+  stAccess.wSecond        = StringToInt(match["aSec"]);
 
-    stModification.wMinute  = StringToInt(match["mMin"]);
-    stModification.wSecond  = StringToInt(match["mSec"]);
+  stCreation.wDay         = StringToInt(match["cDay"]);
+  stCreation.wMonth       = StringToInt(match["cMonth"]);
+  stCreation.wYear        = StringToInt(match["cYear"]);
+  stCreation.wHour        = StringToInt(match["cHour"]);
+  stCreation.wMinute      = StringToInt(match["cMin"]);
+  stCreation.wSecond      = StringToInt(match["cSec"]);
 
-    stAccess.wDay           = StringToInt(match["aDay"]);
-    stAccess.wMonth         = StringToInt(match["aMonth"]);
-    stAccess.wYear          = StringToInt(match["aYear"]);
-    stAccess.wHour          = StringToInt(match["aHour"]);
-    stAccess.wMinute        = StringToInt(match["aMin"]);
-    stAccess.wSecond        = StringToInt(match["aSec"]);
-
-    stCreation.wDay         = StringToInt(match["cDay"]);
-    stCreation.wMonth       = StringToInt(match["cMonth"]);
-    stCreation.wYear        = StringToInt(match["cYear"]);
-    stCreation.wHour        = StringToInt(match["cHour"]);
-    stCreation.wMinute      = StringToInt(match["cMin"]);
-    stCreation.wSecond      = StringToInt(match["cSec"]);
-
-    Info->CRC32             = StringToIntHex(match["CRC"]);
+  Info->CRC32             = StringToIntHex(match["CRC"]);
 
 }
 
 
 static void ParseListingItemPlain(const char *CurFormat, const char *CurStr,
-    struct ArcItemInfo *Info,
-    SYSTEMTIME &stModification, SYSTEMTIME &stCreation, SYSTEMTIME &stAccess)
+                                  struct ArcItemInfo *Info,
+                                  SYSTEMTIME &stModification, SYSTEMTIME &stCreation, SYSTEMTIME &stAccess)
 {
-    enum
-    { OP_OUTSIDE, OP_INSIDE, OP_SKIP }
-    OptionalPart = OP_OUTSIDE;
-    int IsChapter = 0;
+  enum
+  { OP_OUTSIDE, OP_INSIDE, OP_SKIP }
+  OptionalPart = OP_OUTSIDE;
+  int IsChapter = 0;
 
-    for(; *CurStr && *CurFormat; CurFormat++, CurStr++)
+  for(; *CurStr && *CurFormat; CurFormat++, CurStr++)
+  {
+    if(OptionalPart == OP_SKIP)
     {
-		if(OptionalPart == OP_SKIP)
-        {
-            if(*CurFormat == ')')
-                OptionalPart = OP_OUTSIDE;
-            CurStr--;
-            continue;
-        }
-        switch (*CurFormat)
-        {
-        case '*':
-            if(isspace(*CurStr) || !CurStr)
-                CurStr--;
-            else
-                while( /*CurStr[0] && */ CurStr[1] /*&& !isspace(CurStr[0]) */
-                      && !isspace(CurStr[1]))
-                    CurStr++;
-            break;
-        case 'n':
-            if (*CurStr) Info->PathName+= *CurStr;
-            break;
-        case 'c':
-            if (*CurStr) {
-              if (!Info->Description)
-                Info->Description.reset(new std::string);
-              Info->Description->append(1, *CurStr);
-            }
-            break;
-        case '.':
-            {
-                while(!Info->PathName.empty() && isspace(Info->PathName.back()))
-                    Info->PathName.pop_back();
+      if(*CurFormat == ')')
+        OptionalPart = OP_OUTSIDE;
+      CurStr--;
+      continue;
+    }
+    switch (*CurFormat)
+    {
+    case '*':
+      if(isspace(*CurStr) || !CurStr)
+        CurStr--;
+      else
+        while( /*CurStr[0] && */ CurStr[1] /*&& !isspace(CurStr[0]) */
+                                 && !isspace(CurStr[1]))
+          CurStr++;
+      break;
+    case 'n':
+      if (*CurStr) Info->PathName+= *CurStr;
+      break;
+    case 'c':
+      if (*CurStr) {
+        if (!Info->Description)
+          Info->Description.reset(new std::string);
+        Info->Description->append(1, *CurStr);
+      }
+      break;
+    case '.':
+    {
+      while(!Info->PathName.empty() && isspace(Info->PathName.back()))
+        Info->PathName.pop_back();
 
-                if(!Info->PathName.empty())
-                    Info->PathName+= '.';
-            }
-            break;
-        case 'z':
-            if(isdigit(*CurStr))
-            {
-                Info->nFileSize*= 10;
-                Info->nFileSize+= (*CurStr - '0');
-            }
-            else if(OP_INSIDE == OptionalPart)
-            {
-                CurStr--;
-                OptionalPart = OP_SKIP;
-            }
-            break;
-        case 'p':
-            if(isdigit(*CurStr))
-            {
-				Info->nPhysicalSize*= 10;
-				Info->nPhysicalSize+= (*CurStr - '0');
-            }
-            else if(OP_INSIDE == OptionalPart)
-            {
-                CurStr--;
-                OptionalPart = OP_SKIP;
-            }
-            break;
-        case 'a':
-            switch (*CurStr)
-            {
-                case 'd': case 'D': Info->dwFileAttributes |= FILE_ATTRIBUTE_DIRECTORY;  break;
-                case 'h': case 'H': Info->dwFileAttributes |= FILE_ATTRIBUTE_HIDDEN;     break;
-                case 'a': case 'A': Info->dwFileAttributes |= FILE_ATTRIBUTE_ARCHIVE;    break;
-                case 'r': case 'R': Info->dwFileAttributes |= FILE_ATTRIBUTE_READONLY;   break;
-                case 's': case 'S': Info->dwFileAttributes |= FILE_ATTRIBUTE_SYSTEM;     break;
-                case 'c': case 'C': Info->dwFileAttributes |= FILE_ATTRIBUTE_COMPRESSED; break;
-                case 'x': case 'X': Info->dwFileAttributes |= FILE_ATTRIBUTE_EXECUTABLE; break;
-            }
-            break;
+      if(!Info->PathName.empty())
+        Info->PathName+= '.';
+    }
+    break;
+    case 'z':
+      if(isdigit(*CurStr))
+      {
+        Info->nFileSize*= 10;
+        Info->nFileSize+= (*CurStr - '0');
+      }
+      else if(OP_INSIDE == OptionalPart)
+      {
+        CurStr--;
+        OptionalPart = OP_SKIP;
+      }
+      break;
+    case 'p':
+      if(isdigit(*CurStr))
+      {
+        Info->nPhysicalSize*= 10;
+        Info->nPhysicalSize+= (*CurStr - '0');
+      }
+      else if(OP_INSIDE == OptionalPart)
+      {
+        CurStr--;
+        OptionalPart = OP_SKIP;
+      }
+      break;
+    case 'a':
+      switch (*CurStr)
+      {
+      case 'd':
+      case 'D':
+        Info->dwFileAttributes |= FILE_ATTRIBUTE_DIRECTORY;
+        break;
+      case 'h':
+      case 'H':
+        Info->dwFileAttributes |= FILE_ATTRIBUTE_HIDDEN;
+        break;
+      case 'a':
+      case 'A':
+        Info->dwFileAttributes |= FILE_ATTRIBUTE_ARCHIVE;
+        break;
+      case 'r':
+      case 'R':
+        Info->dwFileAttributes |= FILE_ATTRIBUTE_READONLY;
+        break;
+      case 's':
+      case 'S':
+        Info->dwFileAttributes |= FILE_ATTRIBUTE_SYSTEM;
+        break;
+      case 'c':
+      case 'C':
+        Info->dwFileAttributes |= FILE_ATTRIBUTE_COMPRESSED;
+        break;
+      case 'x':
+      case 'X':
+        Info->dwFileAttributes |= FILE_ATTRIBUTE_EXECUTABLE;
+        break;
+      }
+      break;
 // MODIFICATION DATETIME
-        case 'y':
-            if(isdigit(*CurStr))
-                stModification.wYear = stModification.wYear * 10 + (*CurStr - '0');
-            else if(OP_INSIDE == OptionalPart)
-            {
-                CurStr--;
-                OptionalPart = OP_SKIP;
-            }
-            break;
-        case 'd':
-            if(isdigit(*CurStr))
-                stModification.wDay = stModification.wDay * 10 + (*CurStr - '0');
-            else if(OP_INSIDE == OptionalPart)
-            {
-                CurStr--;
-                OptionalPart = OP_SKIP;
-            }
-            break;
-        case 't':
-            if(isdigit(*CurStr))
-                stModification.wMonth = stModification.wMonth * 10 + (*CurStr - '0');
-            else if(OP_INSIDE == OptionalPart)
-            {
-                CurStr--;
-                OptionalPart = OP_SKIP;
-            }
-            break;
-        case 'T':
-            {
-                static const char *Months[12] = { "Jan", "Feb", "Mar", "Apr", "May", "Jun",
-                    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
-                };
+    case 'y':
+      if(isdigit(*CurStr))
+        stModification.wYear = stModification.wYear * 10 + (*CurStr - '0');
+      else if(OP_INSIDE == OptionalPart)
+      {
+        CurStr--;
+        OptionalPart = OP_SKIP;
+      }
+      break;
+    case 'd':
+      if(isdigit(*CurStr))
+        stModification.wDay = stModification.wDay * 10 + (*CurStr - '0');
+      else if(OP_INSIDE == OptionalPart)
+      {
+        CurStr--;
+        OptionalPart = OP_SKIP;
+      }
+      break;
+    case 't':
+      if(isdigit(*CurStr))
+        stModification.wMonth = stModification.wMonth * 10 + (*CurStr - '0');
+      else if(OP_INSIDE == OptionalPart)
+      {
+        CurStr--;
+        OptionalPart = OP_SKIP;
+      }
+      break;
+    case 'T':
+    {
+      static const char *Months[12] = { "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+                                        "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
+                                      };
 
-                for(size_t I = 0; I < sizeof(Months) / sizeof(Months[0]); I++)
-                    if(strncasecmp(CurStr, Months[I], 3) == 0)
-                    {
-                        stModification.wMonth = (WORD)(I + 1);
-                        while(CurFormat[1] == 'T' && CurStr[1])
-                        {
-                            CurStr++;
-                            CurFormat++;
-                        }
-                        break;
-                    }
-            }
-            break;
-        case 'h':
-            if(isdigit(*CurStr))
-                stModification.wHour = stModification.wHour * 10 + (*CurStr - '0');
-            else if(OP_INSIDE == OptionalPart)
-            {
-                CurStr--;
-                OptionalPart = OP_SKIP;
-            }
-            break;
-        case 'H':
-            switch (*CurStr)
-            {
-                case 'A': case 'a':
-                    if(stModification.wHour == 12)
-                        stModification.wHour -= 12;
-                    break;
-                case 'P': case 'p':
-                    if(stModification.wHour < 12)
-                        stModification.wHour += 12;
-                    break;
-            }
-            break;
-        case 'm':
-            if(isdigit(*CurStr))
-                stModification.wMinute = stModification.wMinute * 10 + (*CurStr - '0');
-            else if(OP_INSIDE == OptionalPart)
-            {
-                CurStr--;
-                OptionalPart = OP_SKIP;
-            }
-            break;
-        case 's':
-            if(isdigit(*CurStr))
-                stModification.wSecond = stModification.wSecond * 10 + (*CurStr - '0');
-            else if(OP_INSIDE == OptionalPart)
-            {
-                CurStr--;
-                OptionalPart = OP_SKIP;
-            }
-            break;
-// ACCESS DATETIME
-        case 'b':
-            if(isdigit(*CurStr))
-                stAccess.wDay = stAccess.wDay * 10 + (*CurStr - '0');
-            else if(OP_INSIDE == OptionalPart)
-            {
-                CurStr--;
-                OptionalPart = OP_SKIP;
-            }
-            break;
-        case 'v':
-            if(isdigit(*CurStr))
-                stAccess.wMonth = stAccess.wMonth * 10 + (*CurStr - '0');
-            else if(OP_INSIDE == OptionalPart)
-            {
-                CurStr--;
-                OptionalPart = OP_SKIP;
-            }
-            break;
-        case 'e':
-            if(isdigit(*CurStr))
-                stAccess.wYear = stAccess.wYear * 10 + (*CurStr - '0');
-            else if(OP_INSIDE == OptionalPart)
-            {
-                CurStr--;
-                OptionalPart = OP_SKIP;
-            }
-            break;
-        case 'x':
-            if(isdigit(*CurStr))
-                stAccess.wHour = stAccess.wHour * 10 + (*CurStr - '0');
-            else if(OP_INSIDE == OptionalPart)
-            {
-                CurStr--;
-                OptionalPart = OP_SKIP;
-            }
-            break;
-        case 'l':
-            if(isdigit(*CurStr))
-                stAccess.wMinute = stAccess.wMinute * 10 + (*CurStr - '0');
-            else if(OP_INSIDE == OptionalPart)
-            {
-                CurStr--;
-                OptionalPart = OP_SKIP;
-            }
-            break;
-        case 'k':
-            if(isdigit(*CurStr))
-                stAccess.wSecond = stAccess.wSecond * 10 + (*CurStr - '0');
-            else if(OP_INSIDE == OptionalPart)
-            {
-                CurStr--;
-                OptionalPart = OP_SKIP;
-            }
-            break;
-// CREATION DATETIME
-        case 'j':
-            if(isdigit(*CurStr))
-                stCreation.wDay = stCreation.wDay * 10 + (*CurStr - '0');
-            else if(OP_INSIDE == OptionalPart)
-            {
-                CurStr--;
-                OptionalPart = OP_SKIP;
-            }
-            break;
-        case 'g':
-            if(isdigit(*CurStr))
-                stCreation.wMonth = stCreation.wMonth * 10 + (*CurStr - '0');
-            else if(OP_INSIDE == OptionalPart)
-            {
-                CurStr--;
-                OptionalPart = OP_SKIP;
-            }
-            break;
-        case 'f':
-            if(isdigit(*CurStr))
-                stCreation.wYear = stCreation.wYear * 10 + (*CurStr - '0');
-            else if(OP_INSIDE == OptionalPart)
-            {
-                CurStr--;
-                OptionalPart = OP_SKIP;
-            }
-            break;
-        case 'o':
-            if(isdigit(*CurStr))
-                stCreation.wHour = stCreation.wHour * 10 + (*CurStr - '0');
-            else if(OP_INSIDE == OptionalPart)
-            {
-                CurStr--;
-                OptionalPart = OP_SKIP;
-            }
-            break;
-        case 'i':
-            if(isdigit(*CurStr))
-                stCreation.wMinute = stCreation.wMinute * 10 + (*CurStr - '0');
-            else if(OP_INSIDE == OptionalPart)
-            {
-                CurStr--;
-                OptionalPart = OP_SKIP;
-            }
-            break;
-        case 'u':
-            if(isdigit(*CurStr))
-                stCreation.wSecond = stCreation.wSecond * 10 + (*CurStr - '0');
-            else if(OP_INSIDE == OptionalPart)
-            {
-                CurStr--;
-                OptionalPart = OP_SKIP;
-            }
-            break;
-        case 'r':
-            if(isxdigit(toupper(*CurStr)))
-            {
-                char dig_sub = (*CurStr >= 'a' ? 'a' : (*CurStr >= 'A' ? 'A' : '0'));
-                Info->CRC32 = Info->CRC32 * 16 + (*CurStr - dig_sub);
-            }
-            else if(OP_INSIDE == OptionalPart)
-            {
-                CurStr--;
-                OptionalPart = OP_SKIP;
-            }
-            break;
-        case 'C':
-            if(*CurStr == '-')
-            {
-                IsChapter = 1;
-                ArcChapters = 0;
-            }
-            else if(isdigit(*CurStr))
-            {
-                if(IsChapter)
-                    ArcChapters = ArcChapters * 10 + (*CurStr - '0');
-                else
-                    Info->Chapter = Info->Chapter * 10 + (*CurStr - '0');
-            }
-            break;
-        case '(':
-            OptionalPart = OP_INSIDE;
-            CurStr--;
-            break;
-        case ')':
-            OptionalPart = OP_OUTSIDE;
-            CurStr--;
-            break;
+      for(size_t I = 0; I < sizeof(Months) / sizeof(Months[0]); I++)
+        if(strncasecmp(CurStr, Months[I], 3) == 0)
+        {
+          stModification.wMonth = (WORD)(I + 1);
+          while(CurFormat[1] == 'T' && CurStr[1])
+          {
+            CurStr++;
+            CurFormat++;
+          }
+          break;
         }
     }
+    break;
+    case 'h':
+      if(isdigit(*CurStr))
+        stModification.wHour = stModification.wHour * 10 + (*CurStr - '0');
+      else if(OP_INSIDE == OptionalPart)
+      {
+        CurStr--;
+        OptionalPart = OP_SKIP;
+      }
+      break;
+    case 'H':
+      switch (*CurStr)
+      {
+      case 'A':
+      case 'a':
+        if(stModification.wHour == 12)
+          stModification.wHour -= 12;
+        break;
+      case 'P':
+      case 'p':
+        if(stModification.wHour < 12)
+          stModification.wHour += 12;
+        break;
+      }
+      break;
+    case 'm':
+      if(isdigit(*CurStr))
+        stModification.wMinute = stModification.wMinute * 10 + (*CurStr - '0');
+      else if(OP_INSIDE == OptionalPart)
+      {
+        CurStr--;
+        OptionalPart = OP_SKIP;
+      }
+      break;
+    case 's':
+      if(isdigit(*CurStr))
+        stModification.wSecond = stModification.wSecond * 10 + (*CurStr - '0');
+      else if(OP_INSIDE == OptionalPart)
+      {
+        CurStr--;
+        OptionalPart = OP_SKIP;
+      }
+      break;
+// ACCESS DATETIME
+    case 'b':
+      if(isdigit(*CurStr))
+        stAccess.wDay = stAccess.wDay * 10 + (*CurStr - '0');
+      else if(OP_INSIDE == OptionalPart)
+      {
+        CurStr--;
+        OptionalPart = OP_SKIP;
+      }
+      break;
+    case 'v':
+      if(isdigit(*CurStr))
+        stAccess.wMonth = stAccess.wMonth * 10 + (*CurStr - '0');
+      else if(OP_INSIDE == OptionalPart)
+      {
+        CurStr--;
+        OptionalPart = OP_SKIP;
+      }
+      break;
+    case 'e':
+      if(isdigit(*CurStr))
+        stAccess.wYear = stAccess.wYear * 10 + (*CurStr - '0');
+      else if(OP_INSIDE == OptionalPart)
+      {
+        CurStr--;
+        OptionalPart = OP_SKIP;
+      }
+      break;
+    case 'x':
+      if(isdigit(*CurStr))
+        stAccess.wHour = stAccess.wHour * 10 + (*CurStr - '0');
+      else if(OP_INSIDE == OptionalPart)
+      {
+        CurStr--;
+        OptionalPart = OP_SKIP;
+      }
+      break;
+    case 'l':
+      if(isdigit(*CurStr))
+        stAccess.wMinute = stAccess.wMinute * 10 + (*CurStr - '0');
+      else if(OP_INSIDE == OptionalPart)
+      {
+        CurStr--;
+        OptionalPart = OP_SKIP;
+      }
+      break;
+    case 'k':
+      if(isdigit(*CurStr))
+        stAccess.wSecond = stAccess.wSecond * 10 + (*CurStr - '0');
+      else if(OP_INSIDE == OptionalPart)
+      {
+        CurStr--;
+        OptionalPart = OP_SKIP;
+      }
+      break;
+// CREATION DATETIME
+    case 'j':
+      if(isdigit(*CurStr))
+        stCreation.wDay = stCreation.wDay * 10 + (*CurStr - '0');
+      else if(OP_INSIDE == OptionalPart)
+      {
+        CurStr--;
+        OptionalPart = OP_SKIP;
+      }
+      break;
+    case 'g':
+      if(isdigit(*CurStr))
+        stCreation.wMonth = stCreation.wMonth * 10 + (*CurStr - '0');
+      else if(OP_INSIDE == OptionalPart)
+      {
+        CurStr--;
+        OptionalPart = OP_SKIP;
+      }
+      break;
+    case 'f':
+      if(isdigit(*CurStr))
+        stCreation.wYear = stCreation.wYear * 10 + (*CurStr - '0');
+      else if(OP_INSIDE == OptionalPart)
+      {
+        CurStr--;
+        OptionalPart = OP_SKIP;
+      }
+      break;
+    case 'o':
+      if(isdigit(*CurStr))
+        stCreation.wHour = stCreation.wHour * 10 + (*CurStr - '0');
+      else if(OP_INSIDE == OptionalPart)
+      {
+        CurStr--;
+        OptionalPart = OP_SKIP;
+      }
+      break;
+    case 'i':
+      if(isdigit(*CurStr))
+        stCreation.wMinute = stCreation.wMinute * 10 + (*CurStr - '0');
+      else if(OP_INSIDE == OptionalPart)
+      {
+        CurStr--;
+        OptionalPart = OP_SKIP;
+      }
+      break;
+    case 'u':
+      if(isdigit(*CurStr))
+        stCreation.wSecond = stCreation.wSecond * 10 + (*CurStr - '0');
+      else if(OP_INSIDE == OptionalPart)
+      {
+        CurStr--;
+        OptionalPart = OP_SKIP;
+      }
+      break;
+    case 'r':
+      if(isxdigit(toupper(*CurStr)))
+      {
+        char dig_sub = (*CurStr >= 'a' ? 'a' : (*CurStr >= 'A' ? 'A' : '0'));
+        Info->CRC32 = Info->CRC32 * 16 + (*CurStr - dig_sub);
+      }
+      else if(OP_INSIDE == OptionalPart)
+      {
+        CurStr--;
+        OptionalPart = OP_SKIP;
+      }
+      break;
+    case 'C':
+      if(*CurStr == '-')
+      {
+        IsChapter = 1;
+        ArcChapters = 0;
+      }
+      else if(isdigit(*CurStr))
+      {
+        if(IsChapter)
+          ArcChapters = ArcChapters * 10 + (*CurStr - '0');
+        else
+          Info->Chapter = Info->Chapter * 10 + (*CurStr - '0');
+      }
+      break;
+    case '(':
+      OptionalPart = OP_INSIDE;
+      CurStr--;
+      break;
+    case ')':
+      OptionalPart = OP_OUTSIDE;
+      CurStr--;
+      break;
+    }
+  }
 }

--- a/multiarc/src/formats/rar/rarmainstub.cpp
+++ b/multiarc/src/formats/rar/rarmainstub.cpp
@@ -9,119 +9,125 @@ extern "C" int libarch_main(int numargs, char *args[]);
 
 struct AutoArgs : std::vector<char *>
 {
-	AutoArgs() = default;
-	AutoArgs(const AutoArgs&) = delete;
-	AutoArgs& operator =(const AutoArgs&) = delete;
+  AutoArgs() = default;
+  AutoArgs(const AutoArgs&) = delete;
+  AutoArgs& operator =(const AutoArgs&) = delete;
 
-	FN_NOINLINE void Add(const char *sz, size_t pos)
-	{
-		assert(pos <= size());
-		char *copied_sz = strdup(sz);
-		if (!copied_sz) {
-			throw std::bad_alloc();
-		}
+  FN_NOINLINE void Add(const char *sz, size_t pos)
+  {
+    assert(pos <= size());
+    char *copied_sz = strdup(sz);
+    if (!copied_sz) {
+      throw std::bad_alloc();
+    }
 
-		insert(begin() + pos, copied_sz);
-	}
+    insert(begin() + pos, copied_sz);
+  }
 
-	void Add(const char *sz)
-	{
-		Add(sz, size());
-	}
+  void Add(const char *sz)
+  {
+    Add(sz, size());
+  }
 
-	~AutoArgs()
-	{
-		for (auto p : *this) {
-			free(p);
-		}
-	}
+  ~AutoArgs()
+  {
+    for (auto p : *this) {
+      free(p);
+    }
+  }
 };
 
 int rar_main(int argc, char *argv[])
 {
-	if (argc < 2) {
-		return -1;
-	}
-	std::vector<char *> plain_args;
-	for (int i = 0; i < argc; ++i) {
-		plain_args.emplace_back(argv[i]);
-	}
-	plain_args.emplace_back(nullptr);
+  if (argc < 2) {
+    return -1;
+  }
+  std::vector<char *> plain_args;
+  for (int i = 0; i < argc; ++i) {
+    plain_args.emplace_back(argv[i]);
+  }
+  plain_args.emplace_back(nullptr);
 //	plain_args[0] = "unrar";
-	execvp("unrar", plain_args.data());
+  execvp("unrar", plain_args.data());
 
 #ifdef HAVE_LIBARCHIVE
-	fprintf(stderr, "'unrar' tool not found, falling back to libarchive\n");
+  fprintf(stderr, "'unrar' tool not found, falling back to libarchive\n");
 
-	try {
-		AutoArgs la_args;
-		la_args.Add("libarch");
-		switch (argv[1][0]) {
-			case 'x': la_args.Add("X"); break;
-			case 'e': la_args.Add("x"); break;
-			case 't': la_args.Add("t"); break;
-			default:
-				fprintf(stderr, "Bad argv[1]: '%s'\n", argv[1]);
-				return -1;
-		}
+  try {
+    AutoArgs la_args;
+    la_args.Add("libarch");
+    switch (argv[1][0]) {
+    case 'x':
+      la_args.Add("X");
+      break;
+    case 'e':
+      la_args.Add("x");
+      break;
+    case 't':
+      la_args.Add("t");
+      break;
+    default:
+      fprintf(stderr, "Bad argv[1]: '%s'\n", argv[1]);
+      return -1;
+    }
 
-		int i;
+    int i;
 
-		std::string tmp;
-		for (i = 1; i < argc; ++i) {
-			if (strcmp(argv[i], "--") == 0) {
-				++i;
-				break;
-			}
-			if (strncmp(argv[i], "-p", 2) == 0) {
-				tmp = "-pwd=";
-				tmp+= &argv[i][2];
-				la_args.Add(tmp.c_str());
-			}
-			if (strncmp(argv[i], "-ap", 3) == 0) {
-				tmp = "-@=";
-				tmp+= &argv[i][3];
-				la_args.Add(tmp.c_str());
-			}
-			if (argv[i][0] == '-' && argv[i][1] >= '0' && argv[i][1] <= '9' && !argv[i][2]) {
-				la_args.Add(argv[i]);
-			}
-		}
-		la_args.Add("--");
+    std::string tmp;
+    for (i = 1; i < argc; ++i) {
+      if (strcmp(argv[i], "--") == 0) {
+        ++i;
+        break;
+      }
+      if (strncmp(argv[i], "-p", 2) == 0) {
+        tmp = "-pwd=";
+        tmp+= &argv[i][2];
+        la_args.Add(tmp.c_str());
+      }
+      if (strncmp(argv[i], "-ap", 3) == 0) {
+        tmp = "-@=";
+        tmp+= &argv[i][3];
+        la_args.Add(tmp.c_str());
+      }
+      if (argv[i][0] == '-' && argv[i][1] >= '0' && argv[i][1] <= '9' && !argv[i][2]) {
+        la_args.Add(argv[i]);
+      }
+    }
+    la_args.Add("--");
 
-		if (i + 1 >= argc) {
-			fprintf(stderr, "Nothing to extract\n");
-			return 0;
-		}
+    if (i + 1 >= argc) {
+      fprintf(stderr, "Nothing to extract\n");
+      return 0;
+    }
 
-		la_args.Add(argv[i], 2);
-		++i;
+    la_args.Add(argv[i], 2);
+    ++i;
 
-		if (i + 1 == argc && argv[i][0] == '@') {
-			std::ifstream favis(&argv[i][1]);
-			if (!favis.is_open()) {
-				fprintf(stderr, "Can't open '%s'\n", &argv[i][1]);
-				return 1;
-			}
-			std::string line;
-			while (std::getline(favis, line)) {
-				StrTrimRight(line, "\r\n");
-				if (!line.empty()) {
-					la_args.Add(line.c_str());
-				}
-			}
-		} else for (;i < argc; ++i) {
-			la_args.Add(argv[i]);
-		}
+    if (i + 1 == argc && argv[i][0] == '@') {
+      std::ifstream favis(&argv[i][1]);
+      if (!favis.is_open()) {
+        fprintf(stderr, "Can't open '%s'\n", &argv[i][1]);
+        return 1;
+      }
+      std::string line;
+      while (std::getline(favis, line)) {
+        StrTrimRight(line, "\r\n");
+        if (!line.empty()) {
+          la_args.Add(line.c_str());
+        }
+      }
+    } else for (; i < argc; ++i) {
+        la_args.Add(argv[i]);
+      }
 
-		return libarch_main((int)la_args.size(), la_args.data());
+    return libarch_main((int)la_args.size(), la_args.data());
 
-	} catch (std::exception &e) {
-		fprintf(stderr, "%s: %s\n", __FUNCTION__, e.what());
-		return -1;
-	}
+  } catch (std::exception &e) {
+    fprintf(stderr, "%s: %s\n", __FUNCTION__, e.what());
+    return -1;
+  }
 #else
-	fprintf(stderr, "Please install 'unrar' tool\n");
-	return -1;
+  fprintf(stderr, "Please install 'unrar' tool\n");
+  return -1;
 #endif
 }

--- a/python/.editorconfig
+++ b/python/.editorconfig
@@ -3,3 +3,6 @@ indent_style = space
 
 [*.sh]
 indent_style = tab
+
+[*.hlf]
+indent_size = 2

--- a/tmppanel/.editorconfig
+++ b/tmppanel/.editorconfig
@@ -1,3 +1,6 @@
 [*]
 indent_style = space
 indent_size = 2
+
+[CMakeLists.txt]
+indent_size = 4


### PR DESCRIPTION
 It's default styling is 2 spaces, so let's make exclusions only for ha sources (as it is imported code) and libarchive wrapper (as it is written from scratch).