### PR TITLE
clang-format update and schema overrides

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,14 +4,22 @@ IndentWidth:  4
 TabWidth:     4
 Language:     Cpp
 Standard:     Latest
-SortIncludes: false
+SortIncludes: Never
 
 AccessModifierOffset:              -4
 AlignAfterOpenBracket:             DontAlign
-AlignConsecutiveAssignments:         false
-AlignConsecutiveDeclarations:      false
-AlignConsecutiveBitFields:         true
-AlignConsecutiveMacros:            true
+AlignConsecutiveAssignments:
+  Enabled: false
+AlignConsecutiveDeclarations:
+  Enabled: false
+AlignConsecutiveBitFields:
+  Enabled: true
+  AcrossEmptyLines: true
+  AcrossComments: true
+AlignConsecutiveMacros:
+  Enabled: true
+  AcrossEmptyLines: true
+  AcrossComments: true
 AllowAllArgumentsOnNextLine:       false
 AllowShortFunctionsOnASingleLine:  Inline
 AllowShortLambdasOnASingleLine:    Empty
@@ -25,7 +33,7 @@ IndentCaseLabels:                  true
 BreakBeforeBraces:       Custom
 BraceWrapping:
   AfterClass:            true
-  AfterControlStatement: false
+  AfterControlStatement: Never
   AfterEnum:             true
   AfterFunction:         true
   AfterNamespace:        true

--- a/.clang-format.json
+++ b/.clang-format.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "far2l-clang-format",
+  "title": "ClangFormat Options for far2l",
+  "allOf": [
+    {
+      "$ref": "http://jetbrains.com/schema/clangformat.json"
+    }
+  ],
+  "properties": {
+    "UseTab": {
+      "title": "The way to use tab characters in the resulting file.",
+      "x-intellij-html-description": "Modified to match https://github.com/elfmz/llvm-project",
+      "enum": [
+        "Never",
+        "ForIndentation",
+        "ForContinuationAndIndentation",
+        "AlignWithSpaces",
+        "Always",
+        "ForContinuationAndIndentationAndComments"
+      ],
+      "type": "string"
+    },
+    "AlignByTab": {
+      "title": "Align by tab.",
+      "x-intellij-html-description": "Added to match https://github.com/elfmz/llvm-project",
+      "type": "boolean"
+    },
+    "BreakConstructorInitializers": {
+      "title": "Break constructor initializers.",
+      "x-intellij-html-description": "Modified to match https://github.com/elfmz/llvm-project",
+      "enum": [
+        "AfterColonSeparated"
+      ],
+      "type": "string"
+    },
+    "SpaceBeforeAssignmentOperators": {
+      "title": "If `false`, spaces will be removed before assignment operators.",
+      "x-intellij-html-description": "Modified to match https://github.com/elfmz/llvm-project",
+      "enum": [
+        "OnlyTrivial"
+      ],
+      "type": "string"
+    },
+    "AlignConsecutiveMembersAssignments": {
+      "title": "Align consecutive members assignments.",
+      "x-intellij-html-description": "Added to match https://github.com/elfmz/llvm-project",
+      "type": "boolean"
+    },
+    "AllowLongTrailingComments": {
+      "title": "Allow long trailing comments.",
+      "x-intellij-html-description": "Added to match https://github.com/elfmz/llvm-project",
+      "type": "boolean"
+    }
+  }
+}


### PR DESCRIPTION
.clang-format updated to the current syntax according to the [ClangFormatStyleOptions](https://clang.llvm.org/docs/ClangFormatStyleOptions.html )

additionally schema overrides for CLion added as .clang-format.json to reflect changes from https://github.com/elfmz/llvm-project repo