### PR TITLE
bugfix: far2l --tty: editor hangs when inserting text that ends with …

### DIFF
--- a/WinPort/src/Backend/TTY/TTYX/TTYX.cpp
+++ b/WinPort/src/Backend/TTY/TTYX/TTYX.cpp
@@ -200,6 +200,9 @@ class TTYX
 					_xi_leds = INVALID_MODS; // invalidate now, will update when needed
 				}
 			}
+			if (_get_clipboard.state == GetClipboardContext::REQUESTING) {
+				_get_clipboard.state = GetClipboardContext::PRESENT;
+			}
 			return true;
 		}
 		return false;


### PR DESCRIPTION
…a line feed character from external clipboard manager (CopyQ)

How to reproduce:
Run far2l --tty in terminal, edit text file, paste text which contains ending line break from clipboard (Ctrl-V)

Far2l hangs in TTYX::GetClipboard():
```
		do {
			DispatchOneEvent();
		} while (_get_clipboard.state == GetClipboardContext::REQUESTING);

```