### PR TITLE
Space in dialog windows after title before border line & All Save history config in one place

### DIFF
--- a/far2l/src/cfg/config.cpp
+++ b/far2l/src/cfg/config.cpp
@@ -167,6 +167,7 @@ void SystemSettings()
 	Builder.AddTextAfter(InactivityExitTime, Msg::ConfigInactivityMinutes);
 	Builder.LinkFlags(InactivityExit, InactivityExitTime, DIF_DISABLE);
 
+	AddHistorySettings(Builder, Msg::ConfigSaveHistory, &Opt.SaveHistory, &Opt.HistoryCount);
 	AddHistorySettings(Builder, Msg::ConfigSaveFoldersHistory, &Opt.SaveFoldersHistory,
 			&Opt.FoldersHistoryCount);
 	AddHistorySettings(Builder, Msg::ConfigSaveViewHistory, &Opt.SaveViewHistory, &Opt.ViewHistoryCount);

--- a/far2l/src/dialog.cpp
+++ b/far2l/src/dialog.cpp
@@ -1730,8 +1730,13 @@ void Dialog::ShowDialog(unsigned ID)
 					TruncStrFromEnd(strStr, CW - 2);	// 5 ???
 					LenText = LenStrItem(I, strStr);
 
-					if (LenText < CW - 2) {
+					if (LenText < CW - 2 && !strStr.Begins(L' ') ) {
 						strStr.Insert(0, L' ');
+						LenText = LenStrItem(I, strStr);
+					}
+
+					if (LenText < CW - 2 && !strStr.Ends(L' ') ) { // пробел после текста заголовка и рамкой
+						strStr.Append(L' ');
 						LenText = LenStrItem(I, strStr);
 					}
 


### PR DESCRIPTION
1) Was "=== Title===", now "=== Title ==="

2) Copy "Save commands history" to "System settings" config dialog.
Now all "Save commands history", "Save folders history" & "Save view and edit history"
can be easily found together one place.