### PR TITLE
fix #2139: type of nodetect variable changed from char* to dword (now used as bitmask)

### DIFF
--- a/WinPort/src/Backend/Backend.h
+++ b/WinPort/src/Backend/Backend.h
@@ -10,6 +10,12 @@
 ///   Behavior of backend's code changed in incompatible way.
 #define FAR2L_BACKEND_ABI_VERSION	0x07
 
+#define NODETECT_NONE   0x0000
+#define NODETECT_XI     0x0001
+#define NODETECT_X      0x0002
+#define NODETECT_F      0x0004
+
+
 class IConsoleOutputBackend
 {
 protected:

--- a/WinPort/src/Backend/TTY/TTYBackend.cpp
+++ b/WinPort/src/Backend/TTY/TTYBackend.cpp
@@ -80,7 +80,7 @@ static WORD WChar2WinVKeyCode(WCHAR wc)
 }
 
 
-TTYBackend::TTYBackend(const char *full_exe_path, int std_in, int std_out, bool ext_clipboard, bool norgb, const char *nodetect, bool far2l_tty, unsigned int esc_expiration, int notify_pipe, int *result) :
+TTYBackend::TTYBackend(const char *full_exe_path, int std_in, int std_out, bool ext_clipboard, bool norgb, DWORD nodetect, bool far2l_tty, unsigned int esc_expiration, int notify_pipe, int *result) :
 	_full_exe_path(full_exe_path),
 	_stdin(std_in),
 	_stdout(std_out),
@@ -219,7 +219,7 @@ static bool UnderWayland()
 
 void TTYBackend::ReaderThread()
 {
-	bool prev_far2l_tty = false;
+    bool prev_far2l_tty = false;
 	while (!_exiting) {
 		_far2l_cursor_height = -1; // force cursor height update on next output dispatch
 		_fkeys_support = _far2l_tty ? FKS_UNKNOWN : FKS_NOT_SUPPORTED;
@@ -231,10 +231,10 @@ void TTYBackend::ReaderThread()
 			}
 
 		} else {
-			if (!strchr(_nodetect, 'x') || strstr(_nodetect, "xi")) {
+            if ((_nodetect & NODETECT_X)==0) {
 
 				// disable xi on Wayland as it not work there anyway and also causes delays
-				_ttyx = StartTTYX(_full_exe_path, !strstr(_nodetect, "xi") && !UnderWayland());
+                _ttyx = StartTTYX(_full_exe_path, ((_nodetect & NODETECT_XI)==0) && !UnderWayland());
 			}
 			if (_ttyx) {
 				if (!_ext_clipboard) {
@@ -1242,7 +1242,7 @@ static void OnSigHup(int signo)
 }
 
 
-bool WinPortMainTTY(const char *full_exe_path, int std_in, int std_out, bool ext_clipboard, bool norgb, const char *nodetect, bool far2l_tty, unsigned int esc_expiration, int notify_pipe, int argc, char **argv, int(*AppMain)(int argc, char **argv), int *result)
+bool WinPortMainTTY(const char *full_exe_path, int std_in, int std_out, bool ext_clipboard, bool norgb, DWORD nodetect, bool far2l_tty, unsigned int esc_expiration, int notify_pipe, int argc, char **argv, int(*AppMain)(int argc, char **argv), int *result)
 {
 	TTYBackend vtb(full_exe_path, std_in, std_out, ext_clipboard, norgb, nodetect, far2l_tty, esc_expiration, notify_pipe, result);
 

--- a/WinPort/src/Backend/TTY/TTYBackend.h
+++ b/WinPort/src/Backend/TTY/TTYBackend.h
@@ -20,7 +20,7 @@ class TTYBackend : IConsoleOutputBackend, ITTYInputSpecialSequenceHandler, IFar2
 	int _stdin = 0, _stdout = 1;
 	bool _ext_clipboard;
 	bool _norgb;
-	const char *_nodetect = "";
+    DWORD _nodetect = NODETECT_NONE;
 	bool _far2l_tty = false;
 	bool _osc52clip_set = false;
 
@@ -148,7 +148,7 @@ protected:
 	DWORD QueryControlKeys();
 
 public:
-	TTYBackend(const char *full_exe_path, int std_in, int std_out, bool ext_clipboard, bool norgb, const char *nodetect, bool far2l_tty, unsigned int esc_expiration, int notify_pipe, int *result);
+    TTYBackend(const char *full_exe_path, int std_in, int std_out, bool ext_clipboard, bool norgb, DWORD nodetect, bool far2l_tty, unsigned int esc_expiration, int notify_pipe, int *result);
 	~TTYBackend();
 	void KickAss(bool flush_input_queue = false);
 	bool Startup();

--- a/WinPort/src/Backend/WinPortMain.cpp
+++ b/WinPort/src/Backend/WinPortMain.cpp
@@ -41,7 +41,7 @@ IConsoleInput *g_winport_con_in = nullptr;
 const wchar_t *g_winport_backend = L"";
 
 bool WinPortMainTTY(const char *full_exe_path, int std_in, int std_out,
-	bool ext_clipboard, bool norgb, const char *nodetect, bool far2l_tty,
+    bool ext_clipboard, bool norgb, DWORD nodetect, bool far2l_tty,
 	unsigned int esc_expiration, int notify_pipe, int argc, char **argv,
 	int(*AppMain)(int argc, char **argv), int *result);
 
@@ -247,7 +247,7 @@ extern "C" void WinPortHelp()
 
 struct ArgOptions
 {
-	const char *nodetect = "";
+    DWORD nodetect = NODETECT_NONE;
 	bool tty = false, far2l_tty = false, notty = false, norgb = false;
 	bool mortal = false;
 	bool x11 = false;
@@ -282,11 +282,18 @@ struct ArgOptions
 			norgb = true;
 
 		} else if (strcmp(a, "--nodetect") == 0) {
-			nodetect = "fx";
+            nodetect = NODETECT_F | NODETECT_X;
 
 		} else if (strstr(a, "--nodetect=") == a) {
-			nodetect = a + 11;
-
+            if(strstr(a+11,"xi")) {
+                nodetect = NODETECT_XI;
+            } else if (strchr(a+11,'x')) {
+                nodetect = NODETECT_X;
+            }
+            if(strchr(a+11,'f'))
+            {
+                nodetect |= NODETECT_F;
+            }
 		} else if (strstr(a, "--clipboard=") == a) {
 			ext_clipboard = a + 12;
 
@@ -400,7 +407,7 @@ extern "C" int WinPortMain(const char *full_exe_path, int argc, char **argv, int
 	std::unique_ptr<TTYRawMode> tty_raw_mode;
 	if (!arg_opts.notty) {
 		tty_raw_mode.reset(new TTYRawMode(std_in, std_out));;
-		if (!strchr(arg_opts.nodetect, 'f')) {
+        if ((arg_opts.nodetect & NODETECT_F) == 0) {
 	//		tty_raw_mode.reset(new TTYRawMode(std_out));
 			if (tty_raw_mode->Applied() || IsFar2lFISHTerminal()) {
 				arg_opts.far2l_tty = TTYNegotiateFar2l(std_in, std_out, true);


### PR DESCRIPTION
fix #2139:

Method ArgOptions::ParseArg() [used](https://github.com/elfmz/far2l/blob/e6ad61a1ebfd816232f24bf5e224bf7ef83c2ebc/WinPort/src/Backend/WinPortMain.cpp#L288) internal buffer of local std::string [passed](https://github.com/elfmz/far2l/blob/e6ad61a1ebfd816232f24bf5e224bf7ef83c2ebc/WinPort/src/Backend/WinPortMain.cpp#L355) from WinPortMain(), this led to the corruption of the variable value.

Type of nodetect variable  was changed from char* to DWORD, and now it is used as a bitmask.