### PR TITLE
1) History commands by Alt-F8: fix save directory from panel by Enter & 2) Owner and Group Small Fix

### DIFF
--- a/far2l/bootstrap/scripts/FarEng.hlf.m4
+++ b/far2l/bootstrap/scripts/FarEng.hlf.m4
@@ -2978,7 +2978,7 @@ codepage back. Клавиша #F4# позволяет изменять отоб�
 @CodePagesSet
 $ #ANSI and OEM codepage setting#
   Switchable by #F8# and #Shift-F8# OEM and ANSI code pages are defined based on the file
-  #~~/.config/far2l/cp# (firts line is #OEM#, second is #ANSI#)
+  #~~/.config/far2l/cp# (first line is #OEM#, second is #ANSI#)
   or, if its absence, by environment variable #LC_CTYPE#
 
 @EditCodePageNameDlg

--- a/far2l/src/filetype.cpp
+++ b/far2l/src/filetype.cpp
@@ -120,7 +120,7 @@ static int GetDescriptionWidth(ConfigReader &cfg_reader, const wchar_t *Name = n
 	- Убрал непонятный мне запрет на использование маски файлов типа "*.*"
 	(был когда-то, вроде, такой баг-репорт)
 */
-bool ProcessLocalFileTypes(const wchar_t *Name, int Mode, bool CanAddHistory)
+bool ProcessLocalFileTypes(const wchar_t *Name, int Mode, bool CanAddHistory, FARString &strCurDir)
 {
 	ConfigReader cfg_reader;
 	// RenumKeyRecord(FTS.Associations,FTS.TypeFmt,FTS.Type0);
@@ -250,7 +250,8 @@ bool ProcessLocalFileTypes(const wchar_t *Name, int Mode, bool CanAddHistory)
 				strCommand.LShift(1);
 			} else if (CanAddHistory && !(Opt.ExcludeCmdHistory & EXCLUDECMDHISTORY_NOTFARASS))		// AN
 			{
-				CtrlObject->CmdHistory->AddToHistory(strCommand);
+				//CtrlObject->CmdHistory->AddToHistory(strCommand);
+				CtrlObject->CmdHistory->AddToHistoryExtra(strCommand,strCurDir);
 			}
 
 			// ProcessOSAliases(strCommand);
@@ -293,21 +294,22 @@ bool ProcessLocalFileTypes(const wchar_t *Name, int Mode, bool CanAddHistory)
 	return true;
 }
 
-void ProcessGlobalFileTypes(const wchar_t *Name, bool RunAs, bool CanAddHistory)
+void ProcessGlobalFileTypes(const wchar_t *Name, bool RunAs, bool CanAddHistory, FARString &strCurDir)
 {
 	FARString strName(Name);
 	EscapeSpace(strName);
 	CtrlObject->CmdLine->ExecString(strName, true, true, false, false, RunAs);
 
 	if (CanAddHistory && !(Opt.ExcludeCmdHistory & EXCLUDECMDHISTORY_NOTWINASS)) {
-		CtrlObject->CmdHistory->AddToHistory(strName);
+		//CtrlObject->CmdHistory->AddToHistory(strName);
+		CtrlObject->CmdHistory->AddToHistoryExtra(strName,strCurDir);
 	}
 }
 
 /*
 	Используется для запуска внешнего редактора и вьювера
 */
-void ProcessExternal(const wchar_t *Command, const wchar_t *Name, bool CanAddHistory)
+void ProcessExternal(const wchar_t *Command, const wchar_t *Name, bool CanAddHistory, FARString &strCurDir)
 {
 	FARString strListName, strAnotherListName;
 	FARString strFullName;

--- a/far2l/src/filetype.hpp
+++ b/far2l/src/filetype.hpp
@@ -44,7 +44,7 @@ enum
 	FILETYPE_ALTEDIT		// Alt-F4
 };
 
-void ProcessGlobalFileTypes(const wchar_t *Name, bool RunAs, bool CanAddHistory);
-bool ProcessLocalFileTypes(const wchar_t *Name, int Mode, bool CanAddHistory);
-void ProcessExternal(const wchar_t *Command, const wchar_t *Name, bool CanAddHistory);
+void ProcessGlobalFileTypes(const wchar_t *Name, bool RunAs, bool CanAddHistory, FARString &strCurDir);
+bool ProcessLocalFileTypes(const wchar_t *Name, int Mode, bool CanAddHistory, FARString &strCurDir);
+void ProcessExternal(const wchar_t *Command, const wchar_t *Name, bool CanAddHistory, FARString &strCurDir);
 void EditFileTypes();

--- a/far2l/src/panels/filelist.cpp
+++ b/far2l/src/panels/filelist.cpp
@@ -1471,16 +1471,16 @@ int FileList::ProcessKey(int Key)
 						/* $ 02.08.2001 IS обработаем ассоциации для alt-f4 */
 
 						if (Key == KEY_ALTF4
-								&& ProcessLocalFileTypes(strFileName, FILETYPE_ALTEDIT, !PluginMode))
+								&& ProcessLocalFileTypes(strFileName, FILETYPE_ALTEDIT, !PluginMode, strCurDir))
 							Processed = TRUE;
 
 						else if (Key == KEY_F4
-								&& ProcessLocalFileTypes(strFileName, FILETYPE_EDIT, !PluginMode))
+								&& ProcessLocalFileTypes(strFileName, FILETYPE_EDIT, !PluginMode, strCurDir))
 							Processed = TRUE;
 
 						if (!Processed || Key == KEY_CTRLSHIFTF4) {
 							if (EnableExternal) {
-								ProcessExternal(Opt.strExternalEditor, strFileName, !PluginMode);
+								ProcessExternal(Opt.strExternalEditor, strFileName, !PluginMode, strCurDir);
 								Processed = TRUE;
 							} else {
 								FileEditor *ShellEditor = PluginMode
@@ -1526,16 +1526,16 @@ int FileList::ProcessKey(int Key)
 						/* $ 02.08.2001 IS обработаем ассоциации для alt-f3 */
 
 						if (Key == KEY_ALTF3
-								&& ProcessLocalFileTypes(strFileName, FILETYPE_ALTVIEW, !PluginMode))
+								&& ProcessLocalFileTypes(strFileName, FILETYPE_ALTVIEW, !PluginMode, strCurDir))
 							Processed = TRUE;
 
 						else if (Key == KEY_F3
-								&& ProcessLocalFileTypes(strFileName, FILETYPE_VIEW, !PluginMode))
+								&& ProcessLocalFileTypes(strFileName, FILETYPE_VIEW, !PluginMode, strCurDir))
 							Processed = TRUE;
 
 						if (!Processed || Key == KEY_CTRLSHIFTF3) {
 							if (EnableExternal) {
-								ProcessExternal(Opt.strExternalViewer, strFileName, !PluginMode);
+								ProcessExternal(Opt.strExternalViewer, strFileName, !PluginMode, strCurDir);
 								Processed = TRUE;
 							} else {
 								NamesList ViewList;
@@ -2266,7 +2266,7 @@ void FileList::ProcessEnter(bool EnableExec, bool SeparateWindow, bool EnableAss
 		}
 
 		if (EnableExec && SetCurPath() && !SeparateWindow
-				&& ProcessLocalFileTypes(strFileName, FILETYPE_EXEC, !PluginMode))		//?? is was var!
+				&& ProcessLocalFileTypes(strFileName, FILETYPE_EXEC, !PluginMode, strCurDir))		//?? is was var!
 		{
 			if (PluginMode)
 				QueueDeleteOnClose(strFileName);
@@ -2281,7 +2281,8 @@ void FileList::ProcessEnter(bool EnableExec, bool SeparateWindow, bool EnableAss
 			EnsurePathHasParentPrefix(strFileName);
 
 			if (!(Opt.ExcludeCmdHistory & EXCLUDECMDHISTORY_NOTPANEL) && !PluginMode)	// AN
-				CtrlObject->CmdHistory->AddToHistory(strFileName);
+				//CtrlObject->CmdHistory->AddToHistory(strFileName);
+				CtrlObject->CmdHistory->AddToHistoryExtra(strFileName, strCurDir);
 
 			CtrlObject->CmdLine->ExecString(strFileName, SeparateWindow, true, false, false, RunAs);
 
@@ -2293,7 +2294,7 @@ void FileList::ProcessEnter(bool EnableExec, bool SeparateWindow, bool EnableAss
 
 			if (EnableAssoc && !EnableExec &&		// не запускаем и не в отдельном окне,
 					!SeparateWindow &&				// следовательно это Ctrl-PgDn
-					ProcessLocalFileTypes(strFileName, FILETYPE_ALTEXEC, !PluginMode)) {
+					ProcessLocalFileTypes(strFileName, FILETYPE_ALTEXEC, !PluginMode, strCurDir)) {
 				if (PluginMode)
 					QueueDeleteOnClose(strFileName);
 
@@ -2306,7 +2307,7 @@ void FileList::ProcessEnter(bool EnableExec, bool SeparateWindow, bool EnableAss
 				//					if (SeparateWindow || Opt.UseRegisteredTypes)
 				{
 					SetCurPath();	// OpenFilePlugin can change current path
-					ProcessGlobalFileTypes(strFileName, RunAs, !PluginMode);
+					ProcessGlobalFileTypes(strFileName, RunAs, !PluginMode, strCurDir);
 				}
 
 				if (PluginMode)

--- a/far2l/src/setattr.cpp
+++ b/far2l/src/setattr.cpp
@@ -673,15 +673,23 @@ ListFromFile::ListFromFile(const char *filename, int SelCount)
 	if (SelCount >= 2)
 		Append(Msg::SetAttrOwnerMultiple);
 
+	// may be rewrite to obtain by getpwent() & getgrent() ???
+	// now direct reading from /etc/passwd or /etc/group
 	std::ifstream is;
 	is.open(filename);
 	if (is.is_open()) {
 		std::string str;
 		while (getline(is,str), !str.empty()) {
-			auto pos = str.find(':');
+			// remove comment (starting with '#') from string
+			auto pos = str.find('#');
 			if (pos != std::string::npos)
 				str.resize(pos);
-			Append(FARString(str).CPtr());
+			// ':' need be in string
+			pos = str.find(':');
+			if (pos != std::string::npos) {
+				str.resize(pos);
+				Append(FARString(str).CPtr()); // name always before first ':'
+			}
 		}
 		std::sort(Items.begin()+(SelCount<2 ? 0:1), Items.end(), Cmp);
 	}


### PR DESCRIPTION
1) **History commands by Alt-F8: fix save directory from panel by Enter**

Fix for #1618

2)  **Attributes dialog: Owner and Group Small Fix**

Fix after #1717

Some `/etc/passwd` and `/etc/group`
contain comments starting with '#'
and now fix to skip it.

Also skip lines witout ':'.

Now direct reading from `/etc/passwd` or `/etc/group`
May be rewrite to obtain by `getpwent()` & `getgrent()` ?

3)  **Help typo fix**