### PR TITLE
bugfix: Far2l process crash if compiled with -D_GLIBCXX_ASSERTIONS

### DIFF
--- a/far2l/src/panels/flupdate.cpp
+++ b/far2l/src/panels/flupdate.cpp
@@ -642,7 +642,7 @@ void FileList::UpdatePlugin(int KeepSelection, int IgnoreVisible)
 
 		TotalFileSize+= CurListData->FileSize;
 	}
-	if ((Info.Flags & OPIF_USEHIGHLIGHTING) || (Info.Flags & OPIF_USEATTRHIGHLIGHTING))
+	if (!ListData.IsEmpty() && ((Info.Flags & OPIF_USEHIGHLIGHTING) || (Info.Flags & OPIF_USEATTRHIGHLIGHTING)))
 		CtrlObject->HiFiles->GetHiColor(&ListData[0], ListData.Count(),
 				(Info.Flags & OPIF_USEATTRHIGHLIGHTING) != 0);
 


### PR DESCRIPTION
How to reproduce
 - build Far2l with option -DCMAKE_CXX_FLAGS =-D_GLIBCXX_ASSERTIONS
 - Run Far2l, open Plugins - Temporary panel
 - or Run Far2l, open any archive with empty folder