### PR TITLE
Fix editor AttrStr symbols duplicate during save file

### DIFF
--- a/far2l/src/fileedit.cpp
+++ b/far2l/src/fileedit.cpp
@@ -2325,6 +2325,7 @@ DWORD FileEditor::EditorGetFileAttributes(const wchar_t *Name)
 {
 	SudoClientRegion sdc_rgn;
 	DWORD FileAttributes = apiGetFileAttributes(Name);
+	AttrStr.Clear();
 	if (FileAttributes != INVALID_FILE_ATTRIBUTES) {
 		if (FileAttributes & FILE_ATTRIBUTE_READONLY)
 			AttrStr+= L'R';


### PR DESCRIPTION
Before fix during save file with AttrStr chars was added to str
![изображение](https://github.com/elfmz/far2l/assets/92621645/d631d51d-b7fe-44b2-a29f-8efed1d6518f)
