### PR TITLE
Add SetFileTime to the functions, which are exported with WINPORT_DIRECT

### DIFF
--- a/WinPort/windows.h
+++ b/WinPort/windows.h
@@ -90,6 +90,7 @@
 #define    SetFilePointerEx       WINPORT(SetFilePointerEx)
 #define    SetFilePointer         WINPORT(SetFilePointer)
 #define    GetFileTime            WINPORT(GetFileTime)
+#define    SetFileTime            WINPORT(SetFileTime)
 #define    SetEndOfFile           WINPORT(SetEndOfFile)
 #define    FlushFileBuffers       WINPORT(FlushFileBuffers)
 #define    GetFileType            WINPORT(GetFileType)


### PR DESCRIPTION
One of plugins, which I'm porting, [uses it](https://github.com/atsidaev/far2l-plugins-speccy/blob/9c3b4593490903020af68e7d3343a06ddacafafc/xISD/manager_get_files.cpp#L88).

The function itself exists but it is only visible as WINPORT_SetFileTime.