### PR TITLE
Colorer: Fix resource leak: resource acquired by call to `opendir()` …

### DIFF
--- a/colorer/src/Colorer-library/src/colorer/xml/XmlInputSource.cpp
+++ b/colorer/src/Colorer-library/src/colorer/xml/XmlInputSource.cpp
@@ -161,6 +161,7 @@ void XmlInputSource::getFileFromDir(const String* relPath, std::vector<SString> 
         files.push_back(SString(relPath) + "/" + dire->d_name);
       }
     }
+    closedir(dir);
   }
 }
 #endif


### PR DESCRIPTION
…is not released