### PR TITLE
Fix unneeded open.sh call after clicking on a broken symbolic link

### DIFF
--- a/far2l/src/execute.cpp
+++ b/far2l/src/execute.cpp
@@ -76,7 +76,7 @@ static WCHAR eol[2] = {'\r', '\n'};
 
 class ExecClassifier
 {
-	bool _dir, _file, _executable, _prefixed;
+    bool _dir, _file, _executable, _prefixed, _brokensymlink;
 
 	bool IsExecutableByExtension(const char *s)
 	{
@@ -90,7 +90,7 @@ class ExecClassifier
 public:
 	ExecClassifier(const char *cmd, bool direct)
 		:
-		_dir(false), _file(false), _executable(false), _prefixed(false)
+        _dir(false), _file(false), _executable(false), _prefixed(false), _brokensymlink(false)
 	{
 		Environment::ExplodeCommandLine ecl(cmd);
 		if (!ecl.empty() && ecl.back() == "&") {
@@ -114,6 +114,11 @@ public:
 		struct stat s = {0};
 		if (stat(arg0.c_str(), &s) == -1) {
 			fprintf(stderr, "ExecClassifier('%s', %d) - stat error %u\n", cmd, direct, errno);
+            if ((errno==ENOENT /*|| errno==EACCES*/) && lstat(arg0.c_str(), &s) != -1)
+            {
+                _brokensymlink=true;
+                fprintf(stderr, "ExecClassifier: broken symbolic link!\n");
+            }
 			return;
 		}
 
@@ -161,6 +166,7 @@ public:
 	bool IsFile() const { return _file; }
 	bool IsDir() const { return _dir; }
 	bool IsExecutable() const { return _executable; }
+	bool IsBrokenSymlink() const { return _brokensymlink; }
 };
 
 static std::string GetOpenShVerb(const char *verb)
@@ -395,6 +401,7 @@ ExecuteA(const char *CmdStr, bool SeparateWindow, bool DirectRun, bool WaitForId
 			tmp = GetOpenShVerb("other");
 		}
 	} else if (SeparateWindow) {
+        if(ec.IsBrokenSymlink()) return -1;
 		tmp = GetOpenShVerb("exec");
 	} else
 		return farExecuteA(CmdStr, flags);

--- a/far2l/src/execute.cpp
+++ b/far2l/src/execute.cpp
@@ -401,10 +401,13 @@ ExecuteA(const char *CmdStr, bool SeparateWindow, bool DirectRun, bool WaitForId
 			tmp = GetOpenShVerb("other");
 		}
 	} else if (SeparateWindow) {
-        if(ec.IsBrokenSymlink()) return -1;
+        if(ec.IsBrokenSymlink()) {
+            return -1;
+        }
 		tmp = GetOpenShVerb("exec");
-	} else
-		return farExecuteA(CmdStr, flags);
+    } else {
+        return farExecuteA(CmdStr, flags);
+    }
 
 	if (!tmp.empty()) {
 		flags|= EF_NOWAIT | EF_HIDEOUT;		// open.sh doesnt print anything


### PR DESCRIPTION
fix for #2067

Если [вызов](https://github.com/elfmz/far2l/blob/0eea3cc61a6382013d47c7e7070892ce16bd333b/far2l/src/execute.cpp#L115) [stat](https://ru.manpages.org/stat/2) завершается с ошибкой ENOENT ("No such file or directory"), а [lstat](https://ru.manpages.org/lstat/2) отрабатывает без ошибки, значит мы имеем дело с битой символической ссылкой. [Отдавать](https://github.com/elfmz/far2l/blob/0eea3cc61a6382013d47c7e7070892ce16bd333b/far2l/src/execute.cpp#L398) её на выполнение $FARHOME/open.sh с действием exec не имеет смысла, так как это может приводить к неожиданным последствиям.

**Возможно стоит** также обрабатывать другие коды ошибок, не только ENOENT, либо вообще не проверять, какая именно ошибка -- если lstat отработает нормально, значит ссылка в любом случае проблемная.