### PR TITLE
fix 2207: prevent crash on Quick View and when calculating folder size

### DIFF
--- a/far2l/src/dirinfo.cpp
+++ b/far2l/src/dirinfo.cpp
@@ -54,6 +54,10 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 static void DrawGetDirInfoMsg(const wchar_t *Title, const wchar_t *Name, const UINT64 Size)
 {
+	if (Title == nullptr || Name == nullptr) {
+		return;
+	}
+
 	FARString strSize;
 	FileSizeToStr(strSize, Size, 8, COLUMN_FLOATSIZE | COLUMN_COMMAS);
 	RemoveLeadingSpaces(strSize);


### PR DESCRIPTION
fix https://github.com/elfmz/far2l/issues/2207 : prevent PANIC-PANIC crash during Quick view (Ctrl+Q) or size calculating (F3) of a directory containing inaccessible folders