### PR TITLE
python >= 3.9

### DIFF
--- a/python/src/python.cpp
+++ b/python/src/python.cpp
@@ -21,8 +21,8 @@
 static struct PluginStartupInfo Info;
 static FARSTANDARDFUNCTIONS FSF;
 
-//#define PYPLUGIN_DEBUGLOG "/tmp/far2.py.log"
-// #define PYPLUGIN_DEBUGLOG "" /* to stderr */
+// #define PYPLUGIN_DEBUGLOG "/tmp/far2.py.log"
+ #define PYPLUGIN_DEBUGLOG "" /* to stderr */
 // #define PYPLUGIN_THREADED
 // #define PYPLUGIN_MEASURE_STARTUP
 
@@ -48,6 +48,8 @@ static void python_log(const char *function, unsigned int line, const char *form
 
     if (stream != stderr) {
         fclose(stream);
+    } else {
+        fflush(stderr);
     }
 }
 
@@ -55,39 +57,6 @@ static void python_log(const char *function, unsigned int line, const char *form
 #else
 #define PYTHON_LOG(args...)
 #endif
-
-#define PYTHON_VOID() \
-    if (pyresult != NULL) { \
-        Py_DECREF(pyresult); \
-    }
-
-#define PYTHON_HANDLE(default) \
-    HANDLE result = default; \
-    if (pyresult != NULL) { \
-        if( PyLong_Check(pyresult) ) { \
-            result = (HANDLE)PyLong_AsLong(pyresult); \
-            if (PyErr_Occurred()) { \
-                PyErr_Print(); \
-                result = default; \
-            } \
-        } \
-        Py_DECREF(pyresult); \
-    }
-
-#define PYTHON_INT(default) \
-    int result = default; \
-    if (pyresult != NULL) { \
-        if( PyLong_Check(pyresult) ) { \
-            result = PyLong_AsLong(pyresult); \
-            if (PyErr_Occurred()) { \
-                PyErr_Print(); \
-                result = default; \
-            } \
-        } \
-        Py_DECREF(pyresult); \
-    }
-
-
 
 static PyObject *
 far2l_CheckForInput(PyObject *self, PyObject *args)
@@ -134,12 +103,73 @@ PyInit_far2lc(void)
     return PyModule_Create(&far2lcmodule);
 }
 
+
+#define FAIL_IF_STATUS_EXCEPTION(status)                                       \
+  if (PyStatus_Exception(status)) {                                            \
+PYTHON_LOG("status exception\n"); \
+    goto done;                                                                 \
+  }
+
+bool init_python(std::string program_name)
+{
+#if 1
+    PyStatus status;
+
+    PyConfig config;
+    PyConfig_InitPythonConfig(&config);
+
+	//config.utf8_mode = 1;
+    config.parse_argv = 0;
+    config.install_signal_handlers = 0;
+    config.use_environment = 0;
+    config.user_site_directory = 1;
+
+    /* Set the program name before reading the configuration
+       (decode byte string from the locale encoding).
+
+       Implicitly preinitialize Python. */
+    status = PyConfig_SetBytesString(&config, &config.program_name, program_name.c_str());
+    FAIL_IF_STATUS_EXCEPTION(status);
+
+    /* Read all configuration at once */
+PYTHON_LOG("call PyConfig_Read\n");
+    status = PyConfig_Read(&config);
+    FAIL_IF_STATUS_EXCEPTION(status);
+
+PYTHON_LOG("call Py_InitializeFromConfig\n");
+    status = Py_InitializeFromConfig(&config);
+    FAIL_IF_STATUS_EXCEPTION(status);
+
+    PyImport_AppendInittab("farl2c", PyInit_far2lc);
+#if 0
+{
+    PyObject *sys_path = PySys_GetObject("path");
+//    PyList_Insert(sys_path, 0, PyUnicode_FromString("/devel/bin/python3/lib/python3.11/site-packages"));
+    PyList_Insert(sys_path, 0, PyUnicode_FromString("/path/to/mode/modules2"));
+    PySys_SetObject("path", sys_path);
+}
+#endif
+
+    PyConfig_Clear(&config);
+	return true;
+
+done:
+    PyConfig_Clear(&config);
+    return false;
+#else
+    PyImport_AppendInittab("farl2c", PyInit_far2lc);
+	Py_SetProgramName((wchar_t *)program_name.c_str());
+	return true;
+#endif
+}
+
 #ifdef PYPLUGIN_THREADED
 class PythonHolder : Threaded
 #else
 class PythonHolder
 #endif
 {
+    bool initok;
     std::string pluginPath;
     void *soPythonInterpreter = nullptr;
     PyObject *pyPluginModule = nullptr;
@@ -187,36 +217,36 @@ public:
             pluginPath.resize(pos);
         }
 
-        std::wstring progname;
 #ifdef VIRTUAL_PYTHON
-        StrMB2Wide(VIRTUAL_PYTHON, progname);
+        std::string progname = VIRTUAL_PYTHON;
 #else
-        StrMB2Wide(pluginPath, progname);
-        progname += L"/python/bin/python";
+        std::string progname = pluginPath;
+        progname += "/python/bin/python";
 #endif
 
-        PYTHON_LOG("pluginpath: %s, python library used:%s, progname: %ls\n", pluginPath.c_str(), PYTHON_LIBRARY, progname.c_str());
-
+        PYTHON_LOG("pluginpath: %s, python library used:%s, progname: %s\n", pluginPath.c_str(), PYTHON_LIBRARY, progname.c_str());
         soPythonInterpreter = dlopen(PYTHON_LIBRARY, RTLD_NOW | RTLD_GLOBAL);
         if( !soPythonInterpreter ){
             PYTHON_LOG("error %u from dlopen('%s')\n", errno, PYTHON_LIBRARY);
+            initok = false;
             return;
         }
-        PyImport_AppendInittab("far2lc", PyInit_far2lc);
-        Py_SetProgramName((wchar_t *)progname.c_str());
-        Py_Initialize();
-        PyEval_InitThreads();
 
-        //TranslateInstallPath_Lib2Share(pluginPath);
+        initok = init_python(progname);
+        if( initok )
+        {
+            Py_Initialize();
 
 #ifdef PYPLUGIN_THREADED
-        if (!StartThread()) {
-            PYTHON_LOG("StartThread failed, fallback to synchronous initialization\n");
-            ThreadProc();
-        }
+            if (!StartThread()) {
+                PYTHON_LOG("StartThread failed, fallback to synchronous initialization\n");
+                ThreadProc();
+            }
 #else
-        ThreadProc();
+            ThreadProc();
 #endif
+        }
+
     }
 
     virtual ~PythonHolder()
@@ -235,7 +265,8 @@ public:
             pyPluginModule = nullptr;
         }
 
-        Py_Finalize();
+        if( initok )
+            Py_Finalize();
 
         if( soPythonInterpreter != NULL ) {
             dlclose(soPythonInterpreter);
@@ -243,53 +274,111 @@ public:
         }
     }
 
-    PyObject *vcall(const char *func, int n, ...)
-    {
-#ifdef PYPLUGIN_THREADED
-        WaitThread();
-#endif
-
-        PyObject *pFunc;
-        PyObject *result = NULL;
-
-        if (pyPluginManager == NULL) {
-            return result;
-        }
-
-        // Acquire the GIL
-        PyGILState_STATE gstate = PyGILState_Ensure();
-
-        pFunc = PyObject_GetAttrString(pyPluginManager, func);
+    PyObject *pycall(const char *func, int n, va_list args){
+        PyObject *pyresult = NULL;
+        PyObject *pFunc = PyObject_GetAttrString(pyPluginManager, func);
         if (pFunc == NULL) {
-            goto eof;
+            return pyresult;
         }
 
         if (pFunc && PyCallable_Check(pFunc)) {
             PyObject *pArgs = PyTuple_New(n);
 
-            va_list args;
-            va_start(args, n);
             for (int i = 0; i < n; ++i) {
                 PyObject *pValue = PyLong_FromLong((long int)va_arg(args, void *));
                 PyTuple_SetItem(pArgs, i, pValue);
             }
-            va_end(args);
 
-            result = PyObject_CallObject(pFunc, pArgs);
+            pyresult = PyObject_CallObject(pFunc, pArgs);
             Py_DECREF(pArgs);
-            if (result == NULL) {
-                PyErr_Print();
-                goto eofr;
-            }
+        }
+        Py_XDECREF(pFunc);
+        return pyresult;
+    }
 
-        } else {
-            if (PyErr_Occurred())
-                PyErr_Print();
+    void vcall(const char *func, int n, ...)
+    {
+#ifdef PYPLUGIN_THREADED
+        WaitThread();
+#endif
+        if (pyPluginManager == NULL) {
+            return;
         }
 
-eofr:
-        Py_XDECREF(pFunc);
-eof:
+        // Acquire the GIL
+        PyGILState_STATE gstate = PyGILState_Ensure();
+
+        va_list args;
+        va_start(args, n);
+        PyObject *pyresult = this->pycall(func, n, args);
+        va_end(args);
+        if (pyresult == NULL || PyErr_Occurred()) {
+            PyErr_Print();
+            PYTHON_LOG("Failed to call \"%s\"\n", func);
+        }
+        Py_DECREF(pyresult);
+
+        // Release the GIL. No Python API allowed beyond this point.
+        PyGILState_Release(gstate);
+    }
+
+    int icall(int defresult, const char *func, int n, ...)
+    {
+#ifdef PYPLUGIN_THREADED
+        WaitThread();
+#endif
+        if (pyPluginManager == NULL) {
+            return defresult;
+        }
+
+        // Acquire the GIL
+        PyGILState_STATE gstate = PyGILState_Ensure();
+
+        int result = defresult;
+        va_list args;
+        va_start(args, n);
+        PyObject *pyresult = this->pycall(func, n, args);
+        va_end(args);
+        if( pyresult != NULL && PyLong_Check(pyresult) )
+            result = PyLong_AsLong(pyresult);
+        if (pyresult == NULL || PyErr_Occurred()) {
+            PyErr_Print();
+            PYTHON_LOG("Failed to call \"%s\"\n", func);
+            result = defresult;
+        }
+        Py_DECREF(pyresult);
+
+        // Release the GIL. No Python API allowed beyond this point.
+        PyGILState_Release(gstate);
+        return result;
+    }
+
+    HANDLE hcall(HANDLE defresult, const char *func, int n, ...)
+    {
+#ifdef PYPLUGIN_THREADED
+        WaitThread();
+#endif
+        if (pyPluginManager == NULL) {
+            return defresult;
+        }
+
+        // Acquire the GIL
+        PyGILState_STATE gstate = PyGILState_Ensure();
+
+        HANDLE result = defresult;
+        va_list args;
+        va_start(args, n);
+        PyObject *pyresult = this->pycall(func, n, args);
+        va_end(args);
+        if( pyresult != NULL && PyLong_Check(pyresult) )
+            result = (HANDLE)PyLong_AsLong(pyresult);
+        if (pyresult == NULL || PyErr_Occurred()) {
+            PyErr_Print();
+            PYTHON_LOG("Failed to call \"%s\"\n", func);
+            result = defresult;
+        }
+        Py_DECREF(pyresult);
+
         // Release the GIL. No Python API allowed beyond this point.
         PyGILState_Release(gstate);
         return result;
@@ -327,8 +416,7 @@ XPORT(void, SetStartupInfo)(const struct PluginStartupInfo *Info)
     ::Info=*Info;
     ::FSF=*Info->FSF;
     ::Info.FSF=&::FSF;
-    PyObject *pyresult = g_python_holder->vcall("SetStartupInfo", 1, &::Info);
-    PYTHON_VOID()
+    g_python_holder->vcall("SetStartupInfo", 1, &::Info);
 }
 
 XPORT(void, GetPluginInfo)(struct PluginInfo *Info)
@@ -339,8 +427,7 @@ XPORT(void, GetPluginInfo)(struct PluginInfo *Info)
     Info->DiskMenuStringsNumber = 0;
     Info->PluginMenuStringsNumber = 0;
     Info->PluginConfigStringsNumber = 0;
-    PyObject *pyresult = g_python_holder->vcall("GetPluginInfo", 1, Info);
-    PYTHON_VOID()
+    g_python_holder->vcall("GetPluginInfo", 1, Info);
 
     // enforce plugin preopening to be able to initialize python asynchronously
     Info->Flags|= PF_PREOPEN;
@@ -349,100 +436,73 @@ XPORT(void, GetPluginInfo)(struct PluginInfo *Info)
 XPORT(HANDLE, OpenPlugin)(int OpenFrom,INT_PTR Item)
 {
     PYTHON_LOG("OpenFrom=%d Item=%d\n", OpenFrom, Item);
-    PyObject *pyresult = g_python_holder->vcall("OpenPlugin", 2, OpenFrom, Item);
-    PYTHON_HANDLE(INVALID_HANDLE_VALUE)
-    return result;
+    return g_python_holder->hcall(INVALID_HANDLE_VALUE, "OpenPlugin", 2, OpenFrom, Item);
 }
 
 XPORT(void, ClosePlugin)(HANDLE hPlugin) {
     PYTHON_LOG("\n");
-    PyObject *pyresult = g_python_holder->vcall("ClosePlugin", 1, hPlugin);
-    PYTHON_VOID()
+    g_python_holder->vcall("ClosePlugin", 1, hPlugin);
 }
 
 XPORT(int, Compare)(HANDLE hPlugin,const PluginPanelItem *Item1,const PluginPanelItem *Item2,unsigned int Mode) {
     PYTHON_LOG("Mode=%d\n", Mode);
-    PyObject *pyresult = g_python_holder->vcall("Compare", 4, hPlugin, Item1, Item2, Mode);
-    PYTHON_INT(0)
-    return result;
+    return g_python_holder->icall(0, "Compare", 4, hPlugin, Item1, Item2, Mode);
 }
 XPORT(int, Configure)(int ItemNumber) {
     PYTHON_LOG("ItemNumber=%d\n", ItemNumber);
-    PyObject *pyresult = g_python_holder->vcall("Configure", 1, ItemNumber);
-    PYTHON_INT(0)
-    return result;
+    return g_python_holder->icall(0, "Configure", 1, ItemNumber);
 }
 XPORT(int, DeleteFiles)(HANDLE hPlugin,struct PluginPanelItem *PanelItem,int ItemsNumber,int OpMode) {
     PYTHON_LOG("ItemsNumber=%d OpMode=%d\n", ItemsNumber, OpMode);
-    PyObject *pyresult = g_python_holder->vcall("DeleteFiles", 4, hPlugin, PanelItem, ItemsNumber, OpMode);
-    PYTHON_INT(0)
-    return result;
+    return g_python_holder->icall(0, "DeleteFiles", 4, hPlugin, PanelItem, ItemsNumber, OpMode);
 }
 XPORT(void, ExitFAR)(void) {
     PYTHON_LOG("\n");
-    PyObject *pyresult = g_python_holder->vcall("ExitFAR", 0);
-    PYTHON_VOID()
+    g_python_holder->vcall("ExitFAR", 0);
     delete g_python_holder;
     g_python_holder = nullptr;
 }
 XPORT(void, FreeFindData)(HANDLE hPlugin,PluginPanelItem *PanelItem,int ItemsNumber) {
     PYTHON_LOG("ItemsNumber=%d\n", ItemsNumber);
-    PyObject *pyresult = g_python_holder->vcall("FreeFindData", 3, hPlugin, PanelItem, ItemsNumber);
-    PYTHON_VOID()
+    g_python_holder->vcall("FreeFindData", 3, hPlugin, PanelItem, ItemsNumber);
 }
 XPORT(void, FreeVirtualFindData)(HANDLE hPlugin,PluginPanelItem *PanelItem,int ItemsNumber) {
     PYTHON_LOG("ItemsNumber=%d\n", ItemsNumber);
-    PyObject *pyresult = g_python_holder->vcall("FreeVirtualFindData", 3, hPlugin, PanelItem, ItemsNumber);
-    PYTHON_VOID()
+    g_python_holder->vcall("FreeVirtualFindData", 3, hPlugin, PanelItem, ItemsNumber);
 }
 XPORT(int, GetFiles)(HANDLE hPlugin,PluginPanelItem *PanelItem,int ItemsNumber,int Move,const wchar_t **DestPath,int OpMode) {
     PYTHON_LOG("ItemsNumber=%d Move=%d OpMode=%d\n", ItemsNumber, Move, OpMode);
-    PyObject *pyresult = g_python_holder->vcall("GetFiles", 6, hPlugin, PanelItem, ItemsNumber, Move, DestPath, OpMode);
-    PYTHON_INT(0)
-    return result;
+    return g_python_holder->icall(0, "GetFiles", 6, hPlugin, PanelItem, ItemsNumber, Move, DestPath, OpMode);
 }
 XPORT(int, GetFindData)(HANDLE hPlugin,PluginPanelItem **pPanelItem,int *pItemsNumber,int OpMode) {
     PYTHON_LOG("OpMode=%d\n", OpMode);
-    PyObject *pyresult = g_python_holder->vcall("GetFindData", 4, hPlugin, pPanelItem, pItemsNumber, OpMode);
-    PYTHON_INT(0)
-    return result;
+    return g_python_holder->icall(0, "GetFindData", 4, hPlugin, pPanelItem, pItemsNumber, OpMode);
 }
 XPORT(void, GetOpenPluginInfo)(HANDLE hPlugin, OpenPluginInfo *Info) {
     PYTHON_LOG("\n");
     memset(Info, 0, sizeof(*Info));
     Info->StructSize = sizeof(*Info);
-    PyObject *pyresult = g_python_holder->vcall("GetOpenPluginInfo", 2, hPlugin, Info);
-    PYTHON_VOID()
+    g_python_holder->icall(0, "GetOpenPluginInfo", 2, hPlugin, Info);
 }
 XPORT(int, GetVirtualFindData)(HANDLE hPlugin, PluginPanelItem **pPanelItem, int *pItemsNumber, const wchar_t *Path) {
     PYTHON_LOG("\n");
-    PyObject *pyresult = g_python_holder->vcall("GetVirtualFindData", 4, hPlugin, pPanelItem, pItemsNumber, Path);
-    PYTHON_INT(0)
-    return result;
+    return g_python_holder->icall(0, "GetVirtualFindData", 4, hPlugin, pPanelItem, pItemsNumber, Path);
 }
 XPORT(int, MakeDirectory)(HANDLE hPlugin,const wchar_t **Name,int OpMode) {
     PYTHON_LOG("OpMode=%d\n", OpMode);
-    PyObject *pyresult = g_python_holder->vcall("MakeDirectory", 3, hPlugin, Name, OpMode);
-    PYTHON_INT(0)
-    return result;
+    return g_python_holder->icall(0, "MakeDirectory", 3, hPlugin, Name, OpMode);
 }
 XPORT(HANDLE, OpenFilePlugin)(const wchar_t *Name,const unsigned char *Data,int DataSize,int OpMode) {
     PYTHON_LOG("OpMode=%d Name='%ls'\n", OpMode, Name);
-    PyObject *pyresult = g_python_holder->vcall("OpenFilePlugin", 4, Name, Data, DataSize, OpMode);
-    PYTHON_HANDLE(INVALID_HANDLE_VALUE)
-    return result;
+    return g_python_holder->hcall(INVALID_HANDLE_VALUE, "OpenFilePlugin", 4, Name, Data, DataSize, OpMode);
 }
 XPORT(int, ProcessDialogEvent)(int Event,void *Param) {
     PYTHON_LOG("Event=%d\n", Event);
-    PyObject *pyresult = g_python_holder->vcall("ProcessDialogEvent", 2, Event, Param);
-    PYTHON_INT(0)
-    return result;
+    return g_python_holder->icall(0, "ProcessDialogEvent", 2, Event, Param);
 }
 XPORT(int, ProcessEditorEvent)(int Event,void *Param) {
     PYTHON_LOG("Event=%d\n", Event);
-    PyObject *pyresult = g_python_holder->vcall("ProcessEditorEvent", 2, Event, Param);
-    PYTHON_INT(0)
-    return result;
+    return g_python_holder->icall(0, "ProcessEditorEvent", 2, Event, Param);
 }
 XPORT(int, ProcessEditorInput)(const INPUT_RECORD *Rec) {
     PYTHON_LOG("keydown=%d vkey=%08X cstate=%08X ra=%d la=%d rc=%d lc=%d sh=%d\n",
@@ -455,84 +515,60 @@ XPORT(int, ProcessEditorInput)(const INPUT_RECORD *Rec) {
         (Rec->Event.KeyEvent.dwControlKeyState & LEFT_CTRL_PRESSED) != 0,
         (Rec->Event.KeyEvent.dwControlKeyState & SHIFT_PRESSED) != 0
     );
-    PyObject *pyresult = g_python_holder->vcall("ProcessEditorInput", 1, Rec);
-    PYTHON_INT(0)
-    return result;
+    return g_python_holder->icall(0, "ProcessEditorInput", 1, Rec);
 }
 XPORT(int, ProcessEvent)(HANDLE hPlugin,int Event,void *Param) {
     PYTHON_LOG("Event=%d\n", Event);
-    PyObject *pyresult = g_python_holder->vcall("ProcessEvent", 3, hPlugin, Event, Param);
-    PYTHON_INT(0)
-    return result;
+    return g_python_holder->icall(0, "ProcessEvent", 3, hPlugin, Event, Param);
 }
 XPORT(int, ProcessHostFile)(HANDLE hPlugin,struct PluginPanelItem *PanelItem,int ItemsNumber,int OpMode) {
     PYTHON_LOG("ItemsNumber=%d OpMode=%d\n", ItemsNumber, OpMode);
-    PyObject *pyresult = g_python_holder->vcall("ProcessHostFile", 4, hPlugin, PanelItem, ItemsNumber, OpMode);
-    PYTHON_INT(0)
-    return result;
+    return g_python_holder->icall(0, "ProcessHostFile", 4, hPlugin, PanelItem, ItemsNumber, OpMode);
 }
 XPORT(int, ProcessKey)(HANDLE hPlugin,int Key,unsigned int ControlState) {
     PYTHON_LOG("Key=%d ControlState=0x%x\n", Key, ControlState);
-    PyObject *pyresult = g_python_holder->vcall("ProcessKey", 3, hPlugin, Key, ControlState);
-    PYTHON_INT(0)
-    return result;
+    return g_python_holder->icall(0, "ProcessKey", 3, hPlugin, Key, ControlState);
 }
 XPORT(int, ProcessSynchroEvent)(int Event,void *Param) {
     PYTHON_LOG("Event=%d\n", Event);
-    PyObject *pyresult = g_python_holder->vcall("ProcessSynchroEvent", 2, Event, Param);
-    PYTHON_INT(0)
-    return result;
+    return g_python_holder->icall(0, "ProcessSynchroEvent", 2, Event, Param);
 }
 XPORT(int, ProcessViewerEvent)(int Event,void *Param) {
     PYTHON_LOG("Event=%d\n", Event);
-    PyObject *pyresult = g_python_holder->vcall("ProcessViewerEvent", 2, Event, Param);
-    PYTHON_INT(0)
-    return result;
+    return g_python_holder->icall(0, "ProcessViewerEvent", 2, Event, Param);
 }
 XPORT(int, PutFiles)(HANDLE hPlugin, PluginPanelItem *PanelItem, int ItemsNumber, int Move,const wchar_t *SrcPath, int OpMode) {
     PYTHON_LOG("ItemsNumber=%d Move=%d OpMode=%d SrcPath='%ls'\n", ItemsNumber, Move, OpMode, SrcPath);
-    PyObject *pyresult = g_python_holder->vcall("PutFiles", 6, hPlugin, PanelItem, ItemsNumber, Move, SrcPath, OpMode);
-    PYTHON_INT(0)
-    return result;
+    return g_python_holder->icall(0, "PutFiles", 6, hPlugin, PanelItem, ItemsNumber, Move, SrcPath, OpMode);
 }
 XPORT(int, SetDirectory)(HANDLE hPlugin,const wchar_t *Dir,int OpMode) {
     PYTHON_LOG("OpMode=%d Dir='%ls'\n", OpMode, Dir);
-    PyObject *pyresult = g_python_holder->vcall("SetDirectory", 3, hPlugin, Dir, OpMode);
-    PYTHON_INT(0)
-    return result;
+    return g_python_holder->icall(0, "SetDirectory", 3, hPlugin, Dir, OpMode);
 }
 XPORT(int, SetFindList)(HANDLE hPlugin,const PluginPanelItem *PanelItem,int ItemsNumber) {
     PYTHON_LOG("ItemsNumber=%d\n", ItemsNumber);
-    PyObject *pyresult = g_python_holder->vcall("SetFindList", 3, hPlugin, PanelItem, ItemsNumber);
-    PYTHON_INT(0)
-    return result;
+    return g_python_holder->icall(0, "SetFindList", 3, hPlugin, PanelItem, ItemsNumber);
 }
 XPORT(int, MayExitFAR)(void)
 {
     PYTHON_LOG("\n");
-    PyObject *pyresult = g_python_holder->vcall("MayExitFAR", 0);
-    PYTHON_INT(1)
-    return result;
+    return g_python_holder->icall(1, "MayExitFAR", 0);
 }
+
 #if 0
 XPORT(int, Analyse)(const AnalyseData *pData)
 {
     PYTHON_LOG("\n");
-    PyObject *pyresult = g_python_holder->vcall("Analyse", 1, pData);
-    PYTHON_INT(0)
-    return result;
+    return (int)g_python_holder->vcall("Analyse", 1, pData);
 }
 XPORT(int, GetCustomData)(const wchar_t *FilePath, wchar_t **CustomData)
 {
     PYTHON_LOG("FilePath=%ls\n", FilePath);
-    PyObject *pyresult = g_python_holder->vcall("GetCustomData", 2, FilePath, CustomData);
-    PYTHON_INT(0)
-    return result;
+    return (int)g_python_holder->vcall("GetCustomData", 2, FilePath, CustomData);
 }
 XPORT(void, FreeCustomData)(wchar_t *CustomData)
 {
     PYTHON_LOG("\n");
-    PyObject *pyresult = g_python_holder->vcall("FreeCustomData", 1, CustomData);
-    PYTHON_VOID()
+    g_python_holder->vcall("FreeCustomData", INVALID_HANDLE_VALUE, 1, CustomData);
 }
 #endif

--- a/python/src/python.cpp
+++ b/python/src/python.cpp
@@ -118,7 +118,7 @@ bool init_python(std::string program_name)
     PyConfig config;
     PyConfig_InitPythonConfig(&config);
 
-	//config.utf8_mode = 1;
+    //config.utf8_mode = 1;
     config.parse_argv = 0;
     config.install_signal_handlers = 0;
     config.use_environment = 0;
@@ -151,15 +151,15 @@ PYTHON_LOG("call Py_InitializeFromConfig\n");
 #endif
 
     PyConfig_Clear(&config);
-	return true;
+    return true;
 
 done:
     PyConfig_Clear(&config);
     return false;
 #else
     PyImport_AppendInittab("farl2c", PyInit_far2lc);
-	Py_SetProgramName((wchar_t *)program_name.c_str());
-	return true;
+    Py_SetProgramName((wchar_t *)program_name.c_str());
+    return true;
 #endif
 }
 

--- a/python/src/pythongen.py
+++ b/python/src/pythongen.py
@@ -84,18 +84,21 @@ data = """\\
     fp.write('''\
 import cffi
 ffi = cffi.FFI()
-packed = False
+pack = None
 while True:
     i = data.find('//#pragma pack')
     if i < 0:
-        ffi.cdef(data, packed=packed)
+        ffi.cdef(data, pack=pack)
         break
     ndata = data[:i]
-    ffi.cdef(ndata, packed=packed)
+    ffi.cdef(ndata, pack=pack)
     data = data[i:]
     i = data.find(')')
     s = data[:i+1]
-    packed = s.find('()') < 0
+    if s.find('()') > 0:
+        pack = None
+    else:
+        pack = 2
     data = data[i+1:]
-del packed, data, i, ndata, s
+del pack, data, i, ndata, s
 ''')


### PR DESCRIPTION
changes allowing the use of python >= 3.9
PyErr_Print belongs to the API and cannot be called after PyGILState_Release
resolves #1818