### PR TITLE
Update CMakeLists.txt to fix python plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -444,7 +444,7 @@ if (DEFINED VIRTUAL_PYTHON)
     add_subdirectory (python)
     # Copy this explicitly cuz generic copier command excludes 'far2l'
     install(DIRECTORY "${INSTALL_DIR}/Plugins/python/plug/far2l"
-        DESTINATION "share/far2l/Plugins/python/plug/" USE_SOURCE_PERMISSIONS
+        DESTINATION "lib/far2l/Plugins/python/plug/" USE_SOURCE_PERMISSIONS
         COMPONENT base FILES_MATCHING
         PATTERN "*")
 else()
@@ -458,7 +458,7 @@ else()
                 execute_process(COMMAND echo Python: preparing virtual environment)
                 " COMPONENT system)
             install(CODE "
-                execute_process(COMMAND ${PYTHON3} -m venv --system-site-packages ${CMAKE_INSTALL_PREFIX}/lib/far2l/Plugins/python/plug/python)
+                execute_process(COMMAND ${Python3_EXECUTABLE} -m venv --system-site-packages ${CMAKE_INSTALL_PREFIX}/lib/far2l/Plugins/python/plug/python)
                 " COMPONENT system)
             install(CODE "
                 execute_process(COMMAND echo Python: installing packages)
@@ -469,7 +469,7 @@ else()
 
             # Copy this explicitly cuz generic copier command excludes 'far2l'
             install(DIRECTORY "${INSTALL_DIR}/Plugins/python/plug/far2l"
-                DESTINATION "share/far2l/Plugins/python/plug/" USE_SOURCE_PERMISSIONS
+                DESTINATION "lib/far2l/Plugins/python/plug/" USE_SOURCE_PERMISSIONS
                 COMPONENT base FILES_MATCHING
                 PATTERN "*")
         else()


### PR DESCRIPTION
@m32
Update CMakeLists.txt to fix python plugin.   
Some key python plugin files copied to wrong destination by install procedures. Fix it by changing  "share" to "lib".
Without this fix command "py:load" says "py:load: command not found"