### PR TITLE
ScanFileByMapping fix: take into account the exact upper boundary

### DIFF
--- a/far2l/src/findfile.cpp
+++ b/far2l/src/findfile.cpp
@@ -1035,7 +1035,8 @@ static bool ScanFileByMapping(const char *Name)
 		for (UINT LastPercents = 0;;) {
 			const bool FirstFragment = (FilePos == 0);
 			const bool LastFragment = (FilePos + off_t(smm.Length()) >= FileSize);
-			if (findPattern->FindMatch(View, Length, FirstFragment, LastFragment).first != (size_t)-1) {
+			if (findPattern->FindMatch(View, LastFragment?Length-(FilePos + off_t(smm.Length())-FileSize):Length,
+									   FirstFragment, LastFragment).first != (size_t)-1) {
 				return true;
 			}
 			if (LastFragment) {

--- a/far2l/src/findfile.cpp
+++ b/far2l/src/findfile.cpp
@@ -1035,7 +1035,7 @@ static bool ScanFileByMapping(const char *Name)
 		for (UINT LastPercents = 0;;) {
 			const bool FirstFragment = (FilePos == 0);
 			const bool LastFragment = (FilePos + off_t(smm.Length()) >= FileSize);
-			if (findPattern->FindMatch(View, LastFragment?Length-(FilePos + off_t(smm.Length())-FileSize):Length,
+			if (findPattern->FindMatch(View, LastFragment ? Length-(FilePos + off_t(smm.Length())-FileSize) : Length,
 									   FirstFragment, LastFragment).first != (size_t)-1) {
 				return true;
 			}


### PR DESCRIPTION
При сканировании файла, спроецированного в память, не учитывалась **точная** верхняя граница поиска, заданная переменной SearchInFirst. В итоге в результат поиска файлов попадали лишние файлы, содержащие искомый шаблон, но за пределами указанного пользователем ограничения (поиск вёлся во всём "последнем" окошке из проекции).