### PR TITLE
Better key_code detection

### DIFF
--- a/WinPort/src/Backend/WX/wxMain.cpp
+++ b/WinPort/src/Backend/WX/wxMain.cpp
@@ -1167,7 +1167,7 @@ void WinPortPanel::OnKeyDown( wxKeyEvent& event )
 		event.ControlDown() &&
 		ir.Event.KeyEvent.wVirtualKeyCode &&
 		((ir.Event.KeyEvent.wVirtualKeyCode < 'A') || (ir.Event.KeyEvent.wVirtualKeyCode > 'Z')) &&
-		(event.GetUnicodeKey() > 127)
+		(event.GetKeyCode() == 0)
 	) {
 		// ctrl+non_latin_letter what do not have menu shortcut, like ctrl+">"
 		g_winport_con_in->Enqueue(&ir, 1);

--- a/WinPort/src/Backend/WX/wxMain.cpp
+++ b/WinPort/src/Backend/WX/wxMain.cpp
@@ -1167,7 +1167,7 @@ void WinPortPanel::OnKeyDown( wxKeyEvent& event )
 		event.ControlDown() &&
 		ir.Event.KeyEvent.wVirtualKeyCode &&
 		((ir.Event.KeyEvent.wVirtualKeyCode < 'A') || (ir.Event.KeyEvent.wVirtualKeyCode > 'Z')) &&
-		(event.GetKeyCode() == 0)
+		(!event.GetKeyCode())
 	) {
 		// ctrl+non_latin_letter what do not have menu shortcut, like ctrl+">"
 		g_winport_con_in->Enqueue(&ir, 1);

--- a/WinPort/src/Backend/WX/wxMain.cpp
+++ b/WinPort/src/Backend/WX/wxMain.cpp
@@ -1167,7 +1167,7 @@ void WinPortPanel::OnKeyDown( wxKeyEvent& event )
 		event.ControlDown() &&
 		ir.Event.KeyEvent.wVirtualKeyCode &&
 		((ir.Event.KeyEvent.wVirtualKeyCode < 'A') || (ir.Event.KeyEvent.wVirtualKeyCode > 'Z')) &&
-		(!event.GetKeyCode())
+		(event.GetUnicodeKey() > 127)
 	) {
 		// ctrl+non_latin_letter what do not have menu shortcut, like ctrl+">"
 		g_winport_con_in->Enqueue(&ir, 1);


### PR DESCRIPTION
The previous attempt to detect key_code could behave incorrectly if the system has Latin keyboard layouts other than English. For example, on the German keyboard layout, the keys like `;` or `'` are placed differently from English one, also do `z` and `y` keys.

So I modified the code so that the detection of key_code will only work if the system has English keyboard layout installed, and only English keyboard layout would be used for detection.

Better approach would be to use xkbcommon lib (as it allows to do key mapping using keyboard layouts not enabled system wide; [example](https://github.com/wxWidgets/wxWidgets/issues/23379#issuecomment-1488563133)), but it is one more dependency so we probably do not want it.
