### PR TITLE
Option to disable automatic highlights in history lists

### DIFF
--- a/far2l/bootstrap/scripts/farlang.templ.m4
+++ b/far2l/bootstrap/scripts/farlang.templ.m4
@@ -1865,6 +1865,17 @@ ConfigSaveViewHistory
 "Зберігати історію п&ерегляду та редагування"
 "Захоўваць гісторыю п&раглядаў і зменаў"
 
+ConfigAutoHighlightHistory
+"Автоподсветка в списках истории"
+"Autohighlight in history"
+upd:"Autohighlight in history"
+upd:"Autohighlight in history"
+upd:"Autohighlight in history"
+upd:"Autohighlight in history"
+upd:"Autohighlight in history"
+upd:"Autohighlight in history"
+upd:"Autohighlight in history"
+
 ConfigRegisteredTypes
 "Использовать стандартные &типы файлов"
 "Use Windows &registered types"

--- a/far2l/src/cfg/ConfigOpt.cpp
+++ b/far2l/src/cfg/ConfigOpt.cpp
@@ -252,6 +252,7 @@ const ConfigOpt g_cfg_opts[] {
 	{true,  NSecSystem, "SaveFoldersHistory", &Opt.SaveFoldersHistory, 1},
 	{false, NSecSystem, "SavePluginFoldersHistory", &Opt.SavePluginFoldersHistory, 0},
 	{true,  NSecSystem, "SaveViewHistory", &Opt.SaveViewHistory, 1},
+	{true,  NSecSystem, "AutoHighlightHistory", &Opt.AutoHighlightHistory, 1},
 	{true,  NSecSystem, "AutoSaveSetup", &Opt.AutoSaveSetup, 0},
 	{true,  NSecSystem, "DeleteToRecycleBin", &Opt.DeleteToRecycleBin, 0},
 	{true,  NSecSystem, "DeleteToRecycleBinKillLink", &Opt.DeleteToRecycleBinKillLink, 1},

--- a/far2l/src/cfg/config.cpp
+++ b/far2l/src/cfg/config.cpp
@@ -181,6 +181,7 @@ void SystemSettings()
 	AddHistorySettings(Builder, Msg::ConfigSaveFoldersHistory, &Opt.SaveFoldersHistory,
 			&Opt.FoldersHistoryCount);
 	AddHistorySettings(Builder, Msg::ConfigSaveViewHistory, &Opt.SaveViewHistory, &Opt.ViewHistoryCount);
+	Builder.AddCheckbox(Msg::ConfigAutoHighlightHistory, &Opt.AutoHighlightHistory);
 
 	Builder.AddCheckbox(Msg::ConfigAutoSave, &Opt.AutoSaveSetup);
 	Builder.AddOKCancel();

--- a/far2l/src/cfg/config.hpp
+++ b/far2l/src/cfg/config.hpp
@@ -461,6 +461,7 @@ struct Options
 	int SavePluginFoldersHistory;
 	int FoldersHistoryCount;
 	int DialogsHistoryCount;
+	int AutoHighlightHistory;
 
 	BYTE HistoryShowTimes[8];
 

--- a/far2l/src/hist/history.cpp
+++ b/far2l/src/hist/history.cpp
@@ -378,7 +378,8 @@ int History::Select(const wchar_t *Title, const wchar_t *HelpTopic, FARString &s
 	HistoryMenu.SetHelp(HelpTopic ? HelpTopic : L"HistoryCmd");	
 
 	HistoryMenu.SetPosition(-1, -1, 0, 0);
-	HistoryMenu.AssignHighlights(TRUE);
+	if (Opt.AutoHighlightHistory)
+		HistoryMenu.AssignHighlights(TRUE);
 	return ProcessMenu(strStr, Title, HistoryMenu, Height, Type, nullptr);
 }
 


### PR DESCRIPTION
Automatic assignment of single-button shortcuts to items of dynamically changing lists are quite misclick prone and in a case of commands history even could be dangerous. 

Not sure if it's useful for most users, but I'd like to have an option to disable. Here it is