### PR TITLE
fix #2067, option 1: treat broken or inaccessible symlinks as files

### DIFF
--- a/far2l/src/execute.cpp
+++ b/far2l/src/execute.cpp
@@ -114,6 +114,11 @@ public:
 		struct stat s = {0};
 		if (stat(arg0.c_str(), &s) == -1) {
 			fprintf(stderr, "ExecClassifier('%s', %d) - stat error %u\n", cmd, direct, errno);
+            if ((errno==ENOENT || errno==EACCES) && lstat(arg0.c_str(), &s) != -1)
+            {
+                _file = true;
+                fprintf(stderr, "ExecClassifier: broken or inaccessible symbolic link\n");
+            }
 			return;
 		}
 
@@ -396,8 +401,9 @@ ExecuteA(const char *CmdStr, bool SeparateWindow, bool DirectRun, bool WaitForId
 		}
 	} else if (SeparateWindow) {
 		tmp = GetOpenShVerb("exec");
-	} else
-		return farExecuteA(CmdStr, flags);
+    } else {
+        return farExecuteA(CmdStr, flags);
+    }
 
 	if (!tmp.empty()) {
 		flags|= EF_NOWAIT | EF_HIDEOUT;		// open.sh doesnt print anything


### PR DESCRIPTION
fix #2067 -- **вариант** решения № 1

<details><summary>Суть проблемы:</summary>

Когда [ExecClassifier](https://github.com/elfmz/far2l/blob/0ee8118739d4763d28777cd6de4c6208a58c66e8/far2l/src/execute.cpp#L77) сталкивается с битой или недоступной символической ссылкой, он возвращает управление, не взведя в true [флаги](https://github.com/elfmz/far2l/blob/0ee8118739d4763d28777cd6de4c6208a58c66e8/far2l/src/execute.cpp#L93) _dir или _file.

Далее, в функции [ExecuteA](https://github.com/elfmz/far2l/blob/0ee8118739d4763d28777cd6de4c6208a58c66e8/far2l/src/execute.cpp#L374) проверки [ec.IsDir()](https://github.com/elfmz/far2l/blob/0ee8118739d4763d28777cd6de4c6208a58c66e8/far2l/src/execute.cpp#L387) и [ec.IsFile()](https://github.com/elfmz/far2l/blob/0ee8118739d4763d28777cd6de4c6208a58c66e8/far2l/src/execute.cpp#L389) завершаются с отрицательным результатом, управление передаётся ветке, которая [формирует](https://github.com/elfmz/far2l/blob/0ee8118739d4763d28777cd6de4c6208a58c66e8/far2l/src/execute.cpp#L398) строку запуска для open.sh с аргументом "exec".

Поскольку флаги _dir и _file взведены не были, префикс ./ [не добавляется](https://github.com/elfmz/far2l/blob/0ee8118739d4763d28777cd6de4c6208a58c66e8/far2l/src/execute.cpp#L406), мы получаем имя файла ссылки без полного или относительного пути.

Когда происходит запуск скрипта-хелпера [open.sh](https://github.com/elfmz/far2l/blob/0ee8118739d4763d28777cd6de4c6208a58c66e8/far2l/bootstrap/open.sh), может случиться несколько неожиданных вещей для пользователя:

1. Если имя битой ссылки по стечению обстоятельств совпадёт с именем команды или программы, доступной в PATH, то [проверка](https://github.com/elfmz/far2l/blob/0ee8118739d4763d28777cd6de4c6208a58c66e8/far2l/bootstrap/open.sh#L29) command -v "$1" завершится с положительным результатом, следствием чего будет [запуск в терминале](https://github.com/elfmz/far2l/blob/0ee8118739d4763d28777cd6de4c6208a58c66e8/far2l/bootstrap/open.sh#L31) одноимённого исполняемого файла, а вовсе не того, на что указывала ссылка.

2. Если имя битой ссылки не совпадёт с именем исполняемого файла, то управление передастся [xdg-open](https://github.com/elfmz/far2l/blob/0ee8118739d4763d28777cd6de4c6208a58c66e8/far2l/bootstrap/open.sh#L37). Это скрипт, который в случае работы на системе с KDE делегирует свою работу kde-open. Если последнему передать имя файла без пути, и у него не получится его открыть (как в случае с битой ссылкой), он трактует его как URL и пытается открыть в браузере.

3. Кроме того, в самом скрипте xdg-open говорится:

>    As xdg-open can not handle arguments that begin with a "-" it is recommended to pass filepaths in one of the following ways:
>      * Pass absolute paths, i.e. by using realpath as a preprocessor.
>      * Prefix known relative filepaths with a "./". For example using sed -E 's|^[^/]|./\0|'.
>      * Pass a file URL.
</details>

**Возможное решение (1):**
Когда [сталкиваемся](https://github.com/elfmz/far2l/blob/0ee8118739d4763d28777cd6de4c6208a58c66e8/far2l/src/execute.cpp#L115) с ошибкой ENOENT ("No such file or directory") или EACCES ("Permission denied") stat, пробуем вызвать [lstat](https://ru.manpages.org/lstat/2) c теми же аргументами. Если она отработает без ошибки, значит мы имеем дело с битой/недоступной символической ссылкой, которую можно интерпретировать как файл.

Это приведёт нас в [ветку](https://github.com/elfmz/far2l/blob/0ee8118739d4763d28777cd6de4c6208a58c66e8/far2l/src/execute.cpp#L395), устанавливающую метод открытия "other", а также в [ветку](https://github.com/elfmz/far2l/blob/0ee8118739d4763d28777cd6de4c6208a58c66e8/far2l/src/execute.cpp#L406), добавляющую префикс "./". 

В итоге [отработает](https://github.com/elfmz/far2l/blob/0ee8118739d4763d28777cd6de4c6208a58c66e8/far2l/bootstrap/open.sh#L37) xdg-open с корректно переданным именем файла-ссылки. А на битые ссылки с путём он уже реагирует адекватно.