### PR TITLE
Command prefix `far:` and draft `far:about` command

### DIFF
--- a/far2l/src/cmdline.cpp
+++ b/far2l/src/cmdline.cpp
@@ -997,7 +997,14 @@ bool CommandLine::ProcessFarCommands(const wchar_t *CmdLine)
 		}
 
 		AboutList.SetPosition(-1, -1, 0, 0);
-		AboutList.Process();
+		//AboutList.Process();
+		AboutList.Show();
+		while (!AboutList.Done()) {
+			int Key = AboutList.ReadInput();
+			if (Key == L' ' || Key == KEY_ENTER || Key == KEY_NUMENTER)		// исключаем пробел и ENTER
+				continue;
+			AboutList.ProcessInput();
+		}
 
 		return true;
 	}

--- a/far2l/src/cmdline.cpp
+++ b/far2l/src/cmdline.cpp
@@ -940,7 +940,7 @@ bool CommandLine::ProcessFarCommands(const wchar_t *CmdLine)
 		{
 			AboutList.AddItem(&ais);
 
-			fs.Format(L"Plugin %2d: ",  i+1);
+			fs.Format(L"Plugin %2d | ",  i+1);
 
 			Plugin *pPlugin = CtrlObject->Plugins.GetPlugin(i);
 			if(pPlugin == nullptr) {
@@ -948,12 +948,13 @@ bool CommandLine::ProcessFarCommands(const wchar_t *CmdLine)
 				AboutList.AddItem(fs);
 				continue;
 			}
-			fs.Append( pPlugin->GetModuleName() );
-			AboutList.AddItem(fs);
+			fs2 = fs;
+			fs2.Append( pPlugin->GetModuleName() );
+			AboutList.AddItem(fs2);
 
-			fs = L"   Settings Name: ";
-			fs.Append(pPlugin->GetSettingsName());
-			AboutList.AddItem(fs);
+			fs2 = fs + L"Settings Name: ";
+			fs2.Append(pPlugin->GetSettingsName());
+			AboutList.AddItem(fs2);
 
 			int IFlags;
 			FARString CommandPrefix = L"";
@@ -972,31 +973,27 @@ bool CommandLine::ProcessFarCommands(const wchar_t *CmdLine)
 				}
 			}
 
-			fs = L"  ";
-			fs.AppendFormat(L" %s Cached  ", pPlugin->CheckWorkFlags(PIWF_CACHED) ? "[x]" : "[ ]");
-			AboutList.AddItem(fs);
+			fs2 = fs;
+			fs2.AppendFormat(L"%s Cached  ", pPlugin->CheckWorkFlags(PIWF_CACHED) ? "[x]" : "[ ]");
+			AboutList.AddItem(fs2);
 
 			if (IFlags >= 0) {
-				fs = L"   F11:";
-				fs.AppendFormat(L" %s Panel  ", IFlags & PF_DISABLEPANELS ? "[ ]" : "[x]");
-				fs.AppendFormat(L" %s Dialog  ", IFlags & PF_DIALOG ? "[x]" : "[ ]");
-				fs.AppendFormat(L" %s Viewer  ", IFlags & PF_VIEWER ? "[x]" : "[ ]");
-				fs.AppendFormat(L" %s Editor  ", IFlags & PF_EDITOR ? "[x]" : "[ ]");
-				AboutList.AddItem(fs);
+				fs2 = fs + L"F11:";
+				fs2.AppendFormat(L" %s Panel  ", IFlags & PF_DISABLEPANELS ? "[ ]" : "[x]");
+				fs2.AppendFormat(L" %s Dialog  ", IFlags & PF_DIALOG ? "[x]" : "[ ]");
+				fs2.AppendFormat(L" %s Viewer  ", IFlags & PF_VIEWER ? "[x]" : "[ ]");
+				fs2.AppendFormat(L" %s Editor  ", IFlags & PF_EDITOR ? "[x]" : "[ ]");
+				AboutList.AddItem(fs2);
 			}
-			fs = L"  ";
-			fs.AppendFormat(L" %s EditorInput  ", pPlugin->HasProcessEditorInput() ? "[x]" : "[ ]");
-			AboutList.AddItem(fs);
+			fs2 = fs;
+			fs2.AppendFormat(L"%s EditorInput  ", pPlugin->HasProcessEditorInput() ? "[x]" : "[ ]");
+			AboutList.AddItem(fs2);
 
 			if ( !CommandPrefix.IsEmpty() ) {
-				fs = L"   CommandPrefix: " + CommandPrefix;
-				AboutList.AddItem(fs);
+				fs2 = fs + L"CommandPrefix: " + CommandPrefix;
+				AboutList.AddItem(fs2);
 			}
 			
-			/*for (const auto& i: *Global->CtrlObject->Plugins)
-			{
-				std::wcout << i->Title() << L", version "sv << version_to_string(i->version()) << L'\n';
-			}*/
 		}
 
 		AboutList.SetPosition(-1, -1, 0, 0);

--- a/far2l/src/cmdline.cpp
+++ b/far2l/src/cmdline.cpp
@@ -69,6 +69,8 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "vtcompletor.h"
 #include <limits>
 
+#include "farversion.h"
+
 CommandLine::CommandLine()
 	:
 	CmdStr(CtrlObject->Cp(), 0, true, CtrlObject->CmdHistory, 0,
@@ -476,6 +478,12 @@ int CommandLine::ProcessKey(int Key)
 				CtrlObject->CmdHistory->AddToHistoryExtra(strStr, strCurDirFromPanel);
 			}
 
+			if ( ProcessFarCommands(strStr.CPtr()) ) {
+				CmdStr.SetString(L"", FALSE);
+				Show();
+				return TRUE;
+			}
+
 			// ProcessOSAliases(strStr);
 
 			if (ActivePanel->ProcessPluginEvent(FE_COMMAND, (void *)strStr.CPtr())) {
@@ -845,4 +853,158 @@ void CommandLine::RedrawWithoutComboBoxMark()
 	Redraw();
 	// erase \x2191 character...
 	DrawComboBoxMark(L' ');
+}
+
+bool CommandLine::ProcessFarCommands(const wchar_t *CmdLine)
+{
+	std::wstring strCommand(CmdLine);
+
+	std::string::size_type p = strCommand.find(L"far:");
+
+	if (p == std::string::npos)
+		return false;
+
+	if (p > 0) { // before "far:" may be only spaces/tabs
+		std::string::size_type p2 = strCommand.find_first_not_of(L" \t");
+		if (p2 == std::string::npos || p2 < p)
+			return false;
+	}
+
+	/*if (strCommand.compare(p, std::string::npos, L"far:config") == 0) {
+		return true;
+	}*/
+
+	if (strCommand.compare(p, std::string::npos, L"far:about") == 0) {
+		FARString fs, fs2;
+		int npl;
+
+		VMenu AboutList(L"far:about",nullptr,0,ScrY-4);
+		AboutList.SetFlags(VMENU_WRAPMODE);
+		//AboutList.SetHelp(L"FarAbout");
+		//AboutList.DeleteItems();
+		AboutList.SetBottomTitle(L"ESC or F10 to close, Ctrl-Alt-F - filtering");
+
+		MenuItemEx ais;
+		ais.Flags = LIF_SEPARATOR;
+
+		fs.Format(L"FAR2L Version:  %s", FAR_BUILD);
+		AboutList.AddItem(fs);
+		fs.Format(L"      Platform: %s", FAR_PLATFORM);
+		AboutList.AddItem(fs);
+		fs.Format(L"      Backend:  %ls", WinPortBackend());
+		AboutList.AddItem(fs);
+		fs.Format(L"      Admin:    %ls", Opt.IsUserAdmin ? Msg::FarTitleAddonsAdmin : L"-");
+		AboutList.AddItem(fs);
+		apiGetEnvironmentVariable("HOSTNAME", fs2);
+		fs = L"      Host:     " + fs2;
+		AboutList.AddItem(fs);
+		apiGetEnvironmentVariable("USER", fs2);
+		fs = L"      User:     " + fs2;
+		AboutList.AddItem(fs);
+
+		AboutList.AddItem(L"");
+
+		//apiGetEnvironmentVariable("FARLANG", fs2);
+		fs = L" Main language: " + Opt.strLanguage;
+		AboutList.AddItem(fs);
+
+		fs = L" Help language: " + Opt.strHelpLanguage;
+		AboutList.AddItem(fs);
+
+		apiGetEnvironmentVariable("FARPID", fs2);
+		fs = L"           PID: " + fs2;
+		AboutList.AddItem(fs);
+
+		AboutList.AddItem(L"");
+
+		apiGetEnvironmentVariable("FARHOME", fs2);
+		fs = L"   Far directory: \"" + fs2 + L"\"";
+		AboutList.AddItem(fs);
+
+		fs.Format(L"Config directory: \"%s\"", InMyConfig("",FALSE).c_str() );
+		AboutList.AddItem(fs);
+
+		fs.Format(L" Cache directory: \"%s\"", InMyCache("",FALSE).c_str() );
+		AboutList.AddItem(fs);
+
+		fs.Format(L"  Temp directory: \"%s\"", InMyTemp("").c_str() );
+		AboutList.AddItem(fs);
+
+		AboutList.AddItem(L"");
+
+		npl = CtrlObject->Plugins.GetPluginsCount();
+		fs.Format(L"Number of plugins: %d", npl);
+		AboutList.AddItem(fs);
+
+		for(int i = 0; i < npl; i++)
+		{
+			AboutList.AddItem(&ais);
+
+			fs.Format(L"Plugin %2d: ",  i+1);
+
+			Plugin *pPlugin = CtrlObject->Plugins.GetPlugin(i);
+			if(pPlugin == nullptr) {
+				fs.Append(L"!!! ERROR get plugin");
+				AboutList.AddItem(fs);
+				continue;
+			}
+			fs.Append( pPlugin->GetModuleName() );
+			AboutList.AddItem(fs);
+
+			fs = L"   Settings Name: ";
+			fs.Append(pPlugin->GetSettingsName());
+			AboutList.AddItem(fs);
+
+			int IFlags;
+			FARString CommandPrefix = L"";
+			PluginInfo pInfo{};
+			KeyFileReadHelper kfh(PluginsIni());
+
+			if (pPlugin->CheckWorkFlags(PIWF_CACHED)) {
+				IFlags = kfh.GetUInt(pPlugin->GetSettingsName(), "Flags", 0);
+				CommandPrefix = kfh.GetString(pPlugin->GetSettingsName(), "CommandPrefix", "");
+			}
+			else {
+				IFlags = -1;
+				if (pPlugin->GetPluginInfo(&pInfo)) {
+					IFlags = pInfo.Flags;
+					CommandPrefix = pInfo.CommandPrefix;
+				}
+			}
+
+			fs = L"  ";
+			fs.AppendFormat(L" %s Cached  ", pPlugin->CheckWorkFlags(PIWF_CACHED) ? "[x]" : "[ ]");
+			AboutList.AddItem(fs);
+
+			if (IFlags >= 0) {
+				fs = L"   F11:";
+				fs.AppendFormat(L" %s Panel  ", IFlags & PF_DISABLEPANELS ? "[ ]" : "[x]");
+				fs.AppendFormat(L" %s Dialog  ", IFlags & PF_DIALOG ? "[x]" : "[ ]");
+				fs.AppendFormat(L" %s Viewer  ", IFlags & PF_VIEWER ? "[x]" : "[ ]");
+				fs.AppendFormat(L" %s Editor  ", IFlags & PF_EDITOR ? "[x]" : "[ ]");
+				AboutList.AddItem(fs);
+			}
+			fs = L"  ";
+			fs.AppendFormat(L" %s EditorInput  ", pPlugin->HasProcessEditorInput() ? "[x]" : "[ ]");
+			AboutList.AddItem(fs);
+
+			if ( !CommandPrefix.IsEmpty() ) {
+				fs = L"   CommandPrefix: " + CommandPrefix;
+				AboutList.AddItem(fs);
+			}
+			
+			/*for (const auto& i: *Global->CtrlObject->Plugins)
+			{
+				std::wcout << i->Title() << L", version "sv << version_to_string(i->version()) << L'\n';
+			}*/
+		}
+
+		AboutList.SetPosition(-1, -1, 0, 0);
+		AboutList.Process();
+
+		return true;
+	}
+
+	return false;
+
 }

--- a/far2l/src/cmdline.hpp
+++ b/far2l/src/cmdline.hpp
@@ -73,6 +73,7 @@ private:
 	BOOL IntChDir(const wchar_t *CmdLine, int ClosePlugin, bool Silent = false);
 	bool ProcessOSCommands(const wchar_t *CmdLine, bool SeparateWindow, bool &PrintCommand);
 	void ProcessTabCompletion();
+	bool ProcessFarCommands(const wchar_t *CmdLine);
 	void DrawComboBoxMark(wchar_t MarkChar);
 	void ChangeDirFromHistory(bool PluginPath, int SelectType, FARString strDir, FARString strFile=L"");
 


### PR DESCRIPTION
Draft `far:about` a la far3, but not identical (not in terminal, in list with details)

Думал повторить как в far3, но не разобрался как в far2l делать вывод в терминал и сделал через окно списка.

В окне списка возможно стоит пофиксить эффект, что при наличии LIF_SEPARATOR и прокрутки ниже первой страницы экрана в заголовок списка добавляется ` -` - в истории это к месту, а тут не мешающая некрасивость.