### PR TITLE
fix ttyxi module headers

### DIFF
--- a/WinPort/src/Backend/TTY/TTYX/TTYX.cpp
+++ b/WinPort/src/Backend/TTY/TTYX/TTYX.cpp
@@ -8,8 +8,8 @@
 #include <X11/Xlib.h>
 #include <X11/Xatom.h>
 #include <X11/keysym.h>
+#include <X11/XKBlib.h>
 #ifdef TTYXI
-# include <X11/XKBlib.h>
 # include <X11/extensions/XInput2.h>
 #endif
 


### PR DESCRIPTION
`X11/XKBlib.h` is part of x11-dev, so can be safely moved out of `#ifdef TTYXI`