### PR TITLE
Fix build under Ubuntu 18.04 - update WinPortMain.cpp

### DIFF
--- a/WinPort/src/Backend/WinPortMain.cpp
+++ b/WinPort/src/Backend/WinPortMain.cpp
@@ -34,6 +34,8 @@
 #include "../sudo/sudo_askpass_ipc.h"
 #include "SudoAskpassImpl.h"
 
+#include <memory>
+
 IConsoleOutput *g_winport_con_out = nullptr;
 IConsoleInput *g_winport_con_in = nullptr;
 const wchar_t *g_winport_backend = L"";

--- a/WinPort/src/Backend/WinPortMain.cpp
+++ b/WinPort/src/Backend/WinPortMain.cpp
@@ -34,10 +34,6 @@
 #include "../sudo/sudo_askpass_ipc.h"
 #include "SudoAskpassImpl.h"
 
-#include <memory>
-#include <iostream>
-#include <filesystem>
-
 IConsoleOutput *g_winport_con_out = nullptr;
 IConsoleInput *g_winport_con_in = nullptr;
 const wchar_t *g_winport_backend = L"";


### PR DESCRIPTION
Fix build under Ubuntu 18.04 

```
../../WinPort/src/Backend/WinPortMain.cpp:39:10: fatal error: filesystem: No such file or directory
 #include <filesystem>
          ^~~~~~~~~~~~
compilation terminated.

```
- remove  unnecessary includes from WinPortMain.cpp