### PR TITLE
fix incorrect initial focus highlighting in dialogs

### DIFF
--- a/far2l/src/dialog.cpp
+++ b/far2l/src/dialog.cpp
@@ -717,7 +717,7 @@ unsigned Dialog::InitDialogObjects(unsigned ID)
 	}
 
 	// если FocusPos в пределах и элемент задисаблен, то ищем сначала
-	if (FocusPos != (unsigned)-1 && FocusPos < ItemCount && IsItemFocusable(Item[FocusPos]))
+	if (FocusPos != (unsigned)-1 && FocusPos < ItemCount && !IsItemFocusable(Item[FocusPos]))
 		FocusPos = (unsigned)-1;	// будем искать сначала!
 
 	// предварительный цикл по поводу кнопок

--- a/far2l/src/dialog.cpp
+++ b/far2l/src/dialog.cpp
@@ -742,7 +742,7 @@ unsigned Dialog::InitDialogObjects(unsigned ID)
 			}
 		}
 		// предварительный поик фокуса
-		if (FocusPos == (unsigned)-1 && IsItemFocusable(CurItem))
+		if (FocusPos == (unsigned)-1 && IsItemFocusable(CurItem) && CurItem->Focus)
 			FocusPos = I;		// запомним первый фокусный элемент
 
 		CurItem->Focus = 0;		// сбросим для всех, чтобы не оказалось,


### PR DESCRIPTION
Из-за забытой инверсии, в некоторых диалогах сразу несколько кнопок могли быть подсвечены, будто бы они в фокусе.