### PR TITLE
fix incorrect focus on tab key in DI_RADIOBUTTON

### DIFF
--- a/far2l/src/dialog.cpp
+++ b/far2l/src/dialog.cpp
@@ -3992,46 +3992,33 @@ unsigned Dialog::ChangeFocus(unsigned CurFocusPos, int Step, int SkipGroup)
 {
 	CriticalSectionLock Lock(CS);
 	unsigned OrigFocusPos = CurFocusPos;
-	//	int FucusPosNeed=-1;
-	// В функцию обработки диалога здесь передаем сообщение,
-	// что элемент - LostFocus() - теряет фокус ввода.
-	//	if(DialogMode.Check(DMODE_INITOBJECTS))
-	//		FucusPosNeed=DlgProc((HANDLE)this,DN_KILLFOCUS,FocusPos,0);
-	//	if(FucusPosNeed != -1 && CanGetFocus(Item[FucusPosNeed].Type))
-	//		FocusPos=FucusPosNeed;
-	//	else
-	{
-		for (;;) {
-			CurFocusPos += Step;
 
-			if ((int)CurFocusPos < 0) {
-				CurFocusPos = ItemCount - 1;
-			}
+	for (;;) {
+		CurFocusPos += Step;
 
-			if (CurFocusPos >= ItemCount) {
-				CurFocusPos = 0;
-			}
+		if ((int)CurFocusPos < 0) {
+			CurFocusPos = ItemCount - 1;
+		}
 
-			if (IsItemFocusable(Item[CurFocusPos])) {
-				if (Item[CurFocusPos]->Type == DI_RADIOBUTTON && (SkipGroup || !Item[CurFocusPos]->Selected)) {
-					continue;
-				} else {
-					break;
-				}
-			}
+		if (CurFocusPos >= ItemCount) {
+			CurFocusPos = 0;
+		}
 
-			// убираем зацикливание с последующим подвисанием :-)
-			if (OrigFocusPos == CurFocusPos) {
+		if (IsItemFocusable(Item[CurFocusPos])) {
+			//move straight to selected radio when SkipGroup is true
+			if (Item[CurFocusPos]->Type == DI_RADIOBUTTON && !(SkipGroup && Item[CurFocusPos]->Selected)) {
+				continue;
+			} else {
 				break;
 			}
 		}
+
+		// убираем зацикливание с последующим подвисанием :-)
+		if (OrigFocusPos == CurFocusPos) {
+			break;
+		}
 	}
-	//	Dialog::FocusPos=FocusPos;
-	// В функцию обработки диалога здесь передаем сообщение,
-	// что элемент GotFocus() - получил фокус ввода.
-	// Игнорируем возвращаемое функцией диалога значение
-	//	if(DialogMode.Check(DMODE_INITOBJECTS))
-	//		DlgProc((HANDLE)this,DN_GOTFOCUS,FocusPos,0);
+
 	return (CurFocusPos);
 }
 


### PR DESCRIPTION
При навигации через TAB/Shift+TAB  на группу переключателей мы должны переходить сразу на включенный и покинуть группу при следующем нажатии.
![image](https://github.com/elfmz/far2l/assets/59544275/7a217246-2aef-4d9c-947d-f666f7ca5317)


Это изначальное поведение, которое было сломано в #2219 