### PR TITLE
No redundant recompile on git revision change any more

### DIFF
--- a/far2l/CMakeLists.txt
+++ b/far2l/CMakeLists.txt
@@ -2,14 +2,31 @@ project(far2l)
 
 add_subdirectory (bootstrap)
 
+function(int_to_hex NUMBER HEX_STRING)
+    set(HEX_DIGITS "0" "1" "2" "3" "4" "5" "6" "7" "8" "9" "A" "B" "C" "D" "E" "F")
+    set(RESULT "")
+    while(NOT ${NUMBER} EQUAL 0)
+        math(EXPR DIGIT_INDEX "${NUMBER} % 16")
+        math(EXPR NUMBER "${NUMBER} / 16")
+        list(GET HEX_DIGITS ${DIGIT_INDEX} DIGIT)
+        set(RESULT "${DIGIT}${RESULT}")
+    endwhile()
+
+    string(LENGTH "${RESULT}" RESULT_LENGTH)
+    while(RESULT_LENGTH LESS 4)
+        set(RESULT "0${RESULT}")
+        string(LENGTH "${RESULT}" RESULT_LENGTH)
+    endwhile()
+
+    set(${HEX_STRING} "${RESULT}" PARENT_SCOPE)
+endfunction()
+
 set(BOOTSTRAP "${PROJECT_BINARY_DIR}/bootstrap")
 file(WRITE "${BOOTSTRAP}/farversion.cpp" "#include \"headers.hpp\"\n")
-string(ASCII ${VERSION_MAJOR} ASCII_MAJOR)
-string(HEX ${ASCII_MAJOR} HEX_MAJOR)
-string(ASCII ${VERSION_MINOR} ASCII_MINOR)
-string(HEX ${ASCII_MINOR} HEX_MINOR)
+int_to_hex(${VERSION_MAJOR} HEX_MAJOR)
+int_to_hex(${VERSION_MINOR} HEX_MINOR)
 file(APPEND "${BOOTSTRAP}/farversion.cpp"
-    "uint32_t FAR_VERSION __attribute__((used)) = 0x00${HEX_MAJOR}00${HEX_MINOR};\n")
+    "uint32_t FAR_VERSION __attribute__((used)) = 0x${HEX_MAJOR}${HEX_MINOR};\n")
 file(APPEND "${BOOTSTRAP}/farversion.cpp"
     "const char *FAR_BUILD __attribute__((used)) = \"${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}\";\n")
 

--- a/far2l/CMakeLists.txt
+++ b/far2l/CMakeLists.txt
@@ -30,8 +30,13 @@ file(APPEND "${BOOTSTRAP}/farversion.cpp"
 file(APPEND "${BOOTSTRAP}/farversion.cpp"
     "const char *FAR_BUILD __attribute__((used)) = \"${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}\";\n")
 
+string(TIMESTAMP CURRENT_YEAR "%Y")
+file(WRITE "${BOOTSTRAP}/copyright.cpp"
+    "const char *Copyright __attribute__((used)) = \"FAR2L, version ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH} ${CMAKE_SYSTEM_NAME} ${CMAKE_SYSTEM_PROCESSOR}\\nCopyright (C) 1996-2000 Eugene Roshal, Copyright (C) 2000-2016 Far Group, Copyright (C) 2016-${CURRENT_YEAR} Far People\";\n")
+
 set(SOURCES
 ${BOOTSTRAP}/farversion.cpp
+${BOOTSTRAP}/copyright.cpp
 src/cache.cpp
 src/clipboard.cpp
 src/cmdline.cpp

--- a/far2l/CMakeLists.txt
+++ b/far2l/CMakeLists.txt
@@ -2,7 +2,19 @@ project(far2l)
 
 add_subdirectory (bootstrap)
 
+set(BOOTSTRAP "${PROJECT_BINARY_DIR}/bootstrap")
+file(WRITE "${BOOTSTRAP}/farversion.cpp" "#include \"headers.hpp\"\n")
+string(ASCII ${VERSION_MAJOR} ASCII_MAJOR)
+string(HEX ${ASCII_MAJOR} HEX_MAJOR)
+string(ASCII ${VERSION_MINOR} ASCII_MINOR)
+string(HEX ${ASCII_MINOR} HEX_MINOR)
+file(APPEND "${BOOTSTRAP}/farversion.cpp"
+    "uint32_t FAR_VERSION __attribute__((used)) = 0x00${HEX_MAJOR}00${HEX_MINOR};\n")
+file(APPEND "${BOOTSTRAP}/farversion.cpp"
+    "const char *FAR_BUILD __attribute__((used)) = \"${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}\";\n")
+
 set(SOURCES
+${BOOTSTRAP}/farversion.cpp
 src/cache.cpp
 src/clipboard.cpp
 src/cmdline.cpp

--- a/far2l/CMakeLists.txt
+++ b/far2l/CMakeLists.txt
@@ -29,14 +29,12 @@ file(APPEND "${BOOTSTRAP}/farversion.cpp"
     "uint32_t FAR_VERSION __attribute__((used)) = 0x${HEX_MAJOR}${HEX_MINOR};\n")
 file(APPEND "${BOOTSTRAP}/farversion.cpp"
     "const char *FAR_BUILD __attribute__((used)) = \"${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}\";\n")
-
 string(TIMESTAMP CURRENT_YEAR "%Y")
-file(WRITE "${BOOTSTRAP}/copyright.cpp"
+file(APPEND "${BOOTSTRAP}/farversion.cpp"
     "const char *Copyright __attribute__((used)) = \"FAR2L, version ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH} ${CMAKE_SYSTEM_NAME} ${CMAKE_SYSTEM_PROCESSOR}\\nCopyright (C) 1996-2000 Eugene Roshal, Copyright (C) 2000-2016 Far Group, Copyright (C) 2016-${CURRENT_YEAR} Far People\";\n")
 
 set(SOURCES
 ${BOOTSTRAP}/farversion.cpp
-${BOOTSTRAP}/copyright.cpp
 src/cache.cpp
 src/clipboard.cpp
 src/cmdline.cpp

--- a/far2l/bootstrap/CMakeLists.txt
+++ b/far2l/bootstrap/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required (VERSION 3.0.2)
 
+# copyright.inc and farversion.inc are not used any more,
+# files with relevant constants are generated in far2l/CMakeLists.txt now
+
 add_custom_target(bootstrap 
     DEPENDS copyright.inc farversion.inc farlang.templ lang.inc
 )

--- a/far2l/bootstrap/scripts/farlng.pl
+++ b/far2l/bootstrap/scripts/farlng.pl
@@ -15,7 +15,8 @@ if (!defined($out_dir) || $out_dir eq '') {
 my $feed;
 open($feed, '<', $feed_file) or die "$feed_file: $!";
 
-my $hpp_file = Unquote(FeedExpression(1));
+my $hpp_file_orig = Unquote(FeedExpression(1));
+my $hpp_file = "lang.tmp";
 my $langs_count = FeedExpression(1);
 die "No languages in $feed_file" if $langs_count <= 0;
 die "No HPP file in $feed_file" if $hpp_file eq '';
@@ -76,6 +77,10 @@ for my $lang (@langs) {
 	close($lang);
 }
 
+if (!(-e $hpp_file_orig) || (`diff $hpp_file_orig $hpp_file`)) {
+    system("cp -f $hpp_file $hpp_file_orig");
+    system("rm -f $hpp_file");
+}
 
 #############################################
 

--- a/far2l/src/console/constitle.cpp
+++ b/far2l/src/console/constitle.cpp
@@ -42,6 +42,8 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "console.hpp"
 #include <stdarg.h>
 
+#include "farversion.h"
+
 bool ConsoleTitle::TitleModified = false;
 DWORD ConsoleTitle::ShowTime = 0;
 

--- a/far2l/src/ctrlobj.cpp
+++ b/far2l/src/ctrlobj.cpp
@@ -191,7 +191,6 @@ void ControlObject::ShowStartupBanner(LPCWSTR EmergencyMsg)
 
 	char Xor = 17;
 	std::string tmp_mb;
-	//for (const char *p = FAR_BUILD; *p; ++p) {
 	for (const char *p = Copyright; *p; ++p) {
 		//const char c = (*p & 0x7f) ^ Xor;
 		//Xor^= c;

--- a/far2l/src/ctrlobj.cpp
+++ b/far2l/src/ctrlobj.cpp
@@ -52,6 +52,8 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "dirmix.hpp"
 #include "console.hpp"
 
+#include "farversion.h"
+
 ControlObject *CtrlObject;
 
 ControlObject::ControlObject()
@@ -189,9 +191,11 @@ void ControlObject::ShowStartupBanner(LPCWSTR EmergencyMsg)
 
 	char Xor = 17;
 	std::string tmp_mb;
+	//for (const char *p = FAR_BUILD; *p; ++p) {
 	for (const char *p = Copyright; *p; ++p) {
-		const char c = (*p & 0x7f) ^ Xor;
-		Xor^= c;
+		//const char c = (*p & 0x7f) ^ Xor;
+		//Xor^= c;
+		const char c = *p;
 		if (c == '\n') {
 			Lines.emplace_back(tmp_mb);
 			tmp_mb.clear();

--- a/far2l/src/farversion.h
+++ b/far2l/src/farversion.h
@@ -3,6 +3,8 @@
 extern const uint32_t FAR_VERSION;
 extern const char *FAR_BUILD;
 
+extern const char *Copyright;
+
 #if defined(__x86_64__)
 #define FAR_PLATFORM "x64"
 #elif defined(__ppc64__)

--- a/far2l/src/global.cpp
+++ b/far2l/src/global.cpp
@@ -33,16 +33,6 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "headers.hpp"
 
-/*
-	$ 29.06.2000 tran
-	берем char *CopyRight из inc файла
-*/
-//#include "copyright.h"
-
-/*
-	$ 07.12.2000 SVS
-	+ Версия берется из файла farversion.inc
-*/
 #include "farversion.h"
 
 // идет процесс назначения клавиши в макросе?

--- a/far2l/src/global.cpp
+++ b/far2l/src/global.cpp
@@ -37,7 +37,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	$ 29.06.2000 tran
 	берем char *CopyRight из inc файла
 */
-#include "bootstrap/copyright.inc"
+//#include "copyright.h"
 
 /*
 	$ 07.12.2000 SVS

--- a/far2l/src/global.cpp
+++ b/far2l/src/global.cpp
@@ -43,7 +43,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	$ 07.12.2000 SVS
 	+ Версия берется из файла farversion.inc
 */
-#include "bootstrap/farversion.inc"
+#include "farversion.h"
 
 // идет процесс назначения клавиши в макросе?
 BOOL IsProcessAssignMacroKey = FALSE;

--- a/far2l/src/global.hpp
+++ b/far2l/src/global.hpp
@@ -34,8 +34,6 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-//#include "farversion.h"
-
 extern clock_t StartIdleTime;
 
 extern int WaitInMainLoop;

--- a/far2l/src/global.hpp
+++ b/far2l/src/global.hpp
@@ -34,7 +34,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "farversion.h"
+//#include "farversion.h"
 
 extern clock_t StartIdleTime;
 

--- a/far2l/src/plug/PluginA.cpp
+++ b/far2l/src/plug/PluginA.cpp
@@ -70,6 +70,8 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "wrap.cpp"
 #include <KeyFileHelper.h>
 
+#include "farversion.h"
+
 static const char *szCache_Preload = "Preload";
 static const char *szCache_Preopen = "Preopen";
 static const char *szCache_SysID = "SysID";

--- a/far2l/src/plug/PluginW.cpp
+++ b/far2l/src/plug/PluginW.cpp
@@ -67,6 +67,8 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <vector>
 #include <KeyFileHelper.h>
 
+#include "farversion.h"
+
 static const char *szCache_Preload = "Preload";
 static const char *szCache_Preopen = "Preopen";
 static const char *szCache_SysID = "SysID";

--- a/far2l/src/plug/plugapi.cpp
+++ b/far2l/src/plug/plugapi.cpp
@@ -72,6 +72,8 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "console.hpp"
 #include "InterThreadCall.hpp"
 
+#include "farversion.h"
+
 wchar_t *WINAPI FarItoa(int value, wchar_t *string, int radix)
 {
 	if (string)

--- a/far2l/src/plug/plugins.cpp
+++ b/far2l/src/plug/plugins.cpp
@@ -65,6 +65,8 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <KeyFileHelper.h>
 #include <crc64.h>
 
+#include "farversion.h"
+
 const char *FmtDiskMenuStringD = "DiskMenuString%d";
 const char *FmtPluginMenuStringD = "PluginMenuString%d";
 const char *FmtPluginConfigStringD = "PluginConfigString%d";


### PR DESCRIPTION
see https://github.com/elfmz/far2l/issues/1515#issuecomment-1451851021

NB! Copyright string was encoded using XOR since at least version 1.64 (see ctrlobj.cpp [in 1.64](https://github.com/FarGroup/FarManager/releases/tag/release%2F1.64)). Probably the reason was to prevent from removing or changing copyright string in binary file. We probably do not need such protection currently, so I do not reproduced it in new copyright string generation method.
