### PR TITLE
open.sh and ps.sh scripts corrections

### DIFF
--- a/far2l/bootstrap/open.sh
+++ b/far2l/bootstrap/open.sh
@@ -17,7 +17,7 @@ shift
 
 # Define EXEC_TERM here to allow overriding its from ~/.config/far2l/open.sh
 EXEC_TERM=xterm
-if ( [ ! -z "$DESKTOP_SESSION" ] && [ -x /etc/alternatives/x-terminal-emulator ] ); then
+if [ ! -z "$DESKTOP_SESSION" ] && [ -x /etc/alternatives/x-terminal-emulator ] ; then
 	EXEC_TERM=/etc/alternatives/x-terminal-emulator
 fi
 
@@ -26,7 +26,7 @@ if [ -x ~/.config/far2l/open.sh ]; then
 fi
 
 if [ "$what" = "exec" ] ; then
-	if ( [ -f "$1" ] && [ -x "$1" ] ) || command -v "$1" >/dev/null 2>/dev/null ; then
+	if { [ -f "$1" ] && [ -x "$1" ]; } || command -v "$1" >/dev/null 2>/dev/null ; then
 		if command -v $EXEC_TERM >/dev/null 2>/dev/null ; then
 			$EXEC_TERM -e "$@" >/dev/null 2>/dev/null &
 			exit 0

--- a/far2l/bootstrap/ps.sh
+++ b/far2l/bootstrap/ps.sh
@@ -15,13 +15,13 @@ if command -v htop >/dev/null 2>&1; then #GNOME
 	htop
 
 else
-	if ! test -f ~/.config/far2l/ps.warned ; then
-		B=$'\e[1;91m'
-		N=$'\e[0m'
+	if [ ! -f ~/.config/far2l/ps.warned ] ; then
+		B=$(printf '\e[1;91m')
+		N=$(printf '\e[0m')
 		echo "It is recommended to install <${B}htop${N}> utility."
 		echo "Without <${B}htop${N}> installed far2l will use <${B}top${N}>."
 		echo "Press any key to continue..."
-		read -n 1 k <&1
+		read -r -n 1 k <&1
 		touch ~/.config/far2l/ps.warned
 	fi
 	top


### PR DESCRIPTION
1. Use `{ ..; }` instead of `(..)` and remove superfluous `(..)` around condition to avoid subshell overhead.
2. Replace `$'..'` with `$(printf '..')` for better posix shell compatibility.
3. Replace `test` with `[ .. ]` for better readability.
4. Add `read -r` option to handle backslash key presses too.

<hr>

Отдельный вопрос по поводу вот [этой](https://github.com/elfmz/far2l/blob/cafa42faf1f37e358ed241d98bd0d085574b220b/far2l/bootstrap/ps.sh#L24) конструкции в ps.sh:
```sh
read -n 1 k <&1
```
Переменная `k` и перенаправление `<&1` из stdout несут какой-то сакральный смысл, или это артефакты, которые можно удалить?