### PR TITLE
Work-around for win32-input-mode mouse sequences and SGR extended mouse report

### DIFF
--- a/WinPort/src/Backend/TTY/TTYInput.cpp
+++ b/WinPort/src/Backend/TTY/TTYInput.cpp
@@ -47,19 +47,12 @@ void TTYInput::OnBufUpdated(bool idle)
 		size_t decoded = _parser.Parse(&_buf[0], _buf.size(), idle);
 
 		//work-around for double encoded mouse events in win32-input mode
+		//here we parse mouse sequence from accumulated buffer
 		if (_parser._win_mouse_buffer.size() > 5) {
-
-			fprintf(stderr, "!!!parse accumulated \n");
-			fprintf(stderr, "++temp buf: \n");
-			for (const auto& ch : _parser._temp_buf) {
-				fprintf(stderr, "%c", ch);
-			}
-			fprintf(stderr, "\n++temp buf\n");
-			_parser._temp_buf.clear();
-
 			_parser._win32_accumulate = false;
 			_parser.Parse(&_parser._win_mouse_buffer[0], _parser._win_mouse_buffer.size(), idle);
 			_parser._win_mouse_buffer.clear();
+			fprintf(stderr, "!!!parsed accumulated mouse sequence \n");
 		}
 
 		switch (decoded) {

--- a/WinPort/src/Backend/TTY/TTYInput.cpp
+++ b/WinPort/src/Backend/TTY/TTYInput.cpp
@@ -45,6 +45,23 @@ void TTYInput::OnBufUpdated(bool idle)
 {
 	while (!_buf.empty()) {
 		size_t decoded = _parser.Parse(&_buf[0], _buf.size(), idle);
+
+		//work-around for double encoded mouse events in win32-input mode
+		if (_parser._win_mouse_buffer.size() > 5) {
+
+			fprintf(stderr, "!!!parse accumulated \n");
+			fprintf(stderr, "++temp buf: \n");
+			for (const auto& ch : _parser._temp_buf) {
+				fprintf(stderr, "%c", ch);
+			}
+			fprintf(stderr, "\n++temp buf\n");
+			_parser._temp_buf.clear();
+
+			_parser._win32_accumulate = false;
+			_parser.Parse(&_parser._win_mouse_buffer[0], _parser._win_mouse_buffer.size(), idle);
+			_parser._win_mouse_buffer.clear();
+		}
+
 		switch (decoded) {
 			case TTY_PARSED_PLAINCHARS:
 				decoded = BufTryDecodeUTF8();

--- a/WinPort/src/Backend/TTY/TTYInput.cpp
+++ b/WinPort/src/Backend/TTY/TTYInput.cpp
@@ -48,12 +48,7 @@ void TTYInput::OnBufUpdated(bool idle)
 
 		//work-around for double encoded mouse events in win32-input mode
 		//here we parse mouse sequence from accumulated buffer
-		if (_parser._win_mouse_buffer.size() > 5) {
-			_parser._win32_accumulate = false;
-			_parser.Parse(&_parser._win_mouse_buffer[0], _parser._win_mouse_buffer.size(), idle);
-			_parser._win_mouse_buffer.clear();
-			fprintf(stderr, "!!!parsed accumulated mouse sequence \n");
-		}
+		_parser.ParseWinMouseBuffer(idle);
 
 		switch (decoded) {
 			case TTY_PARSED_PLAINCHARS:

--- a/WinPort/src/Backend/TTY/TTYInputSequenceParser.cpp
+++ b/WinPort/src/Backend/TTY/TTYInputSequenceParser.cpp
@@ -553,7 +553,7 @@ void TTYInputSequenceParser::AddPendingMouseEvent(int action, int col, int row)
 	switch (action) {
 		case 0: // char ' ', left press
 			if (now - _mouse.left_ts <= 800) {
-				ir.Event.MouseEvent.dwEventFlags|= DOUBLE_CLICK;
+				ir.Event.MouseEvent.dwEventFlags |= DOUBLE_CLICK;
 				_mouse.left_ts = 0;
 			} else {
 				_mouse.left_ts = now;
@@ -565,7 +565,7 @@ void TTYInputSequenceParser::AddPendingMouseEvent(int action, int col, int row)
 
 		case 1: //char '!', middle press
 			if (now - _mouse.middle_ts <= 800) {
-				ir.Event.MouseEvent.dwEventFlags|= DOUBLE_CLICK;
+				ir.Event.MouseEvent.dwEventFlags |= DOUBLE_CLICK;
 				_mouse.middle_ts = 0;
 			} else {
 				_mouse.middle_ts = now;
@@ -577,7 +577,7 @@ void TTYInputSequenceParser::AddPendingMouseEvent(int action, int col, int row)
 
 		case 2: // char '"', right press
 			if (now - _mouse.right_ts <= 800) {
-				ir.Event.MouseEvent.dwEventFlags|= DOUBLE_CLICK;
+				ir.Event.MouseEvent.dwEventFlags |= DOUBLE_CLICK;
 				_mouse.right_ts = 0;
 			} else {
 				_mouse.right_ts = now;
@@ -593,13 +593,13 @@ void TTYInputSequenceParser::AddPendingMouseEvent(int action, int col, int row)
 
 		//wheel move
 		case 64: // char '`', wheel up
-			ir.Event.MouseEvent.dwEventFlags|= MOUSE_WHEELED;
-			ir.Event.MouseEvent.dwButtonState|= (0x0001 <<16);
+			ir.Event.MouseEvent.dwEventFlags |= MOUSE_WHEELED;
+			ir.Event.MouseEvent.dwButtonState |= (0x0001 <<16);
 			break;
 
 		case 65: // char 'a', wheel down
-			ir.Event.MouseEvent.dwEventFlags|= MOUSE_WHEELED;
-			ir.Event.MouseEvent.dwButtonState|= (0xffff << 16);
+			ir.Event.MouseEvent.dwEventFlags |= MOUSE_WHEELED;
+			ir.Event.MouseEvent.dwButtonState |= (0xffff << 16);
 			break;
 
 		//drag
@@ -626,14 +626,17 @@ void TTYInputSequenceParser::AddPendingMouseEvent(int action, int col, int row)
 			return;
 	}
 
-	if (_mouse.left)
-			ir.Event.MouseEvent.dwButtonState|= FROM_LEFT_1ST_BUTTON_PRESSED;
+	if (_mouse.left) {
+		ir.Event.MouseEvent.dwButtonState |= FROM_LEFT_1ST_BUTTON_PRESSED;
+	}
 
-	if (_mouse.middle)
-			ir.Event.MouseEvent.dwButtonState|= FROM_LEFT_2ND_BUTTON_PRESSED;
+	if (_mouse.middle) {
+		ir.Event.MouseEvent.dwButtonState |= FROM_LEFT_2ND_BUTTON_PRESSED;
+	}
 
-	if (_mouse.right)
-			ir.Event.MouseEvent.dwButtonState|= RIGHTMOST_BUTTON_PRESSED;
+	if (_mouse.right) {
+		ir.Event.MouseEvent.dwButtonState |= RIGHTMOST_BUTTON_PRESSED;
+	}
 
 	_ir_pending.emplace_back(ir);
 }

--- a/WinPort/src/Backend/TTY/TTYInputSequenceParser.cpp
+++ b/WinPort/src/Backend/TTY/TTYInputSequenceParser.cpp
@@ -552,7 +552,7 @@ void TTYInputSequenceParser::AddPendingMouseEvent(int action, int col, int row)
 	action = action & ~(_shift_ind | _alt_ind | _ctrl_ind);
 	switch (action) {
 		case 0: // char ' ', left press
-			if (now - _mouse.left_ts <= 500) {
+			if (now - _mouse.left_ts <= 800) {
 				ir.Event.MouseEvent.dwEventFlags|= DOUBLE_CLICK;
 				_mouse.left_ts = 0;
 			} else {
@@ -564,7 +564,7 @@ void TTYInputSequenceParser::AddPendingMouseEvent(int action, int col, int row)
 			break;
 
 		case 1: //char '!', middle press
-			if (now - _mouse.middle_ts <= 500) {
+			if (now - _mouse.middle_ts <= 800) {
 				ir.Event.MouseEvent.dwEventFlags|= DOUBLE_CLICK;
 				_mouse.middle_ts = 0;
 			} else {
@@ -576,7 +576,7 @@ void TTYInputSequenceParser::AddPendingMouseEvent(int action, int col, int row)
 			break;
 
 		case 2: // char '"', right press
-			if (now - _mouse.right_ts <= 500) {
+			if (now - _mouse.right_ts <= 800) {
 				ir.Event.MouseEvent.dwEventFlags|= DOUBLE_CLICK;
 				_mouse.right_ts = 0;
 			} else {

--- a/WinPort/src/Backend/TTY/TTYInputSequenceParser.h
+++ b/WinPort/src/Backend/TTY/TTYInputSequenceParser.h
@@ -130,6 +130,11 @@ class TTYInputSequenceParser
 
 
 public:
+	//work-around for double encoded mouse events in win32-input mode
+	std::vector<char> _win_mouse_buffer; // buffer for accumulate unpacked chras
+	std::vector<char> _temp_buf;         // debug buffer
+	bool _win32_accumulate = false;      // flag for parse accumulated sequence from
+
 	TTYInputSequenceParser(ITTYInputSpecialSequenceHandler *handler);
 
 	size_t Parse(const char *s, size_t l, bool idle_expired); // 0 - need more, -1 - not sequence, -2 - unrecognized sequence, >0 - sequence

--- a/WinPort/src/Backend/TTY/TTYInputSequenceParser.h
+++ b/WinPort/src/Backend/TTY/TTYInputSequenceParser.h
@@ -107,6 +107,12 @@ class TTYInputSequenceParser
 	bool _kitty_right_ctrl_down = false;
 	int _iterm_last_flags = 0;
 	char _using_extension = 0;
+	//bit indicators for modifier keys in mouse input sequence
+	const unsigned int
+		_shift_ind = 0x04,
+		_alt_ind   = 0x08,
+		_ctrl_ind  = 0x10;
+
 	//work-around for double encoded mouse events in win32-input mode
 	std::vector<char> _win_mouse_buffer; // buffer for accumulate unpacked chras
 	bool _win32_accumulate = false;      // flag for parse win32-input sequence into _win_mouse_buffer
@@ -122,7 +128,26 @@ class TTYInputSequenceParser
 	void AddStrCursors(WORD vk, const char *code);
 
 	size_t ParseNChars2Key(const char *s, size_t l);
-	void ParseMouse(char action, char col, char raw);
+
+	/**
+	 * Parse X10 mouse report sequence.
+	 * looks like x1B[Mabc
+	*/
+	size_t ParseX10Mouse(const char *s, size_t l);
+
+	/**
+	 * Parse mouse from SGR Extended coordinates sequence.
+	 * looks like x1B[<a;b;cM or x1B[<a;b;cm,
+	*/
+	size_t ParseSGRMouse(const char *s, size_t l);
+
+	/**
+	 * Schedule mouse event.
+	 * constuct INPUT_RECORD of mouse event and appending it to _ir_pending
+	 * Params have to be parsed from input sequence by ether of ParseX10Mouse() or ParseSGRMouse()
+	*/
+	void AddPendingMouseEvent(int action, int col, int row);
+
 	void ParseAPC(const char *s, size_t l);
 	size_t TryParseAsWinTermEscapeSequence(const char *s, size_t l);
 	size_t TryUnwrappWinMouseEscapeSequence(const char *s, size_t l);

--- a/WinPort/src/Backend/TTY/TTYInputSequenceParser.h
+++ b/WinPort/src/Backend/TTY/TTYInputSequenceParser.h
@@ -131,13 +131,13 @@ class TTYInputSequenceParser
 
 	/**
 	 * Parse X10 mouse report sequence.
-	 * looks like x1B[Mabc
+	 * looks like `x1B[Mayx`
 	*/
 	size_t ParseX10Mouse(const char *s, size_t l);
 
 	/**
 	 * Parse mouse from SGR Extended coordinates sequence.
-	 * looks like x1B[<a;b;cM or x1B[<a;b;cm,
+	 * looks like `\x1B[<a;y;xM` or `\x1B[<a;y;xm`,
 	*/
 	size_t ParseSGRMouse(const char *s, size_t l);
 

--- a/WinPort/src/Backend/TTY/TTYInputSequenceParser.h
+++ b/WinPort/src/Backend/TTY/TTYInputSequenceParser.h
@@ -119,6 +119,7 @@ class TTYInputSequenceParser
 	void ParseMouse(char action, char col, char raw);
 	void ParseAPC(const char *s, size_t l);
 	size_t TryParseAsWinTermEscapeSequence(const char *s, size_t l);
+	size_t TryUnwrappWinMouseEscapeSequence(const char *s, size_t l);
 	size_t ReadUTF8InHex(const char *s, wchar_t *uni_char);
 	size_t TryParseAsITerm2EscapeSequence(const char *s, size_t l);
 	size_t TryParseAsKittyEscapeSequence(const char *s, size_t l);
@@ -132,8 +133,8 @@ class TTYInputSequenceParser
 public:
 	//work-around for double encoded mouse events in win32-input mode
 	std::vector<char> _win_mouse_buffer; // buffer for accumulate unpacked chras
-	std::vector<char> _temp_buf;         // debug buffer
-	bool _win32_accumulate = false;      // flag for parse accumulated sequence from
+	bool _win32_accumulate = false;      // flag for parse win32-input sequence into _win_mouse_buffer
+	int _skip_two_sequence = 0;          // counter for skip unwanted sequences after mouse input
 
 	TTYInputSequenceParser(ITTYInputSpecialSequenceHandler *handler);
 

--- a/WinPort/src/Backend/TTY/TTYInputSequenceParserExts.cpp
+++ b/WinPort/src/Backend/TTY/TTYInputSequenceParserExts.cpp
@@ -21,15 +21,15 @@ size_t TTYInputSequenceParser::ParseX10Mouse(const char *s, size_t l)//(char act
 	}
 
 	int action = (int)s[2] - 32;
-	int col    = std::max((int)s[3] - 33, 1); //(unsigned char)'!');
-	int row    = std::max((int)s[4] - 33, 1); //(unsigned char)'!');
+	//make coordinates zero-based
+	int colunm = (int)s[3] - 33;
+	int row    = (int)s[4] - 33;
 
 	if (action > 255 - 32) {
 		return TTY_PARSED_BADSEQUENCE;
 	}
 
-
-	AddPendingMouseEvent(action, col, row);
+	AddPendingMouseEvent(action, colunm, row);
 
 	return 5;
 }
@@ -85,9 +85,9 @@ size_t TTYInputSequenceParser::ParseSGRMouse(const char *s, size_t l)
 		action = pressed ? pars[0] : 3;
 	}
 
-	//make sure coordinates zero-based and positive
-	colunm = std::max(--pars[1], 1);
-	row    = std::max(--pars[2], 1);
+	//make coordinates zero-based
+	colunm = --pars[1];
+	row    = --pars[2];
 
 	AddPendingMouseEvent(action, colunm, row);
 

--- a/WinPort/src/Backend/TTY/TTYInputSequenceParserExts.cpp
+++ b/WinPort/src/Backend/TTY/TTYInputSequenceParserExts.cpp
@@ -9,11 +9,30 @@
 size_t TTYInputSequenceParser::ParseX10Mouse(const char *s, size_t l)//(char action, char col, char raw)
 {
 	/*
-	"\x1B[M" has been recognized.
-	mouse report: "\x1b[Mayx" where:
-		* 'A' button number plus 32, can`t be greater than 223. Codes higher than 113 not used
-		* 'Y' column number (one-based) plus 32.
-		* 'X' row number (one-based) plus 32.
+	`\x1B[M` has been recognized.
+	mouse report: `\x1b[Mayx` where:
+		* `a` - button number plus 32, can`t be greater than 223. Codes higher than 113 not used
+		* `y` - column number (one-based) plus 32.
+		* `x` - row number (one-based) plus 32.
+	X button Encoding:
+		|7|6|5|4|3|2|1|0|
+		| |W|H|M|C|S|B|B|
+		bits 0 and 1 are used for button:
+			* 00 - MB1 pressed (left)
+			* 01 - MB2 pressed (middle)
+			* 10 - MB3 pressed (right)
+			* 11 - released (none)
+		Next three bits indicate modifier keys:
+			* 0x04 - shift
+			* 0x08 - alt (meta)
+			* 0x10 - ctrl
+		32 (x20) is added for drag events:
+			For example, motion into cell x,y with button 1 down is reported as `\x1b[M@yx`.
+				( @  = 32 + 0 (button 1) + 32 (motion indicator) ).
+			Similarly, motion with button 3 down is reported as `\x1b[MByx`.
+			    ( B  = 32 + 2 (button 3) + 32 (motion indicator) ).
+		64 (x40) is added for wheel events.
+		    so wheel up is 64, and wheel down is 65.
 	valid lenght is 5
 	*/
 	if (l < 5) {
@@ -25,7 +44,7 @@ size_t TTYInputSequenceParser::ParseX10Mouse(const char *s, size_t l)//(char act
 	int colunm = (int)s[3] - 33;
 	int row    = (int)s[4] - 33;
 
-	if (action > 255 - 32) {
+	if (action > 223) {
 		return TTY_PARSED_BADSEQUENCE;
 	}
 
@@ -37,17 +56,18 @@ size_t TTYInputSequenceParser::ParseX10Mouse(const char *s, size_t l)//(char act
 size_t TTYInputSequenceParser::ParseSGRMouse(const char *s, size_t l)
 {
 	/*
-	"\x1B[<" has been recognized.
+	`\x1B[<` has been recognized.
 	https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h3-Extended-coordinates
 	Sequence looks like "\x1B[<a;y;xM" or "\x1B[<a;y;xm", where:
-		* 'a' is a sequence of digits representing the button number in decimal.
-		* 'y' is a sequence of digits representing the column number (one-based) in decimal.
-		* 'x' is a sequence of digits representing the row number (one-based) in decimal.
-	The sequence ends with 'M' on button press and on 'm' on button release. (not sure if we need take it in account)
+		* `a` - is a sequence of digits representing the button number in decimal.
+		* `y` - is a sequence of digits representing the column number (one-based) in decimal.
+		* `x` - is a sequence of digits representing the row number (one-based) in decimal.
+	button encoding same as the X10 variant does not add 32
+	The sequence ends with `M` on button press and on `m` on button release.
 	*/
 
-	int pars[3]  = {0};
-	int pars_cnt = 0;
+	int params[3]  = {0};
+	int params_cnt = 0;
 	int action, colunm, row;
 	bool pressed = false;
 
@@ -57,12 +77,12 @@ size_t TTYInputSequenceParser::ParseSGRMouse(const char *s, size_t l)
 			return LIKELY(l < 32) ? TTY_PARSED_WANTMORE : TTY_PARSED_BADSEQUENCE;
 		}
 		if (s[i] == 'M' || s[i] == 'm' || s[i] == ';') {
-			if (pars_cnt == ARRAYSIZE(pars)) {
+			if (params_cnt == ARRAYSIZE(params)) {
 				return TTY_PARSED_BADSEQUENCE;
 			}
 			if (i > n) {
-				pars[pars_cnt] = atoi(&s[n]);
-				++pars_cnt;
+				params[params_cnt] = atoi(&s[n]);
+				++params_cnt;
 			}
 			n = i + 1;
 			if (s[i] == 'M' || s[i] == 'm') {
@@ -76,18 +96,15 @@ size_t TTYInputSequenceParser::ParseSGRMouse(const char *s, size_t l)
 	}
 
 	//here we need to correct mouse move code science it conflict with button release
-	if ((pars[0] & ~(_shift_ind | _alt_ind | _ctrl_ind)) == 35 && !pressed) {
-		action = 35;
-		if (pars[0] & _shift_ind) action |= _shift_ind;
-		if (pars[0] & _ctrl_ind)  action |= _ctrl_ind;
-		if (pars[0] & _alt_ind)   action |= _alt_ind;
+	if ((params[0] & ~(_shift_ind | _alt_ind | _ctrl_ind)) != 35) {
+		action = pressed ? params[0] : 3;
 	} else {
-		action = pressed ? pars[0] : 3;
+		action = params[0];
 	}
 
 	//make coordinates zero-based
-	colunm = --pars[1];
-	row    = --pars[2];
+	colunm = --params[1];
+	row    = --params[2];
 
 	AddPendingMouseEvent(action, colunm, row);
 

--- a/WinPort/src/Backend/TTY/TTYOutput.cpp
+++ b/WinPort/src/Backend/TTY/TTYOutput.cpp
@@ -495,9 +495,11 @@ void TTYOutput::ChangeKeypad(bool app)
 
 void TTYOutput::ChangeMouse(bool enable)
 {
-	Format(ESC "[?1000%c", enable ? 'h' : 'l');
-	Format(ESC "[?1001%c", enable ? 'h' : 'l');
-	Format(ESC "[?1002%c", enable ? 'h' : 'l');
+	Format(ESC "[?1000%c", enable ? 'h' : 'l'); // highlight mouse reporting (SET_VT200_MOUSE).
+	Format(ESC "[?1001%c", enable ? 'h' : 'l'); // X10 mouse reporting (SET_VT200_HIGHLIGHT_MOUSE).
+	Format(ESC "[?1002%c", enable ? 'h' : 'l'); // mouse drag reporting (SET_BTN_EVENT_MOUSE).
+	Format(ESC "[?1003%c", enable ? 'h' : 'l'); // mouse move reporting (SET_ANY_EVENT_MOUSE).
+	Format(ESC "[?1006%c", enable ? 'h' : 'l'); // SGR extended mouse reporting (SET_SGR_EXT_MODE_MOUSE).
 }
 
 void TTYOutput::ChangeTitle(std::string title)


### PR DESCRIPTION
fixes #2072 
Here is complite fix for double encoded mouse sequences in win32-input-mode under WSL.

Due to bug in events encoding in windows ConPTY, mouse input not only encoded in X10 mouse sequences but characters in it also encoded again as win32-input-mode sequences. I patch up this by adding separate buffer for for accumulate unpacked chracters and then parsing it sepparatly.
In addition, I wrote some annotations to describe the process..

All tested under windows 11 WSL Ubuntu 22.04. Seems works just fine.