### PR TITLE
New Flag VMENU_BYSINGLEMOUSECLICK_ONLYSELECT

### DIFF
--- a/far2l/src/cfg/ConfigSaveLoad.cpp
+++ b/far2l/src/cfg/ConfigSaveLoad.cpp
@@ -835,7 +835,7 @@ void AdvancedConfig()
 	FARString title = L"far:config";
 
 	VMenu ListConfig(title + (bHideUnchanged ? L" *" : L""),nullptr,0,ScrY-4);
-	ListConfig.SetFlags(VMENU_SHOWAMPERSAND | VMENU_BYSINGLEMOUSECLICK_ONLYSELECT);
+	ListConfig.SetFlags(VMENU_SHOWAMPERSAND | VMENU_IGNORE_SINGLECLICK);
 	ListConfig.ClearFlags(VMENU_MOUSEREACTION);
 	//ListConfig.SetFlags(VMENU_WRAPMODE);
 	//ListConfig.SetHelp(L"FarConfig");

--- a/far2l/src/cfg/ConfigSaveLoad.cpp
+++ b/far2l/src/cfg/ConfigSaveLoad.cpp
@@ -835,9 +835,9 @@ void AdvancedConfig()
 	FARString title = L"far:config";
 
 	VMenu ListConfig(title + (bHideUnchanged ? L" *" : L""),nullptr,0,ScrY-4);
-	ListConfig.SetFlags(VMENU_SHOWAMPERSAND);
+	ListConfig.SetFlags(VMENU_SHOWAMPERSAND | VMENU_BYSINGLEMOUSECLICK_ONLYSELECT);
+	ListConfig.ClearFlags(VMENU_MOUSEREACTION);
 	//ListConfig.SetFlags(VMENU_WRAPMODE);
-	//ListConfig.ClearFlags(VMENU_MOUSEDOWN);
 	//ListConfig.SetHelp(L"FarConfig");
 
 	ListConfig.SetBottomTitle(L"ESC or F10 to close, Ctrl-Alt-F - filtering, Ctrl-H - changed/all, Ctrl-A - names left/dot");
@@ -850,35 +850,36 @@ void AdvancedConfig()
 	ListConfig.SetPosition(-1, -1, 0, 0);
 	//ListConfig.Process();
 	ListConfig.Show();
-	while (!ListConfig.Done()) {
-		int Key = ListConfig.ReadInput();
-		switch (Key) {
-			case KEY_ENTER:
-			case KEY_NUMENTER: {
-				int i = ListConfig.GetSelectPos();
-				if (i>=0)
-					s_opt_serializers[i].Msg(title);
-				}
-				continue;
-			case KEY_CTRLH:
-				bHideUnchanged = !bHideUnchanged;
-				ListConfig.SetTitle(title + (bHideUnchanged ? L" *" : L""));
-				break;
-			case KEY_CTRLA:
-				bAlignDot = !bAlignDot;
-				break;
-			default:
-				ListConfig.ProcessInput();
-				continue;
-		}
+	int iListExitCode = 0;
+	do {
+		while (!ListConfig.Done()) {
+			int Key = ListConfig.ReadInput();
+			switch (Key) {
+				case KEY_CTRLH:
+					bHideUnchanged = !bHideUnchanged;
+					ListConfig.SetTitle(title + (bHideUnchanged ? L" *" : L""));
+					break;
+				case KEY_CTRLA:
+					bAlignDot = !bAlignDot;
+					break;
+				default:
+					ListConfig.ProcessInput();
+					continue;
+			}
 
-		// regenerate items in loop only if not was contunue
-		int sel_pos = ListConfig.GetSelectPos();
-		ListConfig.DeleteItems();
-		for (const auto &opt_ser : s_opt_serializers)
-			opt_ser.MenuListAppend(ListConfig, len_sections, len_keys, len_sections_keys, bHideUnchanged, bAlignDot);
-		ListConfig.SetSelectPos(sel_pos,0);
-		ListConfig.SetPosition(-1, -1, 0, 0);
-		ListConfig.Show();
-	}
+			// regenerate items in loop only if not was contunue
+			int sel_pos = ListConfig.GetSelectPos();
+			ListConfig.DeleteItems();
+			for (const auto &opt_ser : s_opt_serializers)
+				opt_ser.MenuListAppend(ListConfig, len_sections, len_keys, len_sections_keys, bHideUnchanged, bAlignDot);
+			ListConfig.SetSelectPos(sel_pos,0);
+			ListConfig.SetPosition(-1, -1, 0, 0);
+			ListConfig.Show();
+		}
+		iListExitCode = ListConfig.GetExitCode();
+		if (iListExitCode>=0) {
+			ListConfig.ClearDone(); // no close after select item by ENTER or mouse click
+			s_opt_serializers[iListExitCode].Msg(title);
+		}
+	} while(iListExitCode>=0);
 }

--- a/far2l/src/cmdline.cpp
+++ b/far2l/src/cmdline.cpp
@@ -861,9 +861,9 @@ void FarAbout(PluginManager &Plugins)
 	int npl;
 
 	VMenu ListAbout(L"far:about",nullptr,0,ScrY-4);
-	ListAbout.SetFlags(VMENU_SHOWAMPERSAND);
+	ListAbout.SetFlags(VMENU_SHOWAMPERSAND | VMENU_BYSINGLEMOUSECLICK_ONLYSELECT);
+	ListAbout.ClearFlags(VMENU_MOUSEREACTION);
 	//ListAbout.SetFlags(VMENU_WRAPMODE);
-	//ListAbout.ClearFlags(VMENU_MOUSEDOWN);
 	//ListAbout.SetHelp(L"FarAbout");
 	ListAbout.SetBottomTitle(L"ESC or F10 to close, Ctrl-Alt-F - filtering");
 
@@ -1046,14 +1046,13 @@ void FarAbout(PluginManager &Plugins)
 	}
 
 	ListAbout.SetPosition(-1, -1, 0, 0);
-	//ListAbout.Process();
-	ListAbout.Show();
-	while (!ListAbout.Done()) {
-		int Key = ListAbout.ReadInput();
-		if (Key == KEY_ENTER || Key == KEY_NUMENTER)		// исключаем ENTER
-			continue;
-		ListAbout.ProcessInput();
-	}
+	int iListExitCode = 0;
+	do {
+		ListAbout.Process();
+		iListExitCode = ListAbout.GetExitCode();
+		if (iListExitCode>=0)
+			ListAbout.ClearDone(); // no close after select item by ENTER or mouse click
+	} while(iListExitCode>=0);
 }
 
 bool CommandLine::ProcessFarCommands(const wchar_t *CmdLine)

--- a/far2l/src/cmdline.cpp
+++ b/far2l/src/cmdline.cpp
@@ -861,7 +861,7 @@ void FarAbout(PluginManager &Plugins)
 	int npl;
 
 	VMenu ListAbout(L"far:about",nullptr,0,ScrY-4);
-	ListAbout.SetFlags(VMENU_SHOWAMPERSAND | VMENU_BYSINGLEMOUSECLICK_ONLYSELECT);
+	ListAbout.SetFlags(VMENU_SHOWAMPERSAND | VMENU_IGNORE_SINGLECLICK);
 	ListAbout.ClearFlags(VMENU_MOUSEREACTION);
 	//ListAbout.SetFlags(VMENU_WRAPMODE);
 	//ListAbout.SetHelp(L"FarAbout");

--- a/far2l/src/vmenu.cpp
+++ b/far2l/src/vmenu.cpp
@@ -1330,12 +1330,12 @@ int VMenu::ProcessMouse(MOUSE_EVENT_RECORD *MouseEvent)
 							& (FROM_LEFT_1ST_BUTTON_PRESSED | RIGHTMOST_BUTTON_PRESSED))
 					&& CheckFlags(VMENU_MOUSEDOWN)) {
 				ClearFlags(VMENU_MOUSEDOWN);
-				if (CheckFlags(VMENU_BYSINGLEMOUSECLICK_ONLYSELECT))
+				if (CheckFlags(VMENU_IGNORE_SINGLECLICK))
 					SetSelectPos(MsPos, 1);
 				else
 					ProcessKey(KEY_ENTER);
 			}
-			if (MouseEvent->dwEventFlags==DOUBLE_CLICK) // need if VMENU_BYSINGLEMOUSECLICK_ONLYSELECT disable ENTER by click
+			if (MouseEvent->dwEventFlags==DOUBLE_CLICK) // need if VMENU_IGNORE_SINGLECLICK disable ENTER by click
 					ProcessKey(KEY_ENTER);
 		}
 

--- a/far2l/src/vmenu.cpp
+++ b/far2l/src/vmenu.cpp
@@ -1330,8 +1330,13 @@ int VMenu::ProcessMouse(MOUSE_EVENT_RECORD *MouseEvent)
 							& (FROM_LEFT_1ST_BUTTON_PRESSED | RIGHTMOST_BUTTON_PRESSED))
 					&& CheckFlags(VMENU_MOUSEDOWN)) {
 				ClearFlags(VMENU_MOUSEDOWN);
-				ProcessKey(KEY_ENTER);
+				if (CheckFlags(VMENU_BYSINGLEMOUSECLICK_ONLYSELECT))
+					SetSelectPos(MsPos, 1);
+				else
+					ProcessKey(KEY_ENTER);
 			}
+			if (MouseEvent->dwEventFlags==DOUBLE_CLICK) // need if VMENU_BYSINGLEMOUSECLICK_ONLYSELECT disable ENTER by click
+					ProcessKey(KEY_ENTER);
 		}
 
 		return TRUE;

--- a/far2l/src/vmenu.hpp
+++ b/far2l/src/vmenu.hpp
@@ -87,6 +87,7 @@ enum VMENU_FLAGS
 	VMENU_CHANGECONSOLETITLE = 0x01000000,			//
 	VMENU_MOUSEREACTION      = 0x02000000,			// реагировать на движение мыши? (перемещать позицию при перемещении курсора мыши?)
 	VMENU_DISABLED = 0x04000000,					//
+	VMENU_BYSINGLEMOUSECLICK_ONLYSELECT = 0x08000000,	// по щелчку не ENTER, а только выбор строки (полезно при снятом VMENU_MOUSEREACTION)
 };
 
 class Dialog;

--- a/far2l/src/vmenu.hpp
+++ b/far2l/src/vmenu.hpp
@@ -87,7 +87,7 @@ enum VMENU_FLAGS
 	VMENU_CHANGECONSOLETITLE = 0x01000000,			//
 	VMENU_MOUSEREACTION      = 0x02000000,			// реагировать на движение мыши? (перемещать позицию при перемещении курсора мыши?)
 	VMENU_DISABLED = 0x04000000,					//
-	VMENU_BYSINGLEMOUSECLICK_ONLYSELECT = 0x08000000,	// по щелчку не ENTER, а только выбор строки (полезно при снятом VMENU_MOUSEREACTION)
+	VMENU_IGNORE_SINGLECLICK = 0x08000000,			// по щелчку не ENTER, а только выбор строки (полезно при снятом VMENU_MOUSEREACTION)
 };
 
 class Dialog;


### PR DESCRIPTION
* vmenu: - new Flag VMENU_BYSINGLEMOUSECLICK_ONLYSELECT not produce ENTER (usefull when VMENU_MOUSEREACTION clear) - by DOUBLE_CLICK always produce ENTER
* `far:about` & `far:config` use VMENU_BYSINGLEMOUSECLICK_ONLYSELECT