### PR TITLE
Update wslgclip.sh

### DIFF
--- a/far2l/bootstrap/wslgclip.sh
+++ b/far2l/bootstrap/wslgclip.sh
@@ -6,7 +6,7 @@ script_path=$(dirname "$(readlink -f "$0")")
 case "$1" in
 get)
     if command -v cscript.exe >/dev/null 2>&1; then
-        cscript.exe //Nologo \\\\wsl.localhost\\"$WSL_DISTRO_NAME""$script_path"\\wslgclip.vbs
+        cscript.exe //Nologo $(wslpath -w "$script_path"/wslgclip.vbs)
     else
         powershell.exe -Command Get-Clipboard
     fi


### PR DESCRIPTION
Using a more universal method to convert Linux file paths to Windows file paths. wslpath is a standard utility in WSL.