### PR TITLE
multiarc: check if we have read access to the archive

### DIFF
--- a/multiarc/src/arccmd.cpp
+++ b/multiarc/src/arccmd.cpp
@@ -45,8 +45,9 @@ ArcCommand::ArcCommand(struct PluginPanelItem *PanelItem, int ItemsNumber, const
 			}
 		}
 	} else {
-		if ((CommandType == CMD_EXTRACT || CommandType == CMD_EXTRACTWITHOUTPATH)	// extraction from the archive,
-			&& (sudo_client_is_required_for(".", true) == 1)) {		// check if we have write access to dest dir
+		if((sudo_client_is_required_for(ArcName, false) == 1)							// do we have read access to the archive?
+			|| ((CommandType == CMD_EXTRACT || CommandType == CMD_EXTRACTWITHOUTPATH)	// extraction from the archive,
+				&& (sudo_client_is_required_for(".", true) == 1))) {		// check if we have write access to dest dir
 			NeedSudo = true;
 		}
 	}


### PR DESCRIPTION
Одно из условий потерялось, обнаружилось при тестировании фикса с пересозданием /dev/null из-под root'а, вернул на место.