### PR TITLE
python and pointers

### DIFF
--- a/python/configs/plug/far2l/pluginmanager.py
+++ b/python/configs/plug/far2l/pluginmanager.py
@@ -191,7 +191,8 @@ class PluginManager:
         Info.PluginMenuStringsNumber = len(self._MenuItems)
         Info.PluginConfigStrings = self.ConfigItems
         Info.PluginConfigStringsNumber = len(self._ConfigItems)
-        Info.CommandPrefix = self.s2f("py")
+        self._commandprefix= self.s2f("py")
+        Info.CommandPrefix = self._commandprefix
 
     def OpenPlugin(self, OpenFrom, Item):
         log.debug("OpenPlugin({0}, {1})".format(OpenFrom, Item))


### PR DESCRIPTION
probably the most common problem with this plugin - pointers used after exiting the python procedure
self.s2f returns a pointer to the buffer that must survive the exit from python to far2l, hence the need to hold such a buffer in the variables assigned to self