### PR TITLE
Update setattr.cpp and filefilterparams.cpp

### DIFF
--- a/far2l/src/filefilterparams.cpp
+++ b/far2l/src/filefilterparams.cpp
@@ -801,20 +801,20 @@ bool FileFilterConfig(FileFilterParams *FF, bool ColorConfig)
 	switch (DateFormat) {
 		case 0:
 			// Маска даты для форматов DD.MM.YYYYY и MM.DD.YYYYY
-			strDateMask.Format(L"99%c99%c99999", DateSeparator, DateSeparator);
+			strDateMask.Format(L"99%c99%c9999N", DateSeparator, DateSeparator);
 			break;
 		case 1:
 			// Маска даты для форматов DD.MM.YYYYY и MM.DD.YYYYY
-			strDateMask.Format(L"99%c99%c99999", DateSeparator, DateSeparator);
+			strDateMask.Format(L"99%c99%c9999N", DateSeparator, DateSeparator);
 			break;
 		default:
 			// Маска даты для формата YYYYY.MM.DD
-			strDateMask.Format(L"99999%c99%c99", DateSeparator, DateSeparator);
+			strDateMask.Format(L"N9999%c99%c99", DateSeparator, DateSeparator);
 			break;
 	}
 
 	// Маска времени
-	strTimeMask.Format(L"99%c99%c99%c999", TimeSeparator, TimeSeparator, DecimalSeparator);
+	strTimeMask.Format(L"99%c99%c99%c99N", TimeSeparator, TimeSeparator, DecimalSeparator);
 	DialogDataEx FilterDlgData[] = {
 		{DI_DOUBLEBOX,   3,           1,  84,     18, {},                                  DIF_SHOWAMPERSAND,                      Msg::FileFilterTitle             },
 

--- a/far2l/src/setattr.cpp
+++ b/far2l/src/setattr.cpp
@@ -839,7 +839,7 @@ bool ShellSetFileAttributes(Panel *SrcPanel, LPCWSTR Object)
 		wchar_t DateSeparator = GetDateSeparator();
 		wchar_t TimeSeparator = GetTimeSeparator();
 		wchar_t DecimalSeparator = GetDecimalSeparator();
-		LPCWSTR FmtMask1 = L"99%c99%c99%c999", FmtMask2 = L"99%c99%c99999", FmtMask3 = L"99999%c99%c99";
+		LPCWSTR FmtMask1 = L"99%c99%c99%c999", FmtMask2 = L"99%c99%c9999N", FmtMask3 = L"N9999%c99%c99";
 		FARString strDMask, strTMask;
 		strTMask.Format(FmtMask1, TimeSeparator, TimeSeparator, DecimalSeparator);
 

--- a/far2l/src/setattr.cpp
+++ b/far2l/src/setattr.cpp
@@ -839,7 +839,7 @@ bool ShellSetFileAttributes(Panel *SrcPanel, LPCWSTR Object)
 		wchar_t DateSeparator = GetDateSeparator();
 		wchar_t TimeSeparator = GetTimeSeparator();
 		wchar_t DecimalSeparator = GetDecimalSeparator();
-		LPCWSTR FmtMask1 = L"99%c99%c99%c999", FmtMask2 = L"99%c99%c9999N", FmtMask3 = L"N9999%c99%c99";
+		LPCWSTR FmtMask1 = L"99%c99%c99%c99N", FmtMask2 = L"99%c99%c9999N", FmtMask3 = L"N9999%c99%c99";
 		FARString strDMask, strTMask;
 		strTMask.Format(FmtMask1, TimeSeparator, TimeSeparator, DecimalSeparator);
 


### PR DESCRIPTION
fix:
FmtMask1 = L"99%c99%c99%c99N"
FmtMask2 = L"99%c99%c9999N"
and
FmtMask3 = L"N9999%c99%c99";

without this in Attributes dialog (Ctrl+A)
field year contains 5 digits number instead of  1 space and 4 digits. 
And because of this displayed date it's not correct, 
date "2023/10/13"
is displayed as "20231/01/3 "


fix: filefilterparams.cpp
function bool FileFilterConfig(FileFilterParams *FF, bool ColorConfig)
// ...
switch (DateFormat) {
// ...
strDateMask.Format(L"99%c99%c9999N", DateSeparator, DateSeparator);
// ...
strDateMask.Format(L"99%c99%c9999N", DateSeparator, DateSeparator);
// ...
strDateMask.Format(L"N9999%c99%c99", DateSeparator, DateSeparator);
// ...
}
// ...
strTimeMask.Format(L"99%c99%c99%c99N", TimeSeparator, TimeSeparator, DecimalSeparator);
// ...