### PR TITLE
fix #2142: restore positioning on files in panels in case of manual setup saving (Shift-F9) too

### DIFF
--- a/far2l/src/ctrlobj.cpp
+++ b/far2l/src/ctrlobj.cpp
@@ -116,10 +116,8 @@ void ControlObject::Init()
 	Cp()->LeftPanel->Update(0);
 	Cp()->RightPanel->Update(0);
 
-	if (Opt.AutoSaveSetup) {
-		Cp()->LeftPanel->GoToFile(Opt.strLeftCurFile);
-		Cp()->RightPanel->GoToFile(Opt.strRightCurFile);
-	}
+	Cp()->LeftPanel->GoToFile(Opt.strLeftCurFile);
+	Cp()->RightPanel->GoToFile(Opt.strRightCurFile);
 
 	FARString strStartCurDir;
 	Cp()->ActivePanel->GetCurDir(strStartCurDir);


### PR DESCRIPTION
fix #2142: restore positioning on files in panels in case of manual setup saving (Shift-F9) too
