### PR TITLE
VMenu Title During Filtering - hide vmenu title only if (menu title + filter text) is wider than window

### DIFF
--- a/far2l/src/vmenu.cpp
+++ b/far2l/src/vmenu.cpp
@@ -1615,7 +1615,8 @@ void VMenu::DrawTitles()
 
 	if (!strDisplayTitle.IsEmpty() || bFilterEnabled) {
 		if (bFilterEnabled) {
-			if (bFilterLocked || strFilter.IsEmpty())
+			if (bFilterLocked || strFilter.IsEmpty()
+				|| (int)strDisplayTitle.GetLength() + 3 + (int)strFilter.GetLength() < MaxTitleLength )
 				strDisplayTitle+= L' ';
 			else
 				strDisplayTitle.Clear();


### PR DESCRIPTION
2/2 from #1415