### PR TITLE
disable drawing left placeholder in viewer wrap mode

### DIFF
--- a/far2l/src/viewer.cpp
+++ b/far2l/src/viewer.cpp
@@ -595,7 +595,10 @@ void Viewer::ShowPage(int nMode)
 				}
 			}
 
-			if (StrLen > LeftPos + Width && ViOpt.ShowArrows) {
+			//due to low reliability of unicode wrapping,
+			//left arrow char "»" may appear even in already wrapped line
+			//better disable it in wrap mode
+			if (StrLen > LeftPos + Width && (!VM.Wrap && ViOpt.ShowArrows)) {
 				GotoXY(XX2, Y);
 				SetColor(COL_VIEWERARROWS);
 				BoxText(0xbb);


### PR DESCRIPTION
fixes https://github.com/elfmz/far2l/issues/2136
Continue to fight rendering artifacts with @unxed  :)

One such artifact is the drawing of a placeholder for long lines in wrap mode. Seems like unocode wraping not always correct: remaining part of the line may contain full-width characters and there for become wider than screen.. 

![image](https://github.com/elfmz/far2l/assets/59544275/0198c215-6f14-4e12-a7a2-9619f1317e8b)

It is a bit hacky solution, but in wrap mode left placeholder don't have to be drawn anyway
