### PR TITLE
python in virtual env

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -452,45 +452,49 @@ else()
         " COMPONENT system)
 endif()
 
-if (DEFINED PYTHON AND PYTHON)
-    find_package(PythonLibs 3.0)
-
-    if(PYTHONLIBS_FOUND)
-        find_program (PYTHON3 NAMES python3)
-        if(PYTHON3)
-            message(STATUS "PYTHON plugin enabled")
-            add_subdirectory (python)
-        else()
-            message(WARNING "${ColorRed}PYTHON plugin disabled due to missing python3 ${ColorNormal}")
-        endif ()
-    else()
-        message(WARNING "${ColorRed}PYTHON plugin disabled due to Python libraries not found${ColorNormal}")
-    endif()
-
-    install(CODE "
-        execute_process(COMMAND echo Python: preparing virtual environment)
-        " COMPONENT system)
-    install(CODE "
-        execute_process(COMMAND ${PYTHON3} -m venv --system-site-packages ${CMAKE_INSTALL_PREFIX}/lib/far2l/Plugins/python/plug/python)
-        " COMPONENT system)
-    install(CODE "
-        execute_process(COMMAND echo Python: installing packages)
-        " COMPONENT system)
-    install(CODE "
-        execute_process(COMMAND ${CMAKE_INSTALL_PREFIX}/lib/far2l/Plugins/python/plug/python/bin/python -m pip install cffi debugpy)
-        " COMPONENT system)
-
+if (DEFINED VIRTUAL_PYTHON)
+    message(STATUS "PYTHON plugin with interpreter from virtualenv enabled")
+    add_subdirectory (python)
     # Copy this explicitly cuz generic copier command excludes 'far2l'
     install(DIRECTORY "${INSTALL_DIR}/Plugins/python/plug/far2l"
         DESTINATION "share/far2l/Plugins/python/plug/" USE_SOURCE_PERMISSIONS
         COMPONENT base FILES_MATCHING
         PATTERN "*")
-
 else()
-    message(STATUS "${ColorRed}PYTHON plugin disabled, use -DPYTHON=yes if you need it${ColorNormal}")
-    install(CODE "
-        execute_process(COMMAND rm -f ${CMAKE_INSTALL_PREFIX}/lib/far2l/Plugins/python/plug/python.far-plug-wide)
-        " COMPONENT system)
+    if (DEFINED PYTHON AND PYTHON)
+        find_package(Python3 COMPONENTS Interpreter Development)
+
+        if(Python3_FOUND AND Python3_Development_FOUND)
+            message(STATUS "PYTHON plugin enabled")
+            add_subdirectory (python)
+            install(CODE "
+                execute_process(COMMAND echo Python: preparing virtual environment)
+                " COMPONENT system)
+            install(CODE "
+                execute_process(COMMAND ${PYTHON3} -m venv --system-site-packages ${CMAKE_INSTALL_PREFIX}/lib/far2l/Plugins/python/plug/python)
+                " COMPONENT system)
+            install(CODE "
+                execute_process(COMMAND echo Python: installing packages)
+                " COMPONENT system)
+            install(CODE "
+                execute_process(COMMAND ${CMAKE_INSTALL_PREFIX}/lib/far2l/Plugins/python/plug/python/bin/python -m pip install cffi debugpy)
+                " COMPONENT system)
+
+            # Copy this explicitly cuz generic copier command excludes 'far2l'
+            install(DIRECTORY "${INSTALL_DIR}/Plugins/python/plug/far2l"
+                DESTINATION "share/far2l/Plugins/python/plug/" USE_SOURCE_PERMISSIONS
+                COMPONENT base FILES_MATCHING
+                PATTERN "*")
+        else()
+            message(WARNING "${ColorRed}PYTHON plugin disabled due to missing python3 environment${ColorNormal}")
+        endif ()
+
+    else()
+        message(STATUS "${ColorRed}PYTHON plugin disabled, use -DPYTHON=yes if you need it${ColorNormal}")
+        install(CODE "
+            execute_process(COMMAND rm -f ${CMAKE_INSTALL_PREFIX}/lib/far2l/Plugins/python/plug/python.far-plug-wide)
+            " COMPONENT system)
+    endif()
 endif()
 
 if (NOT DEFINED SIMPLEINDENT OR SIMPLEINDENT)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -9,9 +9,8 @@ ${CMAKE_CURRENT_BINARY_DIR}/incpy/far2lcffi.py
 if (DEFINED VIRTUAL_PYTHON)
     message(STATUS "VIRTUAL env interpreter=${VIRTUAL_PYTHON}")
     message(STATUS "VIRTUAL env interpreter version=${VIRTUAL_PYTHON_VERSION}")
+    # for finding adequate python package
     set(Python3_EXECUTABLE ${VIRTUAL_PYTHON})
-else()
-    set(VIRTUAL_PYTHON_VERSION 0)
 endif()
 
 find_package(Python3 COMPONENTS Interpreter Development)        # find Python interpreter and library
@@ -41,7 +40,12 @@ if (DEFINED VIRTUAL_PYTHON)
     target_compile_definitions(python PRIVATE
         -DVIRTUAL_PYTHON="${VIRTUAL_PYTHON}"
     )
+    set(Python_EXECUTABLE ${VIRTUAL_PYTHON})
+else()
+    set(VIRTUAL_PYTHON_VERSION 0)
+    set(Python_EXECUTABLE ${Python3_EXECUTABLE})
 endif()
+
 
 target_include_directories(python PRIVATE .)
 target_include_directories(python PRIVATE ../WinPort)
@@ -76,5 +80,5 @@ add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/incpy/far2lcffi.py
     DEPENDS ../WinPort/windows.h
     DEPENDS ../WinPort/WinCompat.h
     DEPENDS ../WinPort/WinPort.h
-    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/src/prebuild.sh "${CMAKE_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}" "${VIRTUAL_PYTHON_VERSION}" "${Python3_EXECUTABLE}" "${CMAKE_C_COMPILER} ${CMAKE_C_FLAGS}"
+    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/src/prebuild.sh "${CMAKE_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}" "${VIRTUAL_PYTHON_VERSION}" "${Python_EXECUTABLE}" "${CMAKE_C_COMPILER} ${CMAKE_C_FLAGS}"
 )

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -6,9 +6,15 @@ src/python.cpp
 ${CMAKE_CURRENT_BINARY_DIR}/incpy/far2lcffi.py
 )
 
-#find_package(PythonLibs 3.0)
-find_package(Python3 COMPONENTS Interpreter Development)        # find Python interpreter and library
+if (DEFINED VIRTUAL_PYTHON)
+    message(STATUS "VIRTUAL env interpreter=${VIRTUAL_PYTHON}")
+    message(STATUS "VIRTUAL env interpreter version=${VIRTUAL_PYTHON_VERSION}")
+    set(Python3_EXECUTABLE ${VIRTUAL_PYTHON})
+else()
+    set(VIRTUAL_PYTHON_VERSION 0)
+endif()
 
+find_package(Python3 COMPONENTS Interpreter Development)        # find Python interpreter and library
 message(STATUS "Python3_VERSION = ${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}")
 message(STATUS "Python3_EXECUTABLE = ${Python3_EXECUTABLE}")
 message(STATUS "Python3_STDLIB     = ${Python3_STDLIB}")
@@ -31,6 +37,11 @@ target_compile_definitions(python PRIVATE
     -DPYTHON_LIBRARY="${Python3_LIBRARIES}"
     -DPYTHON_VERSION="${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}"
 )
+if (DEFINED VIRTUAL_PYTHON)
+    target_compile_definitions(python PRIVATE
+        -DVIRTUAL_PYTHON="${VIRTUAL_PYTHON}"
+    )
+endif()
 
 target_include_directories(python PRIVATE .)
 target_include_directories(python PRIVATE ../WinPort)
@@ -47,9 +58,15 @@ add_custom_command(TARGET python POST_BUILD
     DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/configs
     DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/far2lcffi.py
     COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/configs" "${INSTALL_DIR}/Plugins/python"
-    COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_BINARY_DIR}/python" "${INSTALL_DIR}/Plugins/python/plug/python"
     COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_BINARY_DIR}/incpy/far2lcffi.py" "${INSTALL_DIR}/Plugins/python/plug/far2l"
 )
+if (NOT DEFINED VIRTUAL_PYTHON)
+    add_custom_command(TARGET python POST_BUILD
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/configs
+        DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/far2lcffi.py
+        COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_BINARY_DIR}/python" "${INSTALL_DIR}/Plugins/python/plug/python"
+    )
+endif()
 
 add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/incpy/far2lcffi.py
     DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/src/pythongen.py
@@ -59,5 +76,5 @@ add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/incpy/far2lcffi.py
     DEPENDS ../WinPort/windows.h
     DEPENDS ../WinPort/WinCompat.h
     DEPENDS ../WinPort/WinPort.h
-    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/src/prebuild.sh "${CMAKE_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}" "${Python3_EXECUTABLE}" "${CMAKE_C_COMPILER} ${CMAKE_C_FLAGS}"
+    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/src/prebuild.sh "${CMAKE_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}" "${VIRTUAL_PYTHON_VERSION}" "${Python3_EXECUTABLE}" "${CMAKE_C_COMPILER} ${CMAKE_C_FLAGS}"
 )

--- a/python/src/python.cpp
+++ b/python/src/python.cpp
@@ -21,7 +21,7 @@
 static struct PluginStartupInfo Info;
 static FARSTANDARDFUNCTIONS FSF;
 
-// #define PYPLUGIN_DEBUGLOG "/tmp/far2.py.log"
+//#define PYPLUGIN_DEBUGLOG "/tmp/far2.py.log"
 // #define PYPLUGIN_DEBUGLOG "" /* to stderr */
 // #define PYPLUGIN_THREADED
 // #define PYPLUGIN_MEASURE_STARTUP
@@ -141,8 +141,12 @@ public:
         }
 
         std::wstring progname;
+#ifdef VIRTUAL_PYTHON
+        StrMB2Wide(VIRTUAL_PYTHON, progname);
+#else
         StrMB2Wide(pluginPath, progname);
         progname += L"/python/bin/python";
+#endif
 
         PYTHON_LOG("pluginpath: %s, python library used:%s, progname: %ls\n", pluginPath.c_str(), PYTHON_LIBRARY, progname.c_str());
 


### PR DESCRIPTION
new cmake parameters:
VIRTUAL_PYTHON=-DVIRTUAL_PYTHON=/devel/bin/python3/bin/python
VIRTUAL_PYTHON_VERSION=-DVIRTUAL_PYTHON_VERSION=3.8

VIRTUAL_PYTHON - which python interpreter use
VIRTUAL_PYTHON_VERSION - which python version to use when finding the python environment configuration in cmake, the version must match the version of the indicated interpreter in the previous variable

version is specified as major.minor form, ie. for python 3.8.10 it's 3.8
