### PR TITLE
Fix sudo privilege elevation for files moving to trash

### DIFF
--- a/far2l/src/delete.cpp
+++ b/far2l/src/delete.cpp
@@ -724,7 +724,7 @@ static DeletionResult RemoveToRecycleBin(const wchar_t *Name)
 	std::string err_file_arg = err_file.GetMB();
 
 	unsigned int flags = EF_HIDEOUT;
-	if (sudo_client_is_required_for(name_arg.c_str(), true))
+	if (sudo_client_is_required_for(ExtractFilePath(name_arg).c_str(), true))
 		flags|= EF_SUDO;
 
 	QuoteCmdArgIfNeed(name_arg);

--- a/far2l/src/delete.cpp
+++ b/far2l/src/delete.cpp
@@ -723,8 +723,10 @@ static DeletionResult RemoveToRecycleBin(const wchar_t *Name)
 	std::string name_arg = FullName.GetMB();
 	std::string err_file_arg = err_file.GetMB();
 
+
 	unsigned int flags = EF_HIDEOUT;
-	if (sudo_client_is_required_for(ExtractFilePath(name_arg).c_str(), true))
+	if (sudo_client_is_required_for(ExtractFilePath(name_arg).c_str(), true)
+		|| (apiPathIsDir(FullName) && sudo_client_is_required_for(name_arg.c_str(), true)))
 		flags|= EF_SUDO;
 
 	QuoteCmdArgIfNeed(name_arg);


### PR DESCRIPTION
[RemoveToRecycleBin](https://github.com/elfmz/far2l/blob/47a5092dbeb29a07095a7a563ad0410a922ea536/far2l/src/delete.cpp#L716) function [checks](https://github.com/elfmz/far2l/blob/47a5092dbeb29a07095a7a563ad0410a922ea536/far2l/src/delete.cpp#L727) if privilege elevation is necessary based on the full filename passed to it.
However, the ability to delete a file is determined by permissions on the directory containing the file, not on the file itself.
Thus the following troublesome situations may arise:
1. Unnecessary sudo prompt when deleting _**a file we do not own**_ from _**a directory we do own**_. Moreover, the subsequent moving to trash will be done as root, so the deleted file will end up in `/root/.local/share/Trash/` instead of `/home/<username>/.local/share/Trash/`.
2. The sudo password will not be asked (although it should be), when deleting _**a file we own**_ from _**a directory that we do not have write permission to**_. It will end up denying access and prompting to delete the file with "No Recycle Bin".

However, if **a directory** is to be deleted, _kioclient_ and _gio_ still need write permissions to it. This case is checked additionally.

<hr>

**Как вариант** — вообще из функции RemoveToRecycleBin проверку эту выкинуть. Тогда
- в (1) случае и так всё удалится корректно,
- во (2) случае удаление в корзину зафейлится, и будет предложен вариант удалить файл без корзины.
- и, наконец, в случае удаления в корзину директории, для которой запрашивалось бы sudo, также будет отказ и последующий запрос на удаление без корзины.

Ибо, в целом, удаление в `/root/.local/share/Trash/`, которое происходит после sudo, не кажется сильно здравой идеей. Впрочем, во многих дистрибутивах есть [trash-cli](https://github.com/andreafrancia/trash-cli), который можно юзать в форме `sudo trash-restore`.