### PR TITLE
delete.cpp: correct messages and behavior during deleting symbolic links

### DIFF
--- a/far2l/bootstrap/scripts/farlang.templ.m4
+++ b/far2l/bootstrap/scripts/farlang.templ.m4
@@ -5175,6 +5175,18 @@ AskWipeRO
 "Ви хочете знищити його?"
 "Вы жадаеце знішчыць яго?"
 
+DeleteSymLink1
+l:
+"Это symlink на файл"
+"This is a symlink to the file"
+upd:"This is a symlink to the file"
+upd:"This is a symlink to the file"
+upd:"This is a symlink to the file"
+upd:"This is a symlink to the file"
+upd:"This is a symlink to the file"
+upd:"This is a symlink to the file"
+upd:"This is a symlink to the file"
+
 DeleteHardLink1
 l:
 "Файл имеет несколько жёстких ссылок"


### PR DESCRIPTION
* При удалении симлинка на файл или на каталог удаляется именно симлинк - это логично.
  Используя существующие DeleteLinkTitle, AskDeleteLink, AskDeleteLinkFolder и AskDeleteLinkFile
  сделал, чтобы текст диалогового окна отличался от удаления обычного файла/каталога
  хотя бы при удалении единичного symlink на файла/каталог.

* Alt+Del для symlink на файл без предупреждений вытирал содержимое исходного файла,
  поправил аналогично предупреждению для hardink,
  но возможно стоит такие предупреждения разнести,
  чтобы [All] & [Skip all] не разрешали общее поведение (???).

* Alt+Del для symlink на каталог вообще нормально не работал и портил имя симлинка
  - убрал безоговорочно wipe для каталогов из symlink,
  но не проверял досконально на вложенных каталогах и ссылках.

* Вопрос 1 (???) Удаление symlink в корзину на файл удаляет как надо,
  а symlink на каталог удаляет мимо корзины
  - не понял как с исправить попадание в корзину и symlink на каталог.

* Вопрос 2 (???) в F9->Options->System settings есть [x] Delete symbolic links,
  но Opt.DeleteToRecycleBinKillLink есть только в конфиге и при самом удалении не учитывается
  - то ли вообще убрать опцию, то ли как-то поправить логику удаления для учёта параметра?

* Вопрос 3 (???) по Shift+F6 симлинк не переименовывается, а создается копия
  (в терминале по mv переименование без проблем).
  Не понял что там подкрутить, чтобы подправить.
