### PR TITLE
new draft `far:config` & update draft `far:about`

### DIFF
--- a/far2l/src/cfg/ConfigSaveLoad.cpp
+++ b/far2l/src/cfg/ConfigSaveLoad.cpp
@@ -243,39 +243,74 @@ public:
 
 	void MenuListAppend(VMenu &vm,
 					size_t len_sections, size_t len_keys, size_t len_sections_keys,
-					bool all, bool align_dot) const
+					bool bHideUnchanged, bool bAlignDot) const
 	{
-		//MenuItemEx mi;
-		FARString fsn, fs;
-		if (align_dot)
+		MenuItemEx mi;
+		FARString fsn;
+		if (bAlignDot)
 		 fsn.Format(L"%*s.%-*s", len_sections, _section, len_keys, _key);
 		else {
-			fs.Format(L"%s.%s", _section, _key);
-			fsn.Format(L"%-*ls", len_sections_keys, fs.CPtr());
+			mi.strName.Format(L"%s.%s", _section, _key);
+			fsn.Format(L"%-*ls", len_sections_keys, mi.strName.CPtr());
 		}
 		switch (_type)
 		{
 			case T_BOOL:
-				fs.Format(L"%s %ls |  bool|%s", (*_value.b == _default.b ? " " : "*"), fsn.CPtr(), (_value.b ? "true" : "false"));
+				mi.strName.Format(L"%s %ls |  bool|%s", (*_value.b == _default.b ? " " : "*"), fsn.CPtr(), (_value.b ? "true" : "false"));
 				break;
 			case T_INT:
-				fs.Format(L"%s %ls |   int|%d = 0x%x", (*_value.i == _default.i ? " " : "*"), fsn.CPtr(), *_value.i, *_value.i);
+				mi.strName.Format(L"%s %ls |   int|%d = 0x%x", (*_value.i == _default.i ? " " : "*"), fsn.CPtr(), *_value.i, *_value.i);
 				break;
 			case T_DWORD:
-				fs.Format(L"%s %ls | dword|%u = 0x%x", (*_value.dw == _default.dw ? " " : "*"), fsn.CPtr(), *_value.dw, *_value.dw);
+				mi.strName.Format(L"%s %ls | dword|%u = 0x%x", (*_value.dw == _default.dw ? " " : "*"), fsn.CPtr(), *_value.dw, *_value.dw);
 				break;
 			case T_STR:
-				fs.Format(L"%s %ls |string|%ls", (*_value.str == _default.str ? " " : "*"), fsn.CPtr(), _value.str->CPtr());
+				mi.strName.Format(L"%s %ls |string|%ls", (*_value.str == _default.str ? " " : "*"), fsn.CPtr(), _value.str->CPtr());
 				break;
 			case T_BIN:
-				fs.Format(L"%s %ls |binary|(binary has length %u bytes)",
+				mi.strName.Format(L"%s %ls |binary|(binary has length %u bytes)",
 					(_default.bin == nullptr || _value.bin == nullptr ? "?"
 						: ( memcmp(_value.bin, _default.bin, _bin_size) == 0 ? " " : "*")),
 					fsn.CPtr(), _bin_size );
 				break;
 		}
-		if (all || fs.At(0)!=L' ')
-			vm.AddItem(fs);
+		if (bHideUnchanged && mi.strName.At(0)==L' ')
+			mi.Flags |= LIF_HIDDEN;
+		vm.AddItem(&mi);
+	}
+
+	void Msg(const wchar_t *title) const
+	{
+		FARString fs, fs2;
+		Message(MSG_LEFTALIGN, 1, fs.Format(L"%ls - %s.%s", title, _section, _key),
+			fs.Format(L"        Section: %s", _section),
+			fs.Format(L"            Key: %s", _key),
+			fs.Format(L" to config file: %s", (_save ? "saved" : "never")),
+			fs.Format(L"           Type: %s",
+				( _type == T_BOOL ? "bool"
+				: ( _type == T_INT ?  "int"
+				: ( _type == T_DWORD ? "dword"
+				: ( _type == T_STR ? "string"
+				: ( _type == T_BIN ? "binary"
+				: "???") ) ) ) ) ),
+			fs.Format(L"  Default value: %ls",
+				( _type == T_BOOL ? (_default.b ? L"true" : L"false")
+				: ( _type == T_INT ? fs2.Format(L"%d = 0x%x", _default.i, _default.i).CPtr()
+				: ( _type == T_DWORD ? fs2.Format(L"%d = 0x%x", _default.dw, _default.dw).CPtr()
+				: ( _type == T_STR ? _default.str
+				: ( _type == T_BIN ? fs2.Format(L"(binary has length %u bytes)", _bin_size).CPtr()
+				: L"???"	) ) ) ) )
+				),
+			fs.Format(L"  Current value: %ls",
+				( _type == T_BOOL ? (*_value.b ? L"true" : L"false")
+				: ( _type == T_INT ? fs2.Format(L"%d = 0x%x", *_value.i, *_value.i).CPtr()
+				: ( _type == T_DWORD ? fs2.Format(L"%d = 0x%x", *_value.dw, *_value.dw).CPtr()
+				: ( _type == T_STR ? _value.str->CPtr()
+				: ( _type == T_BIN ? fs2.Format(L"(binary has length %u bytes)", _bin_size).CPtr()
+				: L"???" ) ) ) ) )
+				),
+			Msg::Ok);
+
 	}
 
 } s_opt_serializers[] =
@@ -796,8 +831,9 @@ void SaveConfig(int Ask)
 void AdvancedConfig()
 {
 	size_t len_sections = 0, len_keys = 0, len_sections_keys = 0;
-	bool all = true, align_dot = false;
+	bool bHideUnchanged = false, bAlignDot = false;
 	VMenu ListConfig(L"far:config",nullptr,0,ScrY-4);
+	ListConfig.SetFlags(VMENU_SHOWAMPERSAND);
 	//ListConfig.SetFlags(VMENU_WRAPMODE);
 	//ListConfig.ClearFlags(VMENU_MOUSEDOWN);
 	//ListConfig.SetHelp(L"FarConfig");
@@ -810,34 +846,39 @@ void AdvancedConfig()
 	for (const auto &opt_ser : s_opt_serializers)
 		opt_ser.GetMaxLengthSectKeys(len_sections, len_keys, len_sections_keys);
 	for (const auto &opt_ser : s_opt_serializers)
-		opt_ser.MenuListAppend(ListConfig, len_sections, len_keys, len_sections_keys, all, align_dot);
+		opt_ser.MenuListAppend(ListConfig, len_sections, len_keys, len_sections_keys, bHideUnchanged, bAlignDot);
 
 	ListConfig.SetPosition(-1, -1, 0, 0);
 	//ListConfig.Process();
 	ListConfig.Show();
 	while (!ListConfig.Done()) {
 		int Key = ListConfig.ReadInput();
-		if (Key == KEY_ENTER || Key == KEY_NUMENTER)		// исключаем ENTER
-			continue;
-		if (Key == KEY_CTRLH ) {
-			all = !all;
-			ListConfig.DeleteItems();
-			for (const auto &opt_ser : s_opt_serializers)
-				opt_ser.MenuListAppend(ListConfig, len_sections, len_keys, len_sections_keys, all, align_dot);
-			ListConfig.SetPosition(-1, -1, 0, 0);
-			ListConfig.Show();
+		switch (Key) {
+			case KEY_ENTER:
+			case KEY_NUMENTER: {
+				int i = ListConfig.GetSelectPos();
+				if (i>=0)
+					s_opt_serializers[i].Msg(L"far:config");
+				}
+				continue;
+			case KEY_CTRLH:
+				bHideUnchanged = !bHideUnchanged;
+				break;
+			case KEY_CTRLA:
+				bAlignDot = !bAlignDot;
+				break;
+			default:
+				ListConfig.ProcessInput();
+				continue;
 		}
-		if (Key == KEY_CTRLA ) {
-			align_dot = !align_dot;
-			int sel_pos = ListConfig.GetSelectPos();
-			ListConfig.DeleteItems();
-			for (const auto &opt_ser : s_opt_serializers) {
-				opt_ser.MenuListAppend(ListConfig, len_sections, len_keys, len_sections_keys, all, align_dot);
-			}
-			ListConfig.SetSelectPos(sel_pos,0);
-			ListConfig.FastShow();
-		}
-		ListConfig.ProcessInput();
-	}
 
+		// regenerate items in loop only if not was contunue
+		int sel_pos = ListConfig.GetSelectPos();
+		ListConfig.DeleteItems();
+		for (const auto &opt_ser : s_opt_serializers)
+			opt_ser.MenuListAppend(ListConfig, len_sections, len_keys, len_sections_keys, bHideUnchanged, bAlignDot);
+		ListConfig.SetSelectPos(sel_pos,0);
+		ListConfig.SetPosition(-1, -1, 0, 0);
+		ListConfig.Show();
+	}
 }

--- a/far2l/src/cfg/ConfigSaveLoad.cpp
+++ b/far2l/src/cfg/ConfigSaveLoad.cpp
@@ -802,7 +802,7 @@ void AdvancedConfig()
 	//ListConfig.ClearFlags(VMENU_MOUSEDOWN);
 	//ListConfig.SetHelp(L"FarConfig");
 
-	ListConfig.SetBottomTitle(L"ESC or F10 to close, Ctrl-Alt-F - filtering, Ctrl-H - changed/all, Ctrl-A - toogle align names");
+	ListConfig.SetBottomTitle(L"ESC or F10 to close, Ctrl-Alt-F - filtering, Ctrl-H - changed/all, Ctrl-A - names left/dot");
 
 	MenuItemEx mis;
 	mis.Flags = LIF_SEPARATOR;

--- a/far2l/src/cfg/ConfigSaveLoad.cpp
+++ b/far2l/src/cfg/ConfigSaveLoad.cpp
@@ -298,7 +298,7 @@ public:
 				: ( _type == T_INT ? fs2.Format(L"%d = 0x%x", _default.i, _default.i).CPtr()
 				: ( _type == T_DWORD ? fs2.Format(L"%d = 0x%x", _default.dw, _default.dw).CPtr()
 				: ( _type == T_STR ? _default.str
-				: ( _type == T_BIN ? fs2.Format(L"(binary has length %u bytes)", _bin_size).CPtr()
+				: ( _type == T_BIN ? ( _default.bin == nullptr ? L"(no default value set)" : fs2.Format(L"(binary has length %u bytes)", _bin_size).CPtr() )
 				: L"???"	) ) ) ) )
 				),
 			fs.Format(L"  Current value: %ls",

--- a/far2l/src/cfg/ConfigSaveLoad.cpp
+++ b/far2l/src/cfg/ConfigSaveLoad.cpp
@@ -840,9 +840,6 @@ void AdvancedConfig()
 
 	ListConfig.SetBottomTitle(L"ESC or F10 to close, Ctrl-Alt-F - filtering, Ctrl-H - changed/all, Ctrl-A - names left/dot");
 
-	MenuItemEx mis;
-	mis.Flags = LIF_SEPARATOR;
-
 	for (const auto &opt_ser : s_opt_serializers)
 		opt_ser.GetMaxLengthSectKeys(len_sections, len_keys, len_sections_keys);
 	for (const auto &opt_ser : s_opt_serializers)

--- a/far2l/src/cfg/ConfigSaveLoad.hpp
+++ b/far2l/src/cfg/ConfigSaveLoad.hpp
@@ -3,3 +3,4 @@
 void LoadConfig();
 void AssertConfigLoaded();
 void SaveConfig(int Ask);
+void AdvancedConfig();

--- a/far2l/src/cmdline.cpp
+++ b/far2l/src/cmdline.cpp
@@ -870,140 +870,192 @@ bool CommandLine::ProcessFarCommands(const wchar_t *CmdLine)
 			return false;
 	}
 
-	/*if (strCommand.compare(p, std::string::npos, L"far:config") == 0) {
+	if (strCommand.compare(p, std::string::npos, L"far:config") == 0) {
+		AdvancedConfig();
 		return true;
-	}*/
+	}
 
 	if (strCommand.compare(p, std::string::npos, L"far:about") == 0) {
 		FARString fs, fs2;
 		int npl;
 
-		VMenu AboutList(L"far:about",nullptr,0,ScrY-4);
-		AboutList.SetFlags(VMENU_WRAPMODE);
-		//AboutList.SetHelp(L"FarAbout");
-		//AboutList.DeleteItems();
-		AboutList.SetBottomTitle(L"ESC or F10 to close, Ctrl-Alt-F - filtering");
+		VMenu ListAbout(L"far:about",nullptr,0,ScrY-4);
+		//ListAbout.SetFlags(VMENU_WRAPMODE);
+		//ListAbout.ClearFlags(VMENU_MOUSEDOWN);
+		//ListAbout.SetHelp(L"FarAbout");
+		ListAbout.SetBottomTitle(L"ESC or F10 to close, Ctrl-Alt-F - filtering");
 
-		MenuItemEx ais;
-		ais.Flags = LIF_SEPARATOR;
+		MenuItemEx mis;
+		mis.Flags = LIF_SEPARATOR;
 
 		fs.Format(L"FAR2L Version:  %s", FAR_BUILD);
-		AboutList.AddItem(fs);
+		ListAbout.AddItem(fs);
 		fs.Format(L"      Platform: %s", FAR_PLATFORM);
-		AboutList.AddItem(fs);
+		ListAbout.AddItem(fs);
 		fs.Format(L"      Backend:  %ls", WinPortBackend());
-		AboutList.AddItem(fs);
+		ListAbout.AddItem(fs);
 		fs.Format(L"      Admin:    %ls", Opt.IsUserAdmin ? Msg::FarTitleAddonsAdmin : L"-");
-		AboutList.AddItem(fs);
+		ListAbout.AddItem(fs);
 		apiGetEnvironmentVariable("HOSTNAME", fs2);
 		fs = L"      Host:     " + fs2;
-		AboutList.AddItem(fs);
+		ListAbout.AddItem(fs);
 		apiGetEnvironmentVariable("USER", fs2);
 		fs = L"      User:     " + fs2;
-		AboutList.AddItem(fs);
+		ListAbout.AddItem(fs);
 
-		AboutList.AddItem(L"");
+		ListAbout.AddItem(L"");
 
 		//apiGetEnvironmentVariable("FARLANG", fs2);
 		fs = L" Main language: " + Opt.strLanguage;
-		AboutList.AddItem(fs);
+		ListAbout.AddItem(fs);
 
 		fs = L" Help language: " + Opt.strHelpLanguage;
-		AboutList.AddItem(fs);
+		ListAbout.AddItem(fs);
 
-		apiGetEnvironmentVariable("FARPID", fs2);
-		fs = L"           PID: " + fs2;
-		AboutList.AddItem(fs);
+		//apiGetEnvironmentVariable("FARPID", fs2);
+		//fs = L"           PID: " + fs2;
+		fs.Format(L"           PID: %lu", (unsigned long)getpid());
+		ListAbout.AddItem(fs);
 
-		AboutList.AddItem(L"");
+		ListAbout.AddItem(L"");
 
-		apiGetEnvironmentVariable("FARHOME", fs2);
-		fs = L"   Far directory: \"" + fs2 + L"\"";
-		AboutList.AddItem(fs);
+		//apiGetEnvironmentVariable("FARHOME", fs2);
+		fs = L"   Far directory: \"" + g_strFarPath.GetMB() + L"\"";
+		ListAbout.AddItem(fs);
 
 		fs.Format(L"Config directory: \"%s\"", InMyConfig("",FALSE).c_str() );
-		AboutList.AddItem(fs);
+		ListAbout.AddItem(fs);
 
 		fs.Format(L" Cache directory: \"%s\"", InMyCache("",FALSE).c_str() );
-		AboutList.AddItem(fs);
+		ListAbout.AddItem(fs);
 
 		fs.Format(L"  Temp directory: \"%s\"", InMyTemp("").c_str() );
-		AboutList.AddItem(fs);
+		ListAbout.AddItem(fs);
 
-		AboutList.AddItem(L"");
+		ListAbout.AddItem(L"");
 
 		npl = CtrlObject->Plugins.GetPluginsCount();
 		fs.Format(L"Number of plugins: %d", npl);
-		AboutList.AddItem(fs);
+		ListAbout.AddItem(fs);
 
 		for(int i = 0; i < npl; i++)
 		{
-			AboutList.AddItem(&ais);
+			ListAbout.AddItem(&mis);
 
-			fs.Format(L"Plugin %2d | ",  i+1);
+			fs.Format(L"Plugin#%02d | ",  i+1);
 
 			Plugin *pPlugin = CtrlObject->Plugins.GetPlugin(i);
 			if(pPlugin == nullptr) {
 				fs.Append(L"!!! ERROR get plugin");
-				AboutList.AddItem(fs);
+				ListAbout.AddItem(fs);
 				continue;
 			}
 			fs2 = fs;
 			fs2.Append( pPlugin->GetModuleName() );
-			AboutList.AddItem(fs2);
+			ListAbout.AddItem(fs2);
 
 			fs2 = fs + L"Settings Name: ";
 			fs2.Append(pPlugin->GetSettingsName());
-			AboutList.AddItem(fs2);
+			ListAbout.AddItem(fs2);
 
-			int IFlags;
-			FARString CommandPrefix = L"";
+			int iFlags;
 			PluginInfo pInfo{};
 			KeyFileReadHelper kfh(PluginsIni());
+			FARString fsCommandPrefix = L"";
+			FARString fsDiskMenuStrings = L"";
+			FARString fsPluginMenuStrings = L"";
+			FARString fsPluginConfigStrings = L"";
 
 			if (pPlugin->CheckWorkFlags(PIWF_CACHED)) {
-				IFlags = kfh.GetUInt(pPlugin->GetSettingsName(), "Flags", 0);
-				CommandPrefix = kfh.GetString(pPlugin->GetSettingsName(), "CommandPrefix", "");
-			}
-			else {
-				IFlags = -1;
-				if (pPlugin->GetPluginInfo(&pInfo)) {
-					IFlags = pInfo.Flags;
-					CommandPrefix = pInfo.CommandPrefix;
+				iFlags = kfh.GetUInt(pPlugin->GetSettingsName(), "Flags", 0);
+				fsCommandPrefix = kfh.GetString(pPlugin->GetSettingsName(), "CommandPrefix", L"");
+				for (int j = 0; ; j++) {
+					const auto &key_name = StrPrintf("DiskMenuString%d", j);
+					/*if (!kfh.HasKey(key_name))
+						break;*/
+					fs2 = kfh.GetString(pPlugin->GetSettingsName(), key_name, "");
+					if( fs2.IsEmpty() )
+						break;
+					fsDiskMenuStrings.AppendFormat(L" %d=\"%ls\" ", j+1, fs2.CPtr());
+				}
+				for (int j = 0; ; j++) {
+					const auto &key_name = StrPrintf("PluginMenuString%d", j);
+					/*if (!kfh.HasKey(key_name))
+						break;*/
+					fs2 = kfh.GetString(pPlugin->GetSettingsName(), key_name, "");
+					if( fs2.IsEmpty() )
+						break;
+					fsPluginMenuStrings.AppendFormat(L" %d=\"%ls\" ", j+1, fs2.CPtr());
+				}
+				for (int j = 0; ; j++) {
+					const auto &key_name = StrPrintf("PluginConfigString%d", j);
+					/*if (!kfh.HasKey(key_name))
+						break;*/
+					fs2 = kfh.GetString(pPlugin->GetSettingsName(), key_name, "");
+					if( fs2.IsEmpty() )
+						break;
+					fsPluginConfigStrings.AppendFormat(L" %d=\"%ls\" ", j+1, fs2.CPtr());
 				}
 			}
-
-			fs2 = fs;
-			fs2.AppendFormat(L"%s Cached  ", pPlugin->CheckWorkFlags(PIWF_CACHED) ? "[x]" : "[ ]");
-			AboutList.AddItem(fs2);
-
-			if (IFlags >= 0) {
-				fs2 = fs + L"F11:";
-				fs2.AppendFormat(L" %s Panel  ", IFlags & PF_DISABLEPANELS ? "[ ]" : "[x]");
-				fs2.AppendFormat(L" %s Dialog  ", IFlags & PF_DIALOG ? "[x]" : "[ ]");
-				fs2.AppendFormat(L" %s Viewer  ", IFlags & PF_VIEWER ? "[x]" : "[ ]");
-				fs2.AppendFormat(L" %s Editor  ", IFlags & PF_EDITOR ? "[x]" : "[ ]");
-				AboutList.AddItem(fs2);
+			else {
+				if (pPlugin->GetPluginInfo(&pInfo)) {
+					iFlags = pInfo.Flags;
+					fsCommandPrefix = pInfo.CommandPrefix;
+					for (int j = 0; j < pInfo.DiskMenuStringsNumber; j++)
+						fsDiskMenuStrings.AppendFormat(L" %d=\"%ls\"", j+1, pInfo.DiskMenuStrings[j]);
+					for (int j = 0; j < pInfo.PluginMenuStringsNumber; j++)
+						fsPluginMenuStrings.AppendFormat(L" %d=\"%ls\"", j+1, pInfo.PluginMenuStrings[j]);
+					for (int j = 0; j < pInfo.PluginConfigStringsNumber; j++)
+						fsPluginConfigStrings.AppendFormat(L" %d=\"%ls\"", j+1, pInfo.PluginConfigStrings[j]);
+				}
+				else
+					iFlags = -1;
 			}
-			fs2 = fs;
-			fs2.AppendFormat(L"%s EditorInput  ", pPlugin->HasProcessEditorInput() ? "[x]" : "[ ]");
-			AboutList.AddItem(fs2);
 
-			if ( !CommandPrefix.IsEmpty() ) {
-				fs2 = fs + L"CommandPrefix: " + CommandPrefix;
-				AboutList.AddItem(fs2);
+			fs2 = fs + L"    ";
+			fs2.AppendFormat(L" %s Cached ", pPlugin->CheckWorkFlags(PIWF_CACHED) ? "[x]" : "[ ]");
+			fs2.AppendFormat(L" %s Loaded ", pPlugin->GetFuncFlags() & PICFF_LOADED ? "[x]" : "[ ]");
+			ListAbout.AddItem(fs2);
+
+			if (iFlags >= 0) {
+				fs2 = fs + L"F11:";
+				fs2.AppendFormat(L" %s Panel  ", iFlags & PF_DISABLEPANELS ? "[ ]" : "[x]");
+				fs2.AppendFormat(L" %s Dialog ", iFlags & PF_DIALOG ? "[x]" : "[ ]");
+				fs2.AppendFormat(L" %s Viewer ", iFlags & PF_VIEWER ? "[x]" : "[ ]");
+				fs2.AppendFormat(L" %s Editor ", iFlags & PF_EDITOR ? "[x]" : "[ ]");
+				ListAbout.AddItem(fs2);
+			}
+			fs2 = fs + L"    ";
+			fs2.AppendFormat(L" %s EditorInput ", pPlugin->HasProcessEditorInput() ? "[x]" : "[ ]");
+			ListAbout.AddItem(fs2);
+
+			if ( !fsDiskMenuStrings.IsEmpty() ) {
+				fs2 = fs + L"    DiskMenuStrings:" + fsDiskMenuStrings;
+				ListAbout.AddItem(fs2);
+			}
+			if ( !fsPluginMenuStrings.IsEmpty() ) {
+				fs2 = fs + L"  PluginMenuStrings:" + fsPluginMenuStrings;
+				ListAbout.AddItem(fs2);
+			}
+			if ( !fsPluginConfigStrings.IsEmpty() ) {
+				fs2 = fs + L"PluginConfigStrings:" + fsPluginConfigStrings;
+				ListAbout.AddItem(fs2);
+			}
+			if ( !fsCommandPrefix.IsEmpty() ) {
+				fs2.Format(L"%ls      CommandPrefix: \"%ls\"", fs.CPtr(), fsCommandPrefix.CPtr());
+				ListAbout.AddItem(fs2);
 			}
 			
 		}
 
-		AboutList.SetPosition(-1, -1, 0, 0);
-		//AboutList.Process();
-		AboutList.Show();
-		while (!AboutList.Done()) {
-			int Key = AboutList.ReadInput();
-			if (Key == L' ' || Key == KEY_ENTER || Key == KEY_NUMENTER)		// исключаем пробел и ENTER
+		ListAbout.SetPosition(-1, -1, 0, 0);
+		//ListAbout.Process();
+		ListAbout.Show();
+		while (!ListAbout.Done()) {
+			int Key = ListAbout.ReadInput();
+			if (Key == KEY_ENTER || Key == KEY_NUMENTER)		// исключаем ENTER
 				continue;
-			AboutList.ProcessInput();
+			ListAbout.ProcessInput();
 		}
 
 		return true;

--- a/far2l/src/cmdline.cpp
+++ b/far2l/src/cmdline.cpp
@@ -855,6 +855,192 @@ void CommandLine::RedrawWithoutComboBoxMark()
 	DrawComboBoxMark(L' ');
 }
 
+void FarAbout(PluginManager &Plugins)
+{
+	FARString fs, fs2;
+	int npl;
+
+	VMenu ListAbout(L"far:about",nullptr,0,ScrY-4);
+	ListAbout.SetFlags(VMENU_SHOWAMPERSAND);
+	//ListAbout.SetFlags(VMENU_WRAPMODE);
+	//ListAbout.ClearFlags(VMENU_MOUSEDOWN);
+	//ListAbout.SetHelp(L"FarAbout");
+	ListAbout.SetBottomTitle(L"ESC or F10 to close, Ctrl-Alt-F - filtering");
+
+	MenuItemEx mis;
+	mis.Flags = LIF_SEPARATOR;
+
+	fs.Format(L"FAR2L Version:  %s", FAR_BUILD);
+	ListAbout.AddItem(fs);
+	fs.Format(L"      Platform: %s", FAR_PLATFORM);
+	ListAbout.AddItem(fs);
+	fs.Format(L"      Backend:  %ls", WinPortBackend());
+	ListAbout.AddItem(fs);
+	fs.Format(L"      Admin:    %ls", Opt.IsUserAdmin ? Msg::FarTitleAddonsAdmin : L"-");
+	ListAbout.AddItem(fs);
+	apiGetEnvironmentVariable("HOSTNAME", fs2);
+	fs = L"      Host:     " + fs2;
+	ListAbout.AddItem(fs);
+	apiGetEnvironmentVariable("USER", fs2);
+	fs = L"      User:     " + fs2;
+	ListAbout.AddItem(fs);
+
+	ListAbout.AddItem(L"");
+
+	//apiGetEnvironmentVariable("FARLANG", fs2);
+	fs = L" Main language: " + Opt.strLanguage;
+	ListAbout.AddItem(fs);
+
+	fs = L" Help language: " + Opt.strHelpLanguage;
+	ListAbout.AddItem(fs);
+
+	//apiGetEnvironmentVariable("FARPID", fs2);
+	//fs = L"           PID: " + fs2;
+	fs.Format(L"           PID: %lu", (unsigned long)getpid());
+	ListAbout.AddItem(fs);
+
+	ListAbout.AddItem(L"");
+
+	//apiGetEnvironmentVariable("FARHOME", fs2);
+	fs = L"   Far directory: \"" + g_strFarPath.GetMB() + L"\"";
+	ListAbout.AddItem(fs);
+
+	fs.Format(L"Config directory: \"%s\"", InMyConfig("",FALSE).c_str() );
+	ListAbout.AddItem(fs);
+
+	fs.Format(L" Cache directory: \"%s\"", InMyCache("",FALSE).c_str() );
+	ListAbout.AddItem(fs);
+
+	fs.Format(L"  Temp directory: \"%s\"", InMyTemp("").c_str() );
+	ListAbout.AddItem(fs);
+
+	ListAbout.AddItem(L"");
+
+	npl = Plugins.GetPluginsCount();
+	fs.Format(L"Number of plugins: %d", npl);
+	ListAbout.AddItem(fs);
+
+	for(int i = 0; i < npl; i++)
+	{
+		ListAbout.AddItem(&mis);
+
+		fs.Format(L"Plugin#%02d | ",  i+1);
+
+		Plugin *pPlugin = Plugins.GetPlugin(i);
+		if(pPlugin == nullptr) {
+			fs.Append(L"!!! ERROR get plugin");
+			ListAbout.AddItem(fs);
+			continue;
+		}
+		fs2 = fs;
+		fs2.Append( pPlugin->GetModuleName() );
+		ListAbout.AddItem(fs2);
+
+		fs2 = fs + L"Settings Name: ";
+		fs2.Append(pPlugin->GetSettingsName());
+		ListAbout.AddItem(fs2);
+
+		int iFlags;
+		PluginInfo pInfo{};
+		KeyFileReadHelper kfh(PluginsIni());
+		FARString fsCommandPrefix = L"";
+		FARString fsDiskMenuStrings = L"";
+		FARString fsPluginMenuStrings = L"";
+		FARString fsPluginConfigStrings = L"";
+
+		if (pPlugin->CheckWorkFlags(PIWF_CACHED)) {
+			iFlags = kfh.GetUInt(pPlugin->GetSettingsName(), "Flags", 0);
+			fsCommandPrefix = kfh.GetString(pPlugin->GetSettingsName(), "CommandPrefix", L"");
+			for (int j = 0; ; j++) {
+				const auto &key_name = StrPrintf("DiskMenuString%d", j);
+				/*if (!kfh.HasKey(key_name))
+					break;*/
+				fs2 = kfh.GetString(pPlugin->GetSettingsName(), key_name, "");
+				if( fs2.IsEmpty() )
+					break;
+				fsDiskMenuStrings.AppendFormat(L" %d=\"%ls\" ", j+1, fs2.CPtr());
+			}
+			for (int j = 0; ; j++) {
+				const auto &key_name = StrPrintf("PluginMenuString%d", j);
+				/*if (!kfh.HasKey(key_name))
+					break;*/
+				fs2 = kfh.GetString(pPlugin->GetSettingsName(), key_name, "");
+				if( fs2.IsEmpty() )
+					break;
+				fsPluginMenuStrings.AppendFormat(L" %d=\"%ls\" ", j+1, fs2.CPtr());
+			}
+			for (int j = 0; ; j++) {
+				const auto &key_name = StrPrintf("PluginConfigString%d", j);
+				/*if (!kfh.HasKey(key_name))
+					break;*/
+				fs2 = kfh.GetString(pPlugin->GetSettingsName(), key_name, "");
+				if( fs2.IsEmpty() )
+					break;
+				fsPluginConfigStrings.AppendFormat(L" %d=\"%ls\" ", j+1, fs2.CPtr());
+			}
+		}
+		else {
+			if (pPlugin->GetPluginInfo(&pInfo)) {
+				iFlags = pInfo.Flags;
+				fsCommandPrefix = pInfo.CommandPrefix;
+				for (int j = 0; j < pInfo.DiskMenuStringsNumber; j++)
+					fsDiskMenuStrings.AppendFormat(L" %d=\"%ls\"", j+1, pInfo.DiskMenuStrings[j]);
+				for (int j = 0; j < pInfo.PluginMenuStringsNumber; j++)
+					fsPluginMenuStrings.AppendFormat(L" %d=\"%ls\"", j+1, pInfo.PluginMenuStrings[j]);
+				for (int j = 0; j < pInfo.PluginConfigStringsNumber; j++)
+					fsPluginConfigStrings.AppendFormat(L" %d=\"%ls\"", j+1, pInfo.PluginConfigStrings[j]);
+			}
+			else
+				iFlags = -1;
+		}
+
+		fs2 = fs + L"    ";
+		fs2.AppendFormat(L" %s Cached ", pPlugin->CheckWorkFlags(PIWF_CACHED) ? "[x]" : "[ ]");
+		fs2.AppendFormat(L" %s Loaded ", pPlugin->GetFuncFlags() & PICFF_LOADED ? "[x]" : "[ ]");
+		ListAbout.AddItem(fs2);
+
+		if (iFlags >= 0) {
+			fs2 = fs + L"F11:";
+			fs2.AppendFormat(L" %s Panel  ", iFlags & PF_DISABLEPANELS ? "[ ]" : "[x]");
+			fs2.AppendFormat(L" %s Dialog ", iFlags & PF_DIALOG ? "[x]" : "[ ]");
+			fs2.AppendFormat(L" %s Viewer ", iFlags & PF_VIEWER ? "[x]" : "[ ]");
+			fs2.AppendFormat(L" %s Editor ", iFlags & PF_EDITOR ? "[x]" : "[ ]");
+			ListAbout.AddItem(fs2);
+		}
+		fs2 = fs + L"    ";
+		fs2.AppendFormat(L" %s EditorInput ", pPlugin->HasProcessEditorInput() ? "[x]" : "[ ]");
+		ListAbout.AddItem(fs2);
+
+		if ( !fsDiskMenuStrings.IsEmpty() ) {
+			fs2 = fs + L"    DiskMenuStrings:" + fsDiskMenuStrings;
+			ListAbout.AddItem(fs2);
+		}
+		if ( !fsPluginMenuStrings.IsEmpty() ) {
+			fs2 = fs + L"  PluginMenuStrings:" + fsPluginMenuStrings;
+			ListAbout.AddItem(fs2);
+		}
+		if ( !fsPluginConfigStrings.IsEmpty() ) {
+			fs2 = fs + L"PluginConfigStrings:" + fsPluginConfigStrings;
+			ListAbout.AddItem(fs2);
+		}
+		if ( !fsCommandPrefix.IsEmpty() ) {
+			fs2.Format(L"%ls      CommandPrefix: \"%ls\"", fs.CPtr(), fsCommandPrefix.CPtr());
+			ListAbout.AddItem(fs2);
+		}
+		
+	}
+
+	ListAbout.SetPosition(-1, -1, 0, 0);
+	//ListAbout.Process();
+	ListAbout.Show();
+	while (!ListAbout.Done()) {
+		int Key = ListAbout.ReadInput();
+		if (Key == KEY_ENTER || Key == KEY_NUMENTER)		// исключаем ENTER
+			continue;
+		ListAbout.ProcessInput();
+	}
+}
+
 bool CommandLine::ProcessFarCommands(const wchar_t *CmdLine)
 {
 	std::wstring strCommand(CmdLine);
@@ -876,192 +1062,9 @@ bool CommandLine::ProcessFarCommands(const wchar_t *CmdLine)
 	}
 
 	if (strCommand.compare(p, std::string::npos, L"far:about") == 0) {
-		FARString fs, fs2;
-		int npl;
-
-		VMenu ListAbout(L"far:about",nullptr,0,ScrY-4);
-		ListAbout.SetFlags(VMENU_SHOWAMPERSAND);
-		//ListAbout.SetFlags(VMENU_WRAPMODE);
-		//ListAbout.ClearFlags(VMENU_MOUSEDOWN);
-		//ListAbout.SetHelp(L"FarAbout");
-		ListAbout.SetBottomTitle(L"ESC or F10 to close, Ctrl-Alt-F - filtering");
-
-		MenuItemEx mis;
-		mis.Flags = LIF_SEPARATOR;
-
-		fs.Format(L"FAR2L Version:  %s", FAR_BUILD);
-		ListAbout.AddItem(fs);
-		fs.Format(L"      Platform: %s", FAR_PLATFORM);
-		ListAbout.AddItem(fs);
-		fs.Format(L"      Backend:  %ls", WinPortBackend());
-		ListAbout.AddItem(fs);
-		fs.Format(L"      Admin:    %ls", Opt.IsUserAdmin ? Msg::FarTitleAddonsAdmin : L"-");
-		ListAbout.AddItem(fs);
-		apiGetEnvironmentVariable("HOSTNAME", fs2);
-		fs = L"      Host:     " + fs2;
-		ListAbout.AddItem(fs);
-		apiGetEnvironmentVariable("USER", fs2);
-		fs = L"      User:     " + fs2;
-		ListAbout.AddItem(fs);
-
-		ListAbout.AddItem(L"");
-
-		//apiGetEnvironmentVariable("FARLANG", fs2);
-		fs = L" Main language: " + Opt.strLanguage;
-		ListAbout.AddItem(fs);
-
-		fs = L" Help language: " + Opt.strHelpLanguage;
-		ListAbout.AddItem(fs);
-
-		//apiGetEnvironmentVariable("FARPID", fs2);
-		//fs = L"           PID: " + fs2;
-		fs.Format(L"           PID: %lu", (unsigned long)getpid());
-		ListAbout.AddItem(fs);
-
-		ListAbout.AddItem(L"");
-
-		//apiGetEnvironmentVariable("FARHOME", fs2);
-		fs = L"   Far directory: \"" + g_strFarPath.GetMB() + L"\"";
-		ListAbout.AddItem(fs);
-
-		fs.Format(L"Config directory: \"%s\"", InMyConfig("",FALSE).c_str() );
-		ListAbout.AddItem(fs);
-
-		fs.Format(L" Cache directory: \"%s\"", InMyCache("",FALSE).c_str() );
-		ListAbout.AddItem(fs);
-
-		fs.Format(L"  Temp directory: \"%s\"", InMyTemp("").c_str() );
-		ListAbout.AddItem(fs);
-
-		ListAbout.AddItem(L"");
-
-		npl = CtrlObject->Plugins.GetPluginsCount();
-		fs.Format(L"Number of plugins: %d", npl);
-		ListAbout.AddItem(fs);
-
-		for(int i = 0; i < npl; i++)
-		{
-			ListAbout.AddItem(&mis);
-
-			fs.Format(L"Plugin#%02d | ",  i+1);
-
-			Plugin *pPlugin = CtrlObject->Plugins.GetPlugin(i);
-			if(pPlugin == nullptr) {
-				fs.Append(L"!!! ERROR get plugin");
-				ListAbout.AddItem(fs);
-				continue;
-			}
-			fs2 = fs;
-			fs2.Append( pPlugin->GetModuleName() );
-			ListAbout.AddItem(fs2);
-
-			fs2 = fs + L"Settings Name: ";
-			fs2.Append(pPlugin->GetSettingsName());
-			ListAbout.AddItem(fs2);
-
-			int iFlags;
-			PluginInfo pInfo{};
-			KeyFileReadHelper kfh(PluginsIni());
-			FARString fsCommandPrefix = L"";
-			FARString fsDiskMenuStrings = L"";
-			FARString fsPluginMenuStrings = L"";
-			FARString fsPluginConfigStrings = L"";
-
-			if (pPlugin->CheckWorkFlags(PIWF_CACHED)) {
-				iFlags = kfh.GetUInt(pPlugin->GetSettingsName(), "Flags", 0);
-				fsCommandPrefix = kfh.GetString(pPlugin->GetSettingsName(), "CommandPrefix", L"");
-				for (int j = 0; ; j++) {
-					const auto &key_name = StrPrintf("DiskMenuString%d", j);
-					/*if (!kfh.HasKey(key_name))
-						break;*/
-					fs2 = kfh.GetString(pPlugin->GetSettingsName(), key_name, "");
-					if( fs2.IsEmpty() )
-						break;
-					fsDiskMenuStrings.AppendFormat(L" %d=\"%ls\" ", j+1, fs2.CPtr());
-				}
-				for (int j = 0; ; j++) {
-					const auto &key_name = StrPrintf("PluginMenuString%d", j);
-					/*if (!kfh.HasKey(key_name))
-						break;*/
-					fs2 = kfh.GetString(pPlugin->GetSettingsName(), key_name, "");
-					if( fs2.IsEmpty() )
-						break;
-					fsPluginMenuStrings.AppendFormat(L" %d=\"%ls\" ", j+1, fs2.CPtr());
-				}
-				for (int j = 0; ; j++) {
-					const auto &key_name = StrPrintf("PluginConfigString%d", j);
-					/*if (!kfh.HasKey(key_name))
-						break;*/
-					fs2 = kfh.GetString(pPlugin->GetSettingsName(), key_name, "");
-					if( fs2.IsEmpty() )
-						break;
-					fsPluginConfigStrings.AppendFormat(L" %d=\"%ls\" ", j+1, fs2.CPtr());
-				}
-			}
-			else {
-				if (pPlugin->GetPluginInfo(&pInfo)) {
-					iFlags = pInfo.Flags;
-					fsCommandPrefix = pInfo.CommandPrefix;
-					for (int j = 0; j < pInfo.DiskMenuStringsNumber; j++)
-						fsDiskMenuStrings.AppendFormat(L" %d=\"%ls\"", j+1, pInfo.DiskMenuStrings[j]);
-					for (int j = 0; j < pInfo.PluginMenuStringsNumber; j++)
-						fsPluginMenuStrings.AppendFormat(L" %d=\"%ls\"", j+1, pInfo.PluginMenuStrings[j]);
-					for (int j = 0; j < pInfo.PluginConfigStringsNumber; j++)
-						fsPluginConfigStrings.AppendFormat(L" %d=\"%ls\"", j+1, pInfo.PluginConfigStrings[j]);
-				}
-				else
-					iFlags = -1;
-			}
-
-			fs2 = fs + L"    ";
-			fs2.AppendFormat(L" %s Cached ", pPlugin->CheckWorkFlags(PIWF_CACHED) ? "[x]" : "[ ]");
-			fs2.AppendFormat(L" %s Loaded ", pPlugin->GetFuncFlags() & PICFF_LOADED ? "[x]" : "[ ]");
-			ListAbout.AddItem(fs2);
-
-			if (iFlags >= 0) {
-				fs2 = fs + L"F11:";
-				fs2.AppendFormat(L" %s Panel  ", iFlags & PF_DISABLEPANELS ? "[ ]" : "[x]");
-				fs2.AppendFormat(L" %s Dialog ", iFlags & PF_DIALOG ? "[x]" : "[ ]");
-				fs2.AppendFormat(L" %s Viewer ", iFlags & PF_VIEWER ? "[x]" : "[ ]");
-				fs2.AppendFormat(L" %s Editor ", iFlags & PF_EDITOR ? "[x]" : "[ ]");
-				ListAbout.AddItem(fs2);
-			}
-			fs2 = fs + L"    ";
-			fs2.AppendFormat(L" %s EditorInput ", pPlugin->HasProcessEditorInput() ? "[x]" : "[ ]");
-			ListAbout.AddItem(fs2);
-
-			if ( !fsDiskMenuStrings.IsEmpty() ) {
-				fs2 = fs + L"    DiskMenuStrings:" + fsDiskMenuStrings;
-				ListAbout.AddItem(fs2);
-			}
-			if ( !fsPluginMenuStrings.IsEmpty() ) {
-				fs2 = fs + L"  PluginMenuStrings:" + fsPluginMenuStrings;
-				ListAbout.AddItem(fs2);
-			}
-			if ( !fsPluginConfigStrings.IsEmpty() ) {
-				fs2 = fs + L"PluginConfigStrings:" + fsPluginConfigStrings;
-				ListAbout.AddItem(fs2);
-			}
-			if ( !fsCommandPrefix.IsEmpty() ) {
-				fs2.Format(L"%ls      CommandPrefix: \"%ls\"", fs.CPtr(), fsCommandPrefix.CPtr());
-				ListAbout.AddItem(fs2);
-			}
-			
-		}
-
-		ListAbout.SetPosition(-1, -1, 0, 0);
-		//ListAbout.Process();
-		ListAbout.Show();
-		while (!ListAbout.Done()) {
-			int Key = ListAbout.ReadInput();
-			if (Key == KEY_ENTER || Key == KEY_NUMENTER)		// исключаем ENTER
-				continue;
-			ListAbout.ProcessInput();
-		}
-
+		FarAbout(CtrlObject->Plugins);
 		return true;
 	}
 
 	return false;
-
 }

--- a/far2l/src/cmdline.cpp
+++ b/far2l/src/cmdline.cpp
@@ -880,6 +880,7 @@ bool CommandLine::ProcessFarCommands(const wchar_t *CmdLine)
 		int npl;
 
 		VMenu ListAbout(L"far:about",nullptr,0,ScrY-4);
+		ListAbout.SetFlags(VMENU_SHOWAMPERSAND);
 		//ListAbout.SetFlags(VMENU_WRAPMODE);
 		//ListAbout.ClearFlags(VMENU_MOUSEDOWN);
 		//ListAbout.SetHelp(L"FarAbout");


### PR DESCRIPTION
new draft `far:config`: without editable
update draft `far:about`: expanded plugins information + refactoring

---

@elfmz правильно ли я понял, что в **far:about** реализованном через VMenu, нормально не запретить по щелчку мыши делать ENTER, в результате чего и закрывается VMenu?

Поставить для каждого элемента `Flags = LIF_GRAYED` не вариант - цвет сразу становится плохим 😿

`ReadInput` возвращает только клавиши, а тут `ProcessMouse` гонит преобразование уже внутри VMenu без его перехвата наружу.

Установка `ListAbout.SetFlags(VMENU_MOUSEDOWN);` или удаление `ListAbout.ClearFlags(VMENU_MOUSEDOWN);` также не такое поведение мыши не повлияло.

---


В **far:config** при включенном фильтре Ctrl-Alt-F пересоздание списка по Ctrl-H или Ctrl-A сбивает фильтрацию.
Вроде не увидел как проверить текущее состояние фильтра и его выкл - верно ли, что сейчас это всё private в VMenu?
Однако попытка не пересоздавать список, а вручную оперировать в нём `LIF_HIDDEN` дало вообще странности с прокруткой и т.п., что ещё значительно хуже.
