### PR TITLE
History - delete duplicates if Name and Extra equal

### DIFF
--- a/far2l/bootstrap/scripts/farlang.templ.m4
+++ b/far2l/bootstrap/scripts/farlang.templ.m4
@@ -1865,6 +1865,39 @@ ConfigSaveViewHistory
 "Зберігати історію п&ерегляду та редагування"
 "Захоўваць гісторыю п&раглядаў і зменаў"
 
+ConfigHistoryRemoveDupsRule
+"Удаление &дубликатов в истории:"
+"&Remove duplicates in history:"
+upd:"&Remove duplicates in history:"
+upd:"&Remove duplicates in history:"
+upd:"&Remove duplicates in history:"
+upd:"&Remove duplicates in history:"
+upd:"&Remove duplicates in history:"
+upd:"&Remove duplicates in history:"
+upd:"&Remove duplicates in history:"
+
+ConfigHistoryRemoveDupsRuleByName
+"по имени"
+"by name"
+upd:"by name"
+upd:"by name"
+upd:"by name"
+upd:"by name"
+upd:"by name"
+upd:"by name"
+upd:"by name"
+
+ConfigHistoryRemoveDupsRuleByNameExtra
+"по имени и пути"
+"by name and extra"
+upd:"by name and extra"
+upd:"by name and extra"
+upd:"by name and extra"
+upd:"by name and extra"
+upd:"by name and extra"
+upd:"by name and extra"
+upd:"by name and extra"
+
 ConfigAutoHighlightHistory
 "Автоподсветка в списках истории"
 "Autohighlight in history"

--- a/far2l/bootstrap/scripts/farlang.templ.m4
+++ b/far2l/bootstrap/scripts/farlang.templ.m4
@@ -1876,6 +1876,17 @@ upd:"&Remove duplicates in history:"
 upd:"&Remove duplicates in history:"
 upd:"&Remove duplicates in history:"
 
+ConfigHistoryRemoveDupsRuleNever
+"никогда"
+"never"
+upd:"never"
+upd:"never"
+upd:"never"
+upd:"never"
+upd:"never"
+upd:"never"
+upd:"never"
+
 ConfigHistoryRemoveDupsRuleByName
 "по имени"
 "by name"

--- a/far2l/src/cfg/ConfigOpt.cpp
+++ b/far2l/src/cfg/ConfigOpt.cpp
@@ -258,7 +258,7 @@ const ConfigOpt g_cfg_opts[] {
 	{true,  NSecSystem, "SaveFoldersHistory", &Opt.SaveFoldersHistory, 1},
 	{false, NSecSystem, "SavePluginFoldersHistory", &Opt.SavePluginFoldersHistory, 0},
 	{true,  NSecSystem, "SaveViewHistory", &Opt.SaveViewHistory, 1},
-	{true,  NSecSystem, "HistoryRemoveDupsRule", &Opt.HistoryRemoveDupsRule, 1},
+	{true,  NSecSystem, "HistoryRemoveDupsRule", &Opt.HistoryRemoveDupsRule, 2},
 	{true,  NSecSystem, "AutoHighlightHistory", &Opt.AutoHighlightHistory, 1},
 	{true,  NSecSystem, "AutoSaveSetup", &Opt.AutoSaveSetup, 0},
 	{true,  NSecSystem, "DeleteToRecycleBin", &Opt.DeleteToRecycleBin, 0},

--- a/far2l/src/cfg/ConfigOpt.cpp
+++ b/far2l/src/cfg/ConfigOpt.cpp
@@ -258,6 +258,7 @@ const ConfigOpt g_cfg_opts[] {
 	{true,  NSecSystem, "SaveFoldersHistory", &Opt.SaveFoldersHistory, 1},
 	{false, NSecSystem, "SavePluginFoldersHistory", &Opt.SavePluginFoldersHistory, 0},
 	{true,  NSecSystem, "SaveViewHistory", &Opt.SaveViewHistory, 1},
+	{true,  NSecSystem, "HistoryRemoveDupsRule", &Opt.HistoryRemoveDupsRule, 1},
 	{true,  NSecSystem, "AutoHighlightHistory", &Opt.AutoHighlightHistory, 1},
 	{true,  NSecSystem, "AutoSaveSetup", &Opt.AutoSaveSetup, 0},
 	{true,  NSecSystem, "DeleteToRecycleBin", &Opt.DeleteToRecycleBin, 0},

--- a/far2l/src/cfg/config.cpp
+++ b/far2l/src/cfg/config.cpp
@@ -178,11 +178,22 @@ void SystemSettings()
 				DIF_DROPDOWNLIST | DIF_LISTAUTOHIGHLIGHT | DIF_LISTWRAPMODE);
 	MakeLinkSuggest->Indent(4);
 
+	Builder.AddSeparator();
 	AddHistorySettings(Builder, Msg::ConfigSaveHistory, &Opt.SaveHistory, &Opt.HistoryCount);
 	AddHistorySettings(Builder, Msg::ConfigSaveFoldersHistory, &Opt.SaveFoldersHistory,
 			&Opt.FoldersHistoryCount);
 	AddHistorySettings(Builder, Msg::ConfigSaveViewHistory, &Opt.SaveViewHistory, &Opt.ViewHistoryCount);
+	DialogBuilderListItem CAHistRemoveListItems[] = {
+			{Msg::ConfigHistoryRemoveDupsRuleByName, 0},
+			{Msg::ConfigHistoryRemoveDupsRuleByNameExtra,  1},
+	};
+	DialogItemEx *HistRemove =
+		Builder.AddComboBox((int *)&Opt.HistoryRemoveDupsRule, 20, CAHistRemoveListItems, ARRAYSIZE(CAHistRemoveListItems),
+				DIF_DROPDOWNLIST | DIF_LISTAUTOHIGHLIGHT | DIF_LISTWRAPMODE);
+	Builder.AddTextBefore(HistRemove, Msg::ConfigHistoryRemoveDupsRule);
+
 	Builder.AddCheckbox(Msg::ConfigAutoHighlightHistory, &Opt.AutoHighlightHistory);
+	Builder.AddSeparator();
 
 	Builder.AddCheckbox(Msg::ConfigAutoSave, &Opt.AutoSaveSetup);
 	Builder.AddOKCancel();

--- a/far2l/src/cfg/config.cpp
+++ b/far2l/src/cfg/config.cpp
@@ -184,8 +184,9 @@ void SystemSettings()
 			&Opt.FoldersHistoryCount);
 	AddHistorySettings(Builder, Msg::ConfigSaveViewHistory, &Opt.SaveViewHistory, &Opt.ViewHistoryCount);
 	DialogBuilderListItem CAHistRemoveListItems[] = {
-			{Msg::ConfigHistoryRemoveDupsRuleByName, 0},
-			{Msg::ConfigHistoryRemoveDupsRuleByNameExtra,  1},
+			{Msg::ConfigHistoryRemoveDupsRuleNever, 0},
+			{Msg::ConfigHistoryRemoveDupsRuleByName, 1},
+			{Msg::ConfigHistoryRemoveDupsRuleByNameExtra, 2},
 	};
 	DialogItemEx *HistRemove =
 		Builder.AddComboBox((int *)&Opt.HistoryRemoveDupsRule, 20, CAHistRemoveListItems, ARRAYSIZE(CAHistRemoveListItems),

--- a/far2l/src/cfg/config.hpp
+++ b/far2l/src/cfg/config.hpp
@@ -461,6 +461,7 @@ struct Options
 	int SavePluginFoldersHistory;
 	int FoldersHistoryCount;
 	int DialogsHistoryCount;
+	int HistoryRemoveDupsRule;
 	int AutoHighlightHistory;
 
 	BYTE HistoryShowTimes[8];

--- a/far2l/src/hist/history.cpp
+++ b/far2l/src/hist/history.cpp
@@ -142,7 +142,7 @@ void History::AddToHistoryLocal(const wchar_t *Str, const wchar_t *Extra, const 
 							&& (!Opt.HistoryRemoveDupsRule || !StrCmpI(AddRecord.strExtra, HistoryItem->strExtra)))) {
 					AddRecord.Lock = HistoryItem->Lock;
 					HistoryItem = HistoryList.Delete(HistoryItem);
-					if( !Opt.HistoryRemoveDupsRule )
+					if( Opt.HistoryRemoveDupsRule )
 						break; // stop loop only if strict remove by Name and Extra
 				}
 			}

--- a/far2l/src/hist/history.cpp
+++ b/far2l/src/hist/history.cpp
@@ -131,19 +131,18 @@ void History::AddToHistoryLocal(const wchar_t *Str, const wchar_t *Extra, const 
 		AddRecord.strExtra = Extra;
 	}
 
-	if (RemoveDups)		// удалять дубликаты?
+	if (RemoveDups && Opt.HistoryRemoveDupsRule)		// удалять дубликаты?
 	{
 		for (HistoryRecord *HistoryItem = HistoryList.First(); HistoryItem;
 				HistoryItem = HistoryList.Next(HistoryItem)) {
 			if (EqualType(AddRecord.Type, HistoryItem->Type)) {
 				if ((RemoveDups == 1 && !StrCmp(AddRecord.strName, HistoryItem->strName)
-							 && (!Opt.HistoryRemoveDupsRule || !StrCmp(AddRecord.strExtra, HistoryItem->strExtra)))
+							 && (Opt.HistoryRemoveDupsRule<2 || !StrCmp(AddRecord.strExtra, HistoryItem->strExtra)))
 						|| (RemoveDups == 2 && !StrCmpI(AddRecord.strName, HistoryItem->strName)
-							&& (!Opt.HistoryRemoveDupsRule || !StrCmpI(AddRecord.strExtra, HistoryItem->strExtra)))) {
+							&& (Opt.HistoryRemoveDupsRule<2 || !StrCmpI(AddRecord.strExtra, HistoryItem->strExtra)))) {
 					AddRecord.Lock = HistoryItem->Lock;
 					HistoryItem = HistoryList.Delete(HistoryItem);
-					if( Opt.HistoryRemoveDupsRule )
-						break; // stop loop only if strict remove by Name and Extra
+					// break; // not stop loop because after HistoryRemoveDupsRule==0 or ==2 history may has dups
 				}
 			}
 		}

--- a/far2l/src/hist/history.cpp
+++ b/far2l/src/hist/history.cpp
@@ -136,11 +136,14 @@ void History::AddToHistoryLocal(const wchar_t *Str, const wchar_t *Extra, const 
 		for (HistoryRecord *HistoryItem = HistoryList.First(); HistoryItem;
 				HistoryItem = HistoryList.Next(HistoryItem)) {
 			if (EqualType(AddRecord.Type, HistoryItem->Type)) {
-				if ((RemoveDups == 1 && !StrCmp(AddRecord.strName, HistoryItem->strName))
-						|| (RemoveDups == 2 && !StrCmpI(AddRecord.strName, HistoryItem->strName))) {
+				if ((RemoveDups == 1 && !StrCmp(AddRecord.strName, HistoryItem->strName)
+							 && (!Opt.HistoryRemoveDupsRule || !StrCmp(AddRecord.strExtra, HistoryItem->strExtra)))
+						|| (RemoveDups == 2 && !StrCmpI(AddRecord.strName, HistoryItem->strName)
+							&& (!Opt.HistoryRemoveDupsRule || !StrCmpI(AddRecord.strExtra, HistoryItem->strExtra)))) {
 					AddRecord.Lock = HistoryItem->Lock;
 					HistoryItem = HistoryList.Delete(HistoryItem);
-					break;
+					if( !Opt.HistoryRemoveDupsRule )
+						break; // stop loop only if strict remove by Name and Extra
 				}
 			}
 		}


### PR DESCRIPTION
Default behavior change to new "if Name and Extra equal"

Added toggle in System settings: "by Name and extra" and "by name"

Теперь вот так:
![image](https://github.com/elfmz/far2l/assets/92621645/eff17f36-5000-4756-ba76-b528474af843)
Настройка варианта удалению из истории "по имени и пути" давно напрашивалась, а то случайно не в том каталоге запустишь и потом ищи где оно было. Настройку "никогда" добавил до кучи, ибо она легко тут вписалась. 