### PR TITLE
minor readme improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ FreeBSD/MacOS (Cirrus CI): [![Cirrus](https://api.cirrus-ci.com/github/elfmz/far
 * libwxgtk3.0-gtk3-dev (or libwxgtk3.2-dev in newer distributions, or libwxgtk3.0-dev in older ones, optional - needed for GUI backend, not needed with -DUSEWX=no)
 * libx11-dev (optional - needed for X11 extension that provides better UX for TTY backend wherever X11 is available)
 * libxi-dev (optional - needed for X11/Xi extension that provides best UX for TTY backend wherever X11 Xi extension is available)
-* libxerces-c-dev (optional - needed for Colorer plugin)
+* libxerces-c-dev (optional - needed for Colorer plugin, not needed with -DCOLORER=no)
 * libuchardet-dev (optional - needed for auto charset detection, not needed with -DUSEUCD=no)
 * libssh-dev (optional - needed for NetRocks/SFTP)
 * libssl-dev (optional - needed for NetRocks/FTPS)
@@ -39,12 +39,13 @@ FreeBSD/MacOS (Cirrus CI): [![Cirrus](https://api.cirrus-ci.com/github/elfmz/far
 * libunrar-dev (optional - needed for RAR archives support in multiarc, see UNRAR command line option)
 * libpcre3-dev (or libpcre2-dev in older distributions, optional - needed for custom archives support in multiarc)
 * cmake ( >= 3.2.2 )
+* pkg-config
 * g++
 * git (needed for downloading source code)
 
 #### Or simply on Debian/Ubuntu:
 ``` sh
-apt-get install libwxgtk3.0-gtk3-dev libx11-dev libxi-dev libpcre3-dev libxerces-c-dev libuchardet-dev libssh-dev libssl-dev libsmbclient-dev libnfs-dev libneon27-dev libarchive-dev cmake g++ git
+apt-get install libwxgtk3.0-gtk3-dev libx11-dev libxi-dev libpcre3-dev libxerces-c-dev libuchardet-dev libssh-dev libssl-dev libsmbclient-dev libnfs-dev libneon27-dev libarchive-dev cmake pkg-config g++ git
 ```
 
 On Debian unstable/sid:


### PR DESCRIPTION
1) On some systems (like Ubuntu 14.04 LXC image) you need to install pkg-config manually for cmake to succeed.

2) All cmake options needed to build far2l without any dependency are now documented in README.