### PR TITLE
Add missing ssh port in ways.ini

### DIFF
--- a/NetRocks/src/Protocol/SHELL/Helpers/ways.ini
+++ b/NetRocks/src/Protocol/SHELL/Helpers/ways.ini
@@ -1,5 +1,5 @@
 [SSH]
-Command="ssh $OPT0 "$USER@$HOST" "$OPT1""
+Command="ssh $OPT0 -p "$PORT" "$USER@$HOST" "$OPT1""
 OPT0_Name="Compression"
 OPT0_Items="{No:}|Yes:-C"
 OPT1_Name="Login with sudo"


### PR DESCRIPTION
Add missing ssh port in ways.ini. 
Without this fix NetRocks Shell protocol ignores connection port in configuration and unable to connect to nonstandard port.