### PR TITLE
Fix build on DragonflyBSD 6.4. with gcc12

### DIFF
--- a/utils/src/LocalSocket.cpp
+++ b/utils/src/LocalSocket.cpp
@@ -3,6 +3,10 @@
 #include <posix/sys/select.h>
 #endif
 
+#if defined(__DragonFly__)
+#include <sys/select.h>
+#endif
+
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/un.h>

--- a/utils/src/PipeIPC.cpp
+++ b/utils/src/PipeIPC.cpp
@@ -8,6 +8,10 @@
 	#include <posix/sys/select.h>
 #endif
 
+#if defined(__DragonFly__)
+#include <sys/select.h>
+#endif
+
 static std::string FormatIPCError(const char *msg, unsigned int code)
 {
 	std::string s = msg;


### PR DESCRIPTION
After applying the commit https://github.com/elfmz/far2l/commit/85d1dc8c2d232e98e26ad9094509dd5590f5a6e7, it became necessary to use gcc > 8

If you install and use gcc12:

 sudo pkg install gcc-12_5
 export CC=/usr/local/bin/gcc; export CXX=/usr/local/bin/g++
 cmake -DUSEWX=yes -DCMAKE_BUILD_TYPE=Release -G Ninja ..
 cmake --build .

You will get new errors:

FAILED: utils/CMakeFiles/utils.dir/src/LocalSocket.cpp.o /home/user/src/far2l-staging/utils/src/LocalSocket.cpp:197:21: error: 'select' was not declared in this scope; did you mean 'exect'?
  197 |                 if (select(maxfd + 1, &fdr, (fd_set*)nullptr, &fde, (timeval*)nullptr) == -1) {
      |                     ^~~~~~
      |                     exect