### PR TITLE
fix #2139: nodetect variable type changed from char* to std::string

### DIFF
--- a/WinPort/src/Backend/TTY/TTYBackend.cpp
+++ b/WinPort/src/Backend/TTY/TTYBackend.cpp
@@ -80,13 +80,13 @@ static WORD WChar2WinVKeyCode(WCHAR wc)
 }
 
 
-TTYBackend::TTYBackend(const char *full_exe_path, int std_in, int std_out, bool ext_clipboard, bool norgb, const char *nodetect, bool far2l_tty, unsigned int esc_expiration, int notify_pipe, int *result) :
+TTYBackend::TTYBackend(const char *full_exe_path, int std_in, int std_out, bool ext_clipboard, bool norgb, const std::string &nodetect, bool far2l_tty, unsigned int esc_expiration, int notify_pipe, int *result) :
 	_full_exe_path(full_exe_path),
 	_stdin(std_in),
 	_stdout(std_out),
 	_ext_clipboard(ext_clipboard),
 	_norgb(norgb),
-	_nodetect(nodetect),
+    _nodetect(nodetect),
 	_far2l_tty(far2l_tty),
 	_esc_expiration(esc_expiration),
 	_notify_pipe(notify_pipe),
@@ -231,10 +231,9 @@ void TTYBackend::ReaderThread()
 			}
 
 		} else {
-			if (!strchr(_nodetect, 'x') || strstr(_nodetect, "xi")) {
-
+            if (_nodetect.find('x')==std::string::npos || _nodetect.find("xi")!=std::string::npos) {
 				// disable xi on Wayland as it not work there anyway and also causes delays
-				_ttyx = StartTTYX(_full_exe_path, !strstr(_nodetect, "xi") && !UnderWayland());
+                _ttyx = StartTTYX(_full_exe_path, _nodetect.find("xi")==std::string::npos && !UnderWayland());
 			}
 			if (_ttyx) {
 				if (!_ext_clipboard) {
@@ -1242,7 +1241,7 @@ static void OnSigHup(int signo)
 }
 
 
-bool WinPortMainTTY(const char *full_exe_path, int std_in, int std_out, bool ext_clipboard, bool norgb, const char *nodetect, bool far2l_tty, unsigned int esc_expiration, int notify_pipe, int argc, char **argv, int(*AppMain)(int argc, char **argv), int *result)
+bool WinPortMainTTY(const char *full_exe_path, int std_in, int std_out, bool ext_clipboard, bool norgb, const std::string &nodetect, bool far2l_tty, unsigned int esc_expiration, int notify_pipe, int argc, char **argv, int(*AppMain)(int argc, char **argv), int *result)
 {
 	TTYBackend vtb(full_exe_path, std_in, std_out, ext_clipboard, norgb, nodetect, far2l_tty, esc_expiration, notify_pipe, result);
 

--- a/WinPort/src/Backend/TTY/TTYBackend.h
+++ b/WinPort/src/Backend/TTY/TTYBackend.h
@@ -20,7 +20,7 @@ class TTYBackend : IConsoleOutputBackend, ITTYInputSpecialSequenceHandler, IFar2
 	int _stdin = 0, _stdout = 1;
 	bool _ext_clipboard;
 	bool _norgb;
-	const char *_nodetect = "";
+    std::string _nodetect = "";
 	bool _far2l_tty = false;
 	bool _osc52clip_set = false;
 
@@ -148,7 +148,7 @@ protected:
 	DWORD QueryControlKeys();
 
 public:
-	TTYBackend(const char *full_exe_path, int std_in, int std_out, bool ext_clipboard, bool norgb, const char *nodetect, bool far2l_tty, unsigned int esc_expiration, int notify_pipe, int *result);
+    TTYBackend(const char *full_exe_path, int std_in, int std_out, bool ext_clipboard, bool norgb, const std::string &nodetect, bool far2l_tty, unsigned int esc_expiration, int notify_pipe, int *result);
 	~TTYBackend();
 	void KickAss(bool flush_input_queue = false);
 	bool Startup();

--- a/WinPort/src/Backend/WinPortMain.cpp
+++ b/WinPort/src/Backend/WinPortMain.cpp
@@ -41,7 +41,7 @@ IConsoleInput *g_winport_con_in = nullptr;
 const wchar_t *g_winport_backend = L"";
 
 bool WinPortMainTTY(const char *full_exe_path, int std_in, int std_out,
-	bool ext_clipboard, bool norgb, const char *nodetect, bool far2l_tty,
+                    bool ext_clipboard, bool norgb, const std::string &nodetect, bool far2l_tty,
 	unsigned int esc_expiration, int notify_pipe, int argc, char **argv,
 	int(*AppMain)(int argc, char **argv), int *result);
 
@@ -247,7 +247,7 @@ extern "C" void WinPortHelp()
 
 struct ArgOptions
 {
-	const char *nodetect = "";
+    std::string nodetect = "";
 	bool tty = false, far2l_tty = false, notty = false, norgb = false;
 	bool mortal = false;
 	bool x11 = false;
@@ -400,7 +400,7 @@ extern "C" int WinPortMain(const char *full_exe_path, int argc, char **argv, int
 	std::unique_ptr<TTYRawMode> tty_raw_mode;
 	if (!arg_opts.notty) {
 		tty_raw_mode.reset(new TTYRawMode(std_in, std_out));;
-		if (!strchr(arg_opts.nodetect, 'f')) {
+        if (arg_opts.nodetect.find('f')==std::string::npos) {
 	//		tty_raw_mode.reset(new TTYRawMode(std_out));
 			if (tty_raw_mode->Applied() || IsFar2lFISHTerminal()) {
 				arg_opts.far2l_tty = TTYNegotiateFar2l(std_in, std_out, true);


### PR DESCRIPTION
fix #2139:

Method ArgOptions::ParseArg [used](https://github.com/elfmz/far2l/blob/e6ad61a1ebfd816232f24bf5e224bf7ef83c2ebc/WinPort/src/Backend/WinPortMain.cpp#L288) internal buffer of local std::string [passed](https://github.com/elfmz/far2l/blob/e6ad61a1ebfd816232f24bf5e224bf7ef83c2ebc/WinPort/src/Backend/WinPortMain.cpp#L355) from WinPortMain, this led to the corruption of the variable value.

Type of nodetect variable  was changed from char* to std::string.