### PR TITLE
Fix for issue #1873

### DIFF
--- a/NetRocks/src/Protocol/SHELL/Parse.h
+++ b/NetRocks/src/Protocol/SHELL/Parse.h
@@ -3,6 +3,8 @@
 #include <vector>
 #include <string>
 #include "../../FileInformation.h"
+#include <cstdint>
+
 
 struct FileInfo
 {

--- a/NetRocks/src/UI/Settings/ConfigureProtocolSHELL.cpp
+++ b/NetRocks/src/UI/Settings/ConfigureProtocolSHELL.cpp
@@ -7,6 +7,7 @@
 #include "../DialogUtils.h"
 #include "../../Globals.h"
 #include "../../Protocol/SHELL/WayToShellConfig.h"
+#include <stdexcept>
 
 /*                                                  55
 345                      28     35                53


### PR DESCRIPTION
Fix for  NetRocks-SHELL fail to build due to missing include <cstdint>