### PR TITLE
fix __AES__ for old GCC

### DIFF
--- a/multiarc/src/formats/7z/C/AesOpt.c
+++ b/multiarc/src/formats/7z/C/AesOpt.c
@@ -26,7 +26,7 @@
       #endif
     #endif
   #elif defined(__GNUC__)
-    #if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 4)
+    #if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ > 8)
       #define USE_INTEL_AES
       #ifndef __AES__
         #define ATTRIB_AES __attribute__((__target__("aes")))


### PR DESCRIPTION
Fixed in GCC 4.8+ or some later version. Checked on COS7, GCC 4.8.5.

Details in sevenzin discussion:
https://sourceforge.net/p/sevenzip/discussion/45798/thread/0d673fcfaa/