### PR TITLE
Force non escaping

### DIFF
--- a/far2l/src/FilesSuggestor.cpp
+++ b/far2l/src/FilesSuggestor.cpp
@@ -175,14 +175,20 @@ void *FilesSuggestor::ThreadProc()
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 
-void MenuFilesSuggestor::Suggest(const wchar_t *filter, VMenu& menu)
+void MenuFilesSuggestor::Suggest(const wchar_t *filter, VMenu& menu, int escaping)
 {
 	if (!filter || !*filter) {
 		return;
 	}
 
 	std::string filter_mb;
-	Wide2MB(filter, filter_mb);
+	if (!escaping) {
+		FARString filter_escaping = filter;
+		EscapeSpace(filter_escaping);
+		Wide2MB(filter_escaping, filter_mb);
+	}
+	else
+		Wide2MB(filter, filter_mb);
 	std::string orig_filter_mb = filter_mb;
 
 	Environment::Arguments args;
@@ -237,6 +243,7 @@ void MenuFilesSuggestor::Suggest(const wchar_t *filter, VMenu& menu)
 
 	for (auto &suggestion : _suggestions) {
 		FARString str_tmp(orig_prefix);
+		fprintf(stderr, " MenuFilesSuggestor::Suggest(): suggestion.name=\"%s\"\n", suggestion.name.c_str());
 		if (last_arg.quot == Environment::QUOT_DOUBLE) {
 			str_tmp+= EscapeCmdStr(suggestion.name);
 		} else if (last_arg.quot == Environment::QUOT_NONE) {
@@ -254,6 +261,9 @@ void MenuFilesSuggestor::Suggest(const wchar_t *filter, VMenu& menu)
 		} else if (last_arg.quot == Environment::QUOT_SINGLE
 				|| last_arg.quot == Environment::QUOT_DOLLAR_SINGLE) {
 			str_tmp+= L'\'';
+		}
+		if (!escaping) {
+			UnEscapeSpace(str_tmp);
 		}
 		menu.AddItem(str_tmp);
 	}

--- a/far2l/src/FilesSuggestor.cpp
+++ b/far2l/src/FilesSuggestor.cpp
@@ -243,7 +243,6 @@ void MenuFilesSuggestor::Suggest(const wchar_t *filter, VMenu& menu, int escapin
 
 	for (auto &suggestion : _suggestions) {
 		FARString str_tmp(orig_prefix);
-		fprintf(stderr, " MenuFilesSuggestor::Suggest(): suggestion.name=\"%s\"\n", suggestion.name.c_str());
 		if (last_arg.quot == Environment::QUOT_DOUBLE) {
 			str_tmp+= EscapeCmdStr(suggestion.name);
 		} else if (last_arg.quot == Environment::QUOT_NONE) {

--- a/far2l/src/FilesSuggestor.hpp
+++ b/far2l/src/FilesSuggestor.hpp
@@ -38,5 +38,5 @@ class MenuFilesSuggestor : protected FilesSuggestor
 	std::vector<Suggestion> _suggestions;
 
 public:
-	void Suggest(const wchar_t *filter, VMenu& menu);
+	void Suggest(const wchar_t *filter, VMenu& menu, int escaping = 1); // escaping = 0 - filter & results without escaping
 };

--- a/far2l/src/edit.cpp
+++ b/far2l/src/edit.cpp
@@ -2671,7 +2671,7 @@ void EditControl::PopulateCompletionMenu(VMenu &ComplMenu, const FARString &strF
 			if (!m_pSuggestor)
 				m_pSuggestor.reset(new MenuFilesSuggestor);
 
-			m_pSuggestor->Suggest(strFilter, ComplMenu);
+			m_pSuggestor->Suggest(strFilter, ComplMenu, 0); // 0 - always not escaping path names
 		}
 	}
 }

--- a/far2l/src/edit.cpp
+++ b/far2l/src/edit.cpp
@@ -506,7 +506,7 @@ int Edit::ProcessInsPath(FarKey Key, int PrevSelStart, int PrevSelEnd)
 			RetCode = TRUE;
 	} else		// Пути/имена?
 	{
-		RetCode = _MakePath1(Key, strPathName, L"");
+		RetCode = _MakePath1(Key, strPathName, L"", 0); // 0 - always not escaping path names
 	}
 
 	// Если что-нить получилось, именно его и вставим (PathName)

--- a/far2l/src/mix/panelmix.cpp
+++ b/far2l/src/mix/panelmix.cpp
@@ -123,7 +123,7 @@ bool CheckUpdateAnotherPanel(Panel *SrcPanel, const wchar_t *SelName)
 	return false;
 }
 
-int _MakePath1(DWORD Key, FARString &strPathName, const wchar_t *Param2)
+int _MakePath1(DWORD Key, FARString &strPathName, const wchar_t *Param2, int escaping)
 {
 	int RetCode = FALSE;
 	int NeedRealName = FALSE;
@@ -190,7 +190,7 @@ int _MakePath1(DWORD Key, FARString &strPathName, const wchar_t *Param2)
 					AddEndSlash(strPathName);
 				}
 
-				if (Opt.QuotedName & QUOTEDNAME_INSERT)
+				if (escaping & Opt.QuotedName & QUOTEDNAME_INSERT)
 					EscapeSpace(strPathName);
 
 				if (Param2)

--- a/far2l/src/mix/panelmix.hpp
+++ b/far2l/src/mix/panelmix.hpp
@@ -38,7 +38,7 @@ class Panel;
 void ShellUpdatePanels(Panel *SrcPanel, BOOL NeedSetUpADir = FALSE);
 bool CheckUpdateAnotherPanel(Panel *SrcPanel, const wchar_t *SelName);
 
-int _MakePath1(DWORD Key, FARString &strPathName, const wchar_t *Param2);
+int _MakePath1(DWORD Key, FARString &strPathName, const wchar_t *Param2, int escaping = 1); // by default escaping filenames
 
 const FARString FormatStr_Attribute(DWORD FileAttributes, DWORD UnixMode, int Width = -1);
 const FARString FormatStr_DateTime(const FILETIME *FileTime, int ColumnType, DWORD Flags, int Width);

--- a/far2l/src/mix/strmix.cpp
+++ b/far2l/src/mix/strmix.cpp
@@ -189,6 +189,28 @@ FARString &EscapeSpace(FARString &strStr)
 	return strStr;
 }
 
+static FARString unEscapeSpace(const wchar_t *str)
+{
+	if (*str == L'\0')
+		return "''";
+	FARString result;
+	for (const wchar_t *cur = str; *cur; ++cur) {
+		if (*cur == L'\\' && *(cur+1) != L'\\')
+			continue;
+		result.Append(*cur);
+	}
+	return result;
+}
+
+FARString &UnEscapeSpace(FARString &strStr)
+{
+	if (strStr.IsEmpty() || strStr.Contains(L'\\')) {
+		strStr.Copy(unEscapeSpace(strStr.CPtr()));
+	}
+
+	return strStr;
+}
+
 wchar_t *WINAPI QuoteSpaceOnly(wchar_t *Str)
 {
 	if (wcschr(Str, L' '))

--- a/far2l/src/mix/strmix.hpp
+++ b/far2l/src/mix/strmix.hpp
@@ -60,6 +60,7 @@ std::string EscapeUnprintable(const std::string &str);
 std::string UnescapeUnprintable(const std::string &str);
 
 FARString &EscapeSpace(FARString &strStr);
+FARString &UnEscapeSpace(FARString &strStr);
 wchar_t *WINAPI InsertQuote(wchar_t *Str);
 FARString &InsertQuote(FARString &strStr);
 void WINAPI Unquote(FARString &strStr);


### PR DESCRIPTION
Закрывает #2071 и #1670

Не уверен, что во втором коммите в FilesSuggestor.cpp реализовал наиболее эффективно убирание экранирования, ибо сначала оно там излишне многократно делается, но решил не ковырять эту логику, а наиболее минимально влезать в действующий код.