### PR TITLE
Fix double Ctrl+non_latin_key events

### DIFF
--- a/WinPort/src/Backend/WX/wxMain.cpp
+++ b/WinPort/src/Backend/WX/wxMain.cpp
@@ -1167,7 +1167,7 @@ void WinPortPanel::OnKeyDown( wxKeyEvent& event )
 		event.ControlDown() &&
 		ir.Event.KeyEvent.wVirtualKeyCode &&
 		((ir.Event.KeyEvent.wVirtualKeyCode < 'A') || (ir.Event.KeyEvent.wVirtualKeyCode > 'Z')) &&
-		(event.GetUnicodeKey() > 127)
+		(event.GetKeyCode() == 0)
 	) {
 		// ctrl+non_latin_letter what do not have menu shortcut, like ctrl+">"
 		g_winport_con_in->Enqueue(&ir, 1);


### PR DESCRIPTION
rawkeyflags trick should be only applied then keycode is zero