### PR TITLE
Better detect wayland on WSL

### DIFF
--- a/WinPort/src/Backend/TTY/TTYBackend.cpp
+++ b/WinPort/src/Backend/TTY/TTYBackend.cpp
@@ -226,8 +226,9 @@ void TTYBackend::ReaderThread()
 				// disable xi on Wayland as it not work there anyway and also causes delays
 				const char *xdg_st = getenv("XDG_SESSION_TYPE");
 				bool on_wayland = (xdg_st && strcasecmp(xdg_st, "wayland") == 0);
+				char *wayland_display = getenv("WAYLAND_DISPLAY");
 
-				_ttyx = StartTTYX(_full_exe_path, !strstr(_nodetect, "xi") && !on_wayland);
+				_ttyx = StartTTYX(_full_exe_path, !strstr(_nodetect, "xi") && !on_wayland && !wayland_display);
 			}
 			if (_ttyx) {
 				if (!_ext_clipboard) {
@@ -302,7 +303,8 @@ void TTYBackend::ReaderLoop()
 
 		// Enable esc expiration on Wayland as Xi not work there
 		const char *xdg_st = getenv("XDG_SESSION_TYPE");
-		if ((xdg_st && strcasecmp(xdg_st, "wayland") == 0) && !_esc_expiration) {
+		char *wayland_display = getenv("WAYLAND_DISPLAY");
+		if (((xdg_st && strcasecmp(xdg_st, "wayland") == 0) || wayland_display) && !_esc_expiration) {
 			_esc_expiration = 100;
 		}
 


### PR DESCRIPTION
On WSL where may be no XDG_SESSION_TYPE env variable. Added another method of Wayland detection.

![изображение](https://github.com/elfmz/far2l/assets/1151423/1bc959cc-cd3c-4fca-93c7-9ae2dacf5c60)

![изображение](https://github.com/elfmz/far2l/assets/1151423/fb647bd8-6cc4-4970-b16d-6360ba30a243)
