### PR TITLE
uchardet: 1) treat ASCII as UTF-8; 2) indentation fixes

### DIFF
--- a/far2l/src/filestr.cpp
+++ b/far2l/src/filestr.cpp
@@ -736,11 +736,11 @@ static bool GetFileFormatByHeuristics(File &file, UINT &nCodePage)
 		nCodePage = CP_UTF16BE;
 		return true;
 	}
-    if (Val32LE > Val16BE && Val32LE >= Val16LE && Val32LE > Val32BE) {
+	if (Val32LE > Val16BE && Val32LE >= Val16LE && Val32LE > Val32BE) {
 		nCodePage = CP_UTF32LE;
 		return true;
 	}
-    if (Val32BE >= Val16BE && Val32BE > Val16LE && Val32BE > Val32LE) {
+	if (Val32BE >= Val16BE && Val32BE > Val16LE && Val32BE > Val32LE) {
 		nCodePage = CP_UTF32BE;
 		return true;
 	}

--- a/far2l/src/locale/DetectCodepage.cpp
+++ b/far2l/src/locale/DetectCodepage.cpp
@@ -40,8 +40,8 @@ static int CheckForEncodedInName(const char *cs)
 	}
 
 	int r = atoi(cs);
-	if (r == 878) {   // IBM KOI8-R
-		return 20866; // MS KOI8-R
+	if (r == 878) {		// IBM KOI8-R
+		return 20866;	// MS KOI8-R
 	}
 
 	return r;
@@ -49,55 +49,56 @@ static int CheckForEncodedInName(const char *cs)
 
 static int CheckForHardcodedByName(const char *cs)
 {
-    struct cmp_str
-    {
-        bool operator()(char const *a, char const *b) const
-        {
-            return std::strcmp(a, b) < 0;
-        }
-    };
+	struct cmp_str
+	{
+		bool operator()(char const *a, char const *b) const
+		{
+			return std::strcmp(a, b) < 0;
+		}
+	};
 
-    std::map<const char*, int, cmp_str> encodings
-        {
-            {"UTF-16",CP_UTF16LE},
-            {"UTF-32",CP_UTF32LE},
-            {"UTF-8",CP_UTF8},
-            {"ISO-8859-1",28591},          // Latin 1; Western European
-            {"ISO-8859-2",28592},          // Latin 2; Central European
-            {"ISO-8859-3",28593},          // Latin 3; South European
-            {"ISO-8859-4",28594},          // Latin 4; Baltic
-            {"ISO-8859-5",28595},          // Cyrillic
-            {"ISO-8859-6",28596},          // Arabic
-            {"ISO-8859-7",28597},          // Greek
-            {"ISO-8859-8",28598},          // Hebrew
-            {"ISO-8859-9",28599},          // Latin-5; Turkish
-            {"ISO-8859-10",28600},         // Latin-6; Nordic
-            {"ISO-8859-11",874},           // Thai (in fact, it's 28601 but it's not supported by far2l)
-            {"ISO-8859-13",28603},         // Latin-7; Baltic Rim (Estonian)
-            {"ISO-8859-14",28604},         // Latin-8; iso-celtic
-            {"ISO-8859-15",28605},         // Latin-9; Western European
-            {"ISO-8859-16",28606},         // Latin-10; South-Eastern European
-            {"TIS-620",874},               // Thai
-            {"MAC-CYRILLIC",10007},        // Cyrillic (Mac)
-            {"MAC-CENTRALEUROPE",10029},   // Mac OS Central European
-            {"KOI8-R",20866},              // Cyrillic
-            {"EUC-JP",20932},              // Japanese
-            {"ISO-2022-JP",50220},         // Japanese
-            {"ISO-2022-CN",50227},         // Chinese Simplified
-            {"Johab",1361},                // Korean
-            {"SHIFT_JIS",932},             // Japanese
-            {"EUC-KR",51949},              // Korean
-            {"UHC",949},                   // Korean
-            {"ISO-2022-KR",50225},         // Korean
-            {"BIG5",950},                  // Traditional Chinese
-            {"GB18030",54936}              // Chinese Simplified
-        };
+	std::map<const char*, int, cmp_str> encodings
+		{
+			{"UTF-16",CP_UTF16LE},
+			{"UTF-32",CP_UTF32LE},
+			{"UTF-8",CP_UTF8},
+			{"ASCII",CP_UTF8},				// treat ASCII as UTF-8 (better in the editor)
+			{"ISO-8859-1",28591},			// Latin 1; Western European
+			{"ISO-8859-2",28592},			// Latin 2; Central European
+			{"ISO-8859-3",28593},			// Latin 3; South European
+			{"ISO-8859-4",28594},			// Latin 4; Baltic
+			{"ISO-8859-5",28595},			// Cyrillic
+			{"ISO-8859-6",28596},			// Arabic
+			{"ISO-8859-7",28597},			// Greek
+			{"ISO-8859-8",28598},			// Hebrew
+			{"ISO-8859-9",28599},			// Latin-5; Turkish
+			{"ISO-8859-10",28600},			// Latin-6; Nordic
+			{"ISO-8859-11",874},			// Thai (in fact, it's 28601 but it's not supported by far2l)
+			{"ISO-8859-13",28603},			// Latin-7; Baltic Rim (Estonian)
+			{"ISO-8859-14",28604},			// Latin-8; iso-celtic
+			{"ISO-8859-15",28605},			// Latin-9; Western European
+			{"ISO-8859-16",28606},			// Latin-10; South-Eastern European
+			{"TIS-620",874},				// Thai
+			{"MAC-CYRILLIC",10007},			// Cyrillic (Mac)
+			{"MAC-CENTRALEUROPE",10029},	// Mac OS Central European
+			{"KOI8-R",20866},				// Cyrillic
+			{"EUC-JP",20932},				// Japanese
+			{"ISO-2022-JP",50220},			// Japanese
+			{"ISO-2022-CN",50227},			// Chinese Simplified
+			{"Johab",1361},					// Korean
+			{"SHIFT_JIS",932},				// Japanese
+			{"EUC-KR",51949},				// Korean
+			{"UHC",949},					// Korean
+			{"ISO-2022-KR",50225},			// Korean
+			{"BIG5",950},					// Traditional Chinese
+			{"GB18030",54936}				// Chinese Simplified
+		};
 
-    // the rest:
-    // ASCII, EUC-TW, GEORGIAN-ACADEMY, GEORGIAN-PS, HZ-GB-2312, VISCII
+	// the rest:
+	// EUC-TW, GEORGIAN-ACADEMY, GEORGIAN-PS, HZ-GB-2312, VISCII
 
-    auto r= encodings.find(cs);
-    return r==encodings.end() ? -1 : r->second;
+	auto r= encodings.find(cs);
+	return r==encodings.end() ? -1 : r->second;
 }
 
 static int TranslateUDCharset(const char *cs)
@@ -108,7 +109,7 @@ static int TranslateUDCharset(const char *cs)
 	if (r == -1)
 		fprintf(stderr, "TranslateUDCharset: unknown charset '%s'\n", cs);
 
-    return r;
+	return r;
 }
 
 int DetectCodePage(const char *data, size_t len)


### PR DESCRIPTION
1) treat uchardet's ASCII as UTF-8
2) replaced spaces with tabs according to CODESTYLE.md
