### PR TITLE
Fix copy to Telegram last NUL char

### DIFF
--- a/WinPort/src/Backend/WX/wxClipboardBackend.cpp
+++ b/WinPort/src/Backend/WX/wxClipboardBackend.cpp
@@ -206,7 +206,7 @@ void *wxClipboardBackend::OnClipboardSetData(UINT format, void *data)
 		wxCustomDataObject *cdo = new wxCustomDataObject(wxT("text/plain;charset=utf-8"));
 		wxString wx_str((const wchar_t *)data);
 		const std::string &tmp = wx_str.ToStdString();
-		cdo->SetData(tmp.size() + 1, tmp.c_str()); // including ending NUL char
+		cdo->SetData(tmp.size(), tmp.c_str()); // not including ending NUL char
 		g_wx_data_to_clipboard->Add(cdo);
 
 		g_wx_data_to_clipboard->Add(new wxTextDataObjectTweaked(wx_str));
@@ -217,7 +217,7 @@ void *wxClipboardBackend::OnClipboardSetData(UINT format, void *data)
 
 	} else if (format==CF_TEXT) {
 		wxCustomDataObject *cdo = new wxCustomDataObject(wxT("text/plain;charset=utf-8"));
-		cdo->SetData(strlen((const char *)data) + 1, data); // including ending NUL char
+		cdo->SetData(strlen((const char *)data), data); // not including ending NUL char
 		g_wx_data_to_clipboard->Add(cdo);
 
 		g_wx_data_to_clipboard->Add(new wxTextDataObjectTweaked(wxString::FromUTF8((const char *)data)));


### PR DESCRIPTION
Fix after #2053 & https://github.com/elfmz/far2l/commit/ca3ccdcac00f5c6d6228596ec9aa5f255a9cc8ec

In my x11 before this fix pasting in Telegram with last strange char:
![image](https://github.com/elfmz/far2l/assets/92621645/1a058ec7-59ed-4a10-8a7d-94431673031a)
after fix all correct:
![image](https://github.com/elfmz/far2l/assets/92621645/2f7bcce3-57a5-478d-a780-a6534e1e843a)

Please anybody verify in Wayland and in WSL.
