### PR TITLE
Case sensitive fix & improvements

### DIFF
--- a/far2l/bootstrap/scripts/farlang.templ.m4
+++ b/far2l/bootstrap/scripts/farlang.templ.m4
@@ -11943,15 +11943,15 @@ FindFileCaseFileMask
 "Улічваць рэ&гістр (масак файлаў)"
 
 FindFileCase
-"&Учитывать регистр"
-"&Case sensitive"
+"&Учитывать регистр (текст)"
+"&Case sensitive (text)"
 "Roz&lišovat velikost písmen"
-"Gr&oß-/Kleinschreibung"
+"Gr&oß-/Kleinschreibung (text)"
 "&Nagy/kisbetű érzékeny"
 "&Uwzględnij wielkość liter"
-"Sensible min/ma&yúsc."
-"&Враховувати регістр"
-"&Улічваць рэгістр"
+"Sensible min/ma&yúsc (texto)"
+"&Враховувати регістр (текст)"
+"&Улічваць рэгістр (тэкст)"
 
 FindFileWholeWords
 "Только &целые слова"

--- a/far2l/src/filefilterparams.cpp
+++ b/far2l/src/filefilterparams.cpp
@@ -353,8 +353,8 @@ bool FileFilterParams::FileInFilterImpl(const FARString &strFileName, DWORD dwFi
 	}
 
 	// Режим проверки маски файла включен?
-	if (FMask.Used && !FMask.FilterMask.Compare(strFileName)) {		// Файл не попадает под маску введённую в фильтре?
-		return false;												// Не пропускаем этот файл
+	if (FMask.Used && !FMask.FilterMask.Compare(strFileName, false)) {		// Файл не попадает под маску введённую в фильтре?
+		return false;														// Не пропускаем этот файл
 	}
 
 	// Да! Файл выдержал все испытания и будет допущен к использованию

--- a/far2l/src/filefilterparams.cpp
+++ b/far2l/src/filefilterparams.cpp
@@ -354,7 +354,7 @@ bool FileFilterParams::FileInFilterImpl(const FARString &strFileName, DWORD dwFi
 
 	// Режим проверки маски файла включен?
 	if (FMask.Used && !FMask.FilterMask.Compare(strFileName)) {		// Файл не попадает под маску введённую в фильтре?
-		return false;														// Не пропускаем этот файл
+		return false;												// Не пропускаем этот файл
 	}
 
 	// Да! Файл выдержал все испытания и будет допущен к использованию

--- a/far2l/src/filefilterparams.cpp
+++ b/far2l/src/filefilterparams.cpp
@@ -353,7 +353,7 @@ bool FileFilterParams::FileInFilterImpl(const FARString &strFileName, DWORD dwFi
 	}
 
 	// Режим проверки маски файла включен?
-	if (FMask.Used && !FMask.FilterMask.Compare(strFileName, false)) {		// Файл не попадает под маску введённую в фильтре?
+	if (FMask.Used && !FMask.FilterMask.Compare(strFileName)) {		// Файл не попадает под маску введённую в фильтре?
 		return false;														// Не пропускаем этот файл
 	}
 

--- a/far2l/src/filemask/BaseFileMask.hpp
+++ b/far2l/src/filemask/BaseFileMask.hpp
@@ -45,6 +45,6 @@ public:
 
 public:
 	virtual bool Set(const wchar_t *Masks, DWORD Flags) = 0;
-	virtual bool Compare(const wchar_t *Name) const     = 0;
+	virtual bool Compare(const wchar_t *Name, bool ignorecase=true) const     = 0;
 	virtual bool IsEmpty() const { return true; }
 };

--- a/far2l/src/filemask/BaseFileMask.hpp
+++ b/far2l/src/filemask/BaseFileMask.hpp
@@ -45,6 +45,6 @@ public:
 
 public:
 	virtual bool Set(const wchar_t *Masks, DWORD Flags) = 0;
-	virtual bool Compare(const wchar_t *Name, bool ignorecase=true) const     = 0;
+	virtual bool Compare(const wchar_t *Name, bool ignorecase = true) const     = 0;
 	virtual bool IsEmpty() const { return true; }
 };

--- a/far2l/src/filemask/CFileMask.cpp
+++ b/far2l/src/filemask/CFileMask.cpp
@@ -102,7 +102,7 @@ bool CFileMask::IsEmpty() const
 	Возвращает TRUE в случае успеха.
 	Путь в имени файла игнорируется.
 */
-bool CFileMask::Compare(const wchar_t *FileName) const
+bool CFileMask::Compare(const wchar_t *FileName, bool ignorecase) const
 {
-	return FileMask ? FileMask->Compare(PointToName(FileName)) : false;
+	return FileMask ? FileMask->Compare(PointToName(FileName), ignorecase) : false;
 }

--- a/far2l/src/filemask/CFileMask.hpp
+++ b/far2l/src/filemask/CFileMask.hpp
@@ -54,7 +54,7 @@ public:
 
 public:
 	bool Set(const wchar_t *Masks, DWORD Flags);
-	bool Compare(const wchar_t *Name) const;
+	bool Compare(const wchar_t *Name, bool ignorecase=true) const;
 	bool IsEmpty() const;
 	void Free();
 };

--- a/far2l/src/filemask/CFileMask.hpp
+++ b/far2l/src/filemask/CFileMask.hpp
@@ -54,7 +54,7 @@ public:
 
 public:
 	bool Set(const wchar_t *Masks, DWORD Flags);
-	bool Compare(const wchar_t *Name, bool ignorecase=true) const;
+	bool Compare(const wchar_t *Name, bool ignorecase = true) const;
 	bool IsEmpty() const;
 	void Free();
 };

--- a/far2l/src/filemask/FileMasksProcessor.cpp
+++ b/far2l/src/filemask/FileMasksProcessor.cpp
@@ -94,7 +94,7 @@ bool FileMasksProcessor::IsEmpty() const
 	Возвращает TRUE в случае успеха.
 	Путь к файлу в FileName НЕ игнорируется
 */
-bool FileMasksProcessor::Compare(const wchar_t *FileName) const
+bool FileMasksProcessor::Compare(const wchar_t *FileName, bool ignorecase) const
 {
 	if (re) {
 		StackHeapArray<RegExpMatch> m(n);
@@ -105,7 +105,7 @@ bool FileMasksProcessor::Compare(const wchar_t *FileName) const
 	const wchar_t *MaskPtr;		// указатель на текущую маску в списке
 	for (size_t MI = 0; nullptr != (MaskPtr = Masks.Get(MI)); ++MI) {
 		// SkipPath=FALSE, т.к. в CFileMask вызывается PointToName
-		if (CmpName(MaskPtr, FileName, false))
+		if (CmpName(MaskPtr, FileName, false, ignorecase))
 			return true;
 	}
 

--- a/far2l/src/filemask/FileMasksProcessor.hpp
+++ b/far2l/src/filemask/FileMasksProcessor.hpp
@@ -53,7 +53,7 @@ public:
 
 public:
 	virtual bool Set(const wchar_t *Masks, DWORD Flags);
-	virtual bool Compare(const wchar_t *Name, bool ignorecase=true) const;
+	virtual bool Compare(const wchar_t *Name, bool ignorecase = true) const;
 	virtual bool IsEmpty() const;
 	void Free();
 

--- a/far2l/src/filemask/FileMasksProcessor.hpp
+++ b/far2l/src/filemask/FileMasksProcessor.hpp
@@ -53,7 +53,7 @@ public:
 
 public:
 	virtual bool Set(const wchar_t *Masks, DWORD Flags);
-	virtual bool Compare(const wchar_t *Name) const;
+	virtual bool Compare(const wchar_t *Name, bool ignorecase=true) const;
 	virtual bool IsEmpty() const;
 	void Free();
 

--- a/far2l/src/filemask/FileMasksWithExclude.cpp
+++ b/far2l/src/filemask/FileMasksWithExclude.cpp
@@ -128,9 +128,9 @@ bool FileMasksWithExclude::Set(const wchar_t *masks, DWORD Flags)
 	Возвращает TRUE в случае успеха.
 	Путь к файлу в FileName НЕ игнорируется
 */
-bool FileMasksWithExclude::Compare(const wchar_t *FileName) const
+bool FileMasksWithExclude::Compare(const wchar_t *FileName, bool ignorecase) const
 {
-	return (Include.Compare(FileName) && !Exclude.Compare(FileName));
+	return (Include.Compare(FileName,ignorecase) && !Exclude.Compare(FileName,ignorecase));
 }
 
 bool FileMasksWithExclude::IsEmpty() const

--- a/far2l/src/filemask/FileMasksWithExclude.cpp
+++ b/far2l/src/filemask/FileMasksWithExclude.cpp
@@ -130,7 +130,7 @@ bool FileMasksWithExclude::Set(const wchar_t *masks, DWORD Flags)
 */
 bool FileMasksWithExclude::Compare(const wchar_t *FileName, bool ignorecase) const
 {
-	return (Include.Compare(FileName,ignorecase) && !Exclude.Compare(FileName,ignorecase));
+	return (Include.Compare(FileName, ignorecase) && !Exclude.Compare(FileName, ignorecase));
 }
 
 bool FileMasksWithExclude::IsEmpty() const

--- a/far2l/src/filemask/FileMasksWithExclude.hpp
+++ b/far2l/src/filemask/FileMasksWithExclude.hpp
@@ -50,7 +50,7 @@ public:
 
 public:
 	virtual bool Set(const wchar_t *Masks, DWORD Flags);
-	virtual bool Compare(const wchar_t *Name) const;
+	virtual bool Compare(const wchar_t *Name, bool ignorecase=true) const;
 	virtual bool IsEmpty() const;
 	static bool IsExcludeMask(const wchar_t *masks);
 

--- a/far2l/src/filemask/FileMasksWithExclude.hpp
+++ b/far2l/src/filemask/FileMasksWithExclude.hpp
@@ -50,7 +50,7 @@ public:
 
 public:
 	virtual bool Set(const wchar_t *Masks, DWORD Flags);
-	virtual bool Compare(const wchar_t *Name, bool ignorecase=true) const;
+	virtual bool Compare(const wchar_t *Name, bool ignorecase = true) const;
 	virtual bool IsEmpty() const;
 	static bool IsExcludeMask(const wchar_t *masks);
 

--- a/far2l/src/findfile.cpp
+++ b/far2l/src/findfile.cpp
@@ -745,13 +745,6 @@ static LONG_PTR WINAPI MainDlgProc(HANDLE hDlg, int Msg, int Param1, LONG_PTR Pa
 					if (!Mask || !*Mask)
 						Mask = L"*";
 
-					if (SendDlgMessage(hDlg, DM_GETCHECK, FAD_CHECKBOX_CASEMASK, 0) == BSTATE_UNCHECKED) {
-						// workaround for case-insensitive compare
-						FARString tmp = Mask;
-						tmp.Lower();
-						return FileMaskForFindFile.Set(tmp.CPtr(), 0);
-					}
-
 					return FileMaskForFindFile.Set(Mask, 0);
 				}
 				case FAD_BUTTON_DRIVE: {
@@ -1146,14 +1139,7 @@ static void AnalyzeFileItem(HANDLE hDlg, PluginPanelItem *FileItem, const wchar_
 	if ((FindData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0 && !Opt.FindOpt.FindFolders)
 		return;
 
-	if (!Opt.FindOpt.FindCaseSensitiveFileMask) {
-		// workaround for case-insensitive compare
-		FARString tmp = FileName;
-		tmp.Lower();
-		if (!FileMaskForFindFile.Compare(tmp))
-			return;
-	}
-	else if (!FileMaskForFindFile.Compare(FileName))
+	if (!FileMaskForFindFile.Compare(FileName, !Opt.FindOpt.FindCaseSensitiveFileMask ))
 		return;
 
 	size_t ArcIndex = itd.GetFindFileArcIndex();

--- a/far2l/src/findfile.cpp
+++ b/far2l/src/findfile.cpp
@@ -1139,7 +1139,7 @@ static void AnalyzeFileItem(HANDLE hDlg, PluginPanelItem *FileItem, const wchar_
 	if ((FindData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0 && !Opt.FindOpt.FindFolders)
 		return;
 
-	if (!FileMaskForFindFile.Compare(FileName, !Opt.FindOpt.FindCaseSensitiveFileMask ))
+	if (!FileMaskForFindFile.Compare(FileName, !Opt.FindOpt.FindCaseSensitiveFileMask))
 		return;
 
 	size_t ArcIndex = itd.GetFindFileArcIndex();

--- a/far2l/src/mix/processname.cpp
+++ b/far2l/src/mix/processname.cpp
@@ -169,7 +169,7 @@ int ConvertWildcards(const wchar_t *SrcName, FARString &strDest, int SelectedFol
 // IS: это реальное тело функции сравнения с маской, но использовать
 // IS: "снаружи" нужно не эту функцию, а CmpName (ее тело расположено
 // IS: после CmpName_Body)
-static bool CmpName_Body(const wchar_t *pattern, const wchar_t *str)
+static bool CmpName_Body(const wchar_t *pattern, const wchar_t *str, bool ignorecase)
 {
 	for (;; ++str) {
 		/*
@@ -200,12 +200,25 @@ static bool CmpName_Body(const wchar_t *pattern, const wchar_t *str)
 				if (!FindAnyOfChars(pattern, "*?[")) {
 					const size_t pattern_len = wcslen(pattern);
 					const size_t str_len = wcslen(str);
-					return (str_len >= pattern_len
-							&& wmemcmp(pattern, str + str_len - pattern_len, pattern_len) == 0);
+
+					bool result = (str_len >= pattern_len);
+					if(result) {
+						if(ignorecase) {
+							for(size_t i=0; i<pattern_len; ++i) {
+								if(Upper(pattern[i])!=Upper(str[str_len - pattern_len + i ])) {
+									result=false;
+									break;
+								}
+							}
+						} else {
+							result=(wmemcmp(pattern, str + str_len - pattern_len, pattern_len) == 0);
+						}
+					}
+					return result;
 				}
 
 				do {
-					if (CmpName_Body(pattern, str))
+					if (CmpName_Body(pattern, str, ignorecase))
 						return true;
 				} while (*str++);
 
@@ -229,7 +242,7 @@ static bool CmpName_Body(const wchar_t *pattern, const wchar_t *str)
 				}
 
 				match = 0;
-				stringc = Upper(stringc);
+
 				while ((rangec = *pattern++) != 0) {
 					if (rangec == L']') {
 						if (match)
@@ -242,10 +255,12 @@ static bool CmpName_Body(const wchar_t *pattern, const wchar_t *str)
 						continue;
 
 					if (rangec == L'-' && *(pattern - 2) != L'[' && *pattern != L']') {
-						match = (stringc <= Upper(*pattern) && Upper(*(pattern - 2)) <= stringc);
+						match = ignorecase ?
+							(Upper(stringc) <= Upper(*pattern) && Upper(*(pattern - 2)) <= Upper(stringc))
+										   : (stringc <= *pattern && *(pattern - 2) <= stringc);
 						pattern++;
 					} else
-						match = (stringc == Upper(rangec));
+						match = ignorecase ?(Upper(stringc) == Upper(rangec)):(stringc == rangec);
 				}
 
 				if (!rangec)
@@ -254,16 +269,20 @@ static bool CmpName_Body(const wchar_t *pattern, const wchar_t *str)
 				break;
 
 			default:
-				if (Upper(patternc) != stringc && Lower(patternc) != stringc)
-					return false;
-
+				if(ignorecase) {
+					if (Upper(patternc) != stringc && Lower(patternc) != stringc)
+						return false;
+				} else {
+					if (patternc != stringc)
+						return false;
+				}
 				break;
 		}
 	}
 }
 
 // IS: функция для внешнего мира, использовать ее
-bool CmpName(const wchar_t *pattern, const wchar_t *str, bool skippath)
+bool CmpName(const wchar_t *pattern, const wchar_t *str, bool skippath, bool ignorecase)
 {
 	if (!pattern || !str)
 		return false;
@@ -271,5 +290,5 @@ bool CmpName(const wchar_t *pattern, const wchar_t *str, bool skippath)
 	if (skippath)
 		str = PointToName(str);
 
-	return CmpName_Body(pattern, str);
+	return CmpName_Body(pattern, str, ignorecase);
 }

--- a/far2l/src/mix/processname.cpp
+++ b/far2l/src/mix/processname.cpp
@@ -202,10 +202,10 @@ static bool CmpName_Body(const wchar_t *pattern, const wchar_t *str, bool ignore
 					const size_t str_len = wcslen(str);
 
 					bool result = (str_len >= pattern_len);
-					if(result) {
-						if(ignorecase) {
+					if (result) {
+						if (ignorecase) {
 							for(size_t i = 0; i< pattern_len; ++i) {
-								if(Upper(pattern[i]) != Upper(str[str_len - pattern_len + i])) {
+								if (Upper(pattern[i]) != Upper(str[str_len - pattern_len + i])) {
 									result = false;
 									break;
 								}

--- a/far2l/src/mix/processname.cpp
+++ b/far2l/src/mix/processname.cpp
@@ -204,7 +204,7 @@ static bool CmpName_Body(const wchar_t *pattern, const wchar_t *str, bool ignore
 					bool result = (str_len >= pattern_len);
 					if (result) {
 						if (ignorecase) {
-							for(size_t i = 0; i< pattern_len; ++i) {
+							for (size_t i = 0; i < pattern_len; ++i) {
 								if (Upper(pattern[i]) != Upper(str[str_len - pattern_len + i])) {
 									result = false;
 									break;
@@ -255,12 +255,14 @@ static bool CmpName_Body(const wchar_t *pattern, const wchar_t *str, bool ignore
 						continue;
 
 					if (rangec == L'-' && *(pattern - 2) != L'[' && *pattern != L']') {
-						match = ignorecase ?
-							(Upper(stringc) <= Upper(*pattern) && Upper(*(pattern - 2)) <= Upper(stringc))
+						match = ignorecase
+							? (Upper(stringc) <= Upper(*pattern) && Upper(*(pattern - 2)) <= Upper(stringc))
 							: (stringc <= *pattern && *(pattern - 2) <= stringc);
 						pattern++;
 					} else
-						match = ignorecase ? (Upper(stringc) == Upper(rangec)) : (stringc == rangec);
+						match = ignorecase
+							? (Upper(stringc) == Upper(rangec))
+							: (stringc == rangec);
 				}
 
 				if (!rangec)

--- a/far2l/src/mix/processname.cpp
+++ b/far2l/src/mix/processname.cpp
@@ -257,7 +257,7 @@ static bool CmpName_Body(const wchar_t *pattern, const wchar_t *str, bool ignore
 					if (rangec == L'-' && *(pattern - 2) != L'[' && *pattern != L']') {
 						match = ignorecase ?
 							(Upper(stringc) <= Upper(*pattern) && Upper(*(pattern - 2)) <= Upper(stringc))
-										   : (stringc <= *pattern && *(pattern - 2) <= stringc);
+							: (stringc <= *pattern && *(pattern - 2) <= stringc);
 						pattern++;
 					} else
 						match = ignorecase ? (Upper(stringc) == Upper(rangec)) : (stringc == rangec);

--- a/far2l/src/mix/processname.cpp
+++ b/far2l/src/mix/processname.cpp
@@ -204,14 +204,14 @@ static bool CmpName_Body(const wchar_t *pattern, const wchar_t *str, bool ignore
 					bool result = (str_len >= pattern_len);
 					if(result) {
 						if(ignorecase) {
-							for(size_t i=0; i<pattern_len; ++i) {
-								if(Upper(pattern[i])!=Upper(str[str_len - pattern_len + i ])) {
-									result=false;
+							for(size_t i = 0; i< pattern_len; ++i) {
+								if(Upper(pattern[i]) != Upper(str[str_len - pattern_len + i])) {
+									result = false;
 									break;
 								}
 							}
 						} else {
-							result=(wmemcmp(pattern, str + str_len - pattern_len, pattern_len) == 0);
+							result = (wmemcmp(pattern, str + str_len - pattern_len, pattern_len) == 0);
 						}
 					}
 					return result;
@@ -260,7 +260,7 @@ static bool CmpName_Body(const wchar_t *pattern, const wchar_t *str, bool ignore
 										   : (stringc <= *pattern && *(pattern - 2) <= stringc);
 						pattern++;
 					} else
-						match = ignorecase ?(Upper(stringc) == Upper(rangec)):(stringc == rangec);
+						match = ignorecase ? (Upper(stringc) == Upper(rangec)) : (stringc == rangec);
 				}
 
 				if (!rangec)
@@ -269,7 +269,7 @@ static bool CmpName_Body(const wchar_t *pattern, const wchar_t *str, bool ignore
 				break;
 
 			default:
-				if(ignorecase) {
+				if (ignorecase) {
 					if (Upper(patternc) != stringc && Lower(patternc) != stringc)
 						return false;
 				} else {

--- a/far2l/src/mix/processname.hpp
+++ b/far2l/src/mix/processname.hpp
@@ -38,4 +38,4 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // обработать имя файла: сравнить с маской, масками, сгенерировать по маске
 int WINAPI ProcessName(const wchar_t *param1, wchar_t *param2, DWORD size, DWORD flags);
 int ConvertWildcards(const wchar_t *SrcName, FARString &strDest, int SelectedFolderNameLength);
-bool CmpName(const wchar_t *pattern, const wchar_t *str, bool skippath = true, bool ignorecase=true);
+bool CmpName(const wchar_t *pattern, const wchar_t *str, bool skippath = true, bool ignorecase = true);

--- a/far2l/src/mix/processname.hpp
+++ b/far2l/src/mix/processname.hpp
@@ -38,4 +38,4 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // обработать имя файла: сравнить с маской, масками, сгенерировать по маске
 int WINAPI ProcessName(const wchar_t *param1, wchar_t *param2, DWORD size, DWORD flags);
 int ConvertWildcards(const wchar_t *SrcName, FARString &strDest, int SelectedFolderNameLength);
-bool CmpName(const wchar_t *pattern, const wchar_t *str, bool skippath = true);
+bool CmpName(const wchar_t *pattern, const wchar_t *str, bool skippath = true, bool ignorecase=true);

--- a/far2l/src/panels/filelist.cpp
+++ b/far2l/src/panels/filelist.cpp
@@ -3344,9 +3344,6 @@ long FileList::SelectFiles(int Mode, const wchar_t *Mask)
 
 	long workCount = 0;
 
-	if (SelectDlg[3].Selected == BSTATE_UNCHECKED) // Opt.PanelCaseSensitiveCompareSelect
-		strMask.Lower(); // workaround for case-insensitive compare
-
 	if (bUseFilter || FileMask.Set(strMask, FMF_SILENT))	// Скомпилируем маски файлов и работаем
 	{														// дальше в зависимости от успеха компиляции
 		for (auto &CurPtr : ListData) {
@@ -3358,14 +3355,8 @@ long FileList::SelectFiles(int Mode, const wchar_t *Mask)
 				if (bUseFilter)
 					Match = Filter.FileInFilter(*CurPtr);
 				else {
-					if (SelectDlg[3].Selected == BSTATE_UNCHECKED) { // Opt.PanelCaseSensitiveCompareSelect
-						// workaround for case-insensitive compare
-						strCurName = CurPtr->strName;
-						strCurName.Lower();
-						Match = FileMask.Compare(strCurName);
-					}
-					else
-						Match = FileMask.Compare(CurPtr->strName);
+					Match = FileMask.Compare(CurPtr->strName,
+											 SelectDlg[3].Selected == BSTATE_UNCHECKED /*Opt.PanelCaseSensitiveCompareSelect*/);
 				}
 			}
 


### PR DESCRIPTION
По мотивам обсуждений в https://github.com/elfmz/far2l/issues/2029.

- Логика регистро(не)зависимого сличения с маской перенесена в `CmpName_Body()`, поиск файлов по Alt-F7 и пометка файлов на панели по Gray+ полагается теперь на это.
- Обновлены сигнатуры методов `Compare` у BaseFileMask, CFileMask, FileMasksProcessor, FileMasksWithExclude путём добавления нового параметра bool ignorecase с дефолтным значением true.
- Скорректированы вызовы методов `Compare`.
- Обновлён farlang.templ.m4: добавлено уточнение "(text)" для чекбокса учета регистра искомой подстроки в содержимом файлов.

<hr>

При просмотре оригинальной CmpName_Body() была обнаружена любопытная деталь.

Часть процессинга одной и той же маски она осуществляла регистро**независимо** (например, [тут](https://github.com/elfmz/far2l/blob/64af534152606d99d4a4376fa6fc26b9c321f4e6/far2l/src/mix/processname.cpp#L257) или [тут](https://github.com/elfmz/far2l/blob/64af534152606d99d4a4376fa6fc26b9c321f4e6/far2l/src/mix/processname.cpp#L245)-и-[тут](https://github.com/elfmz/far2l/blob/64af534152606d99d4a4376fa6fc26b9c321f4e6/far2l/src/mix/processname.cpp#L248) после кастования к верхнему регистру [здесь](https://github.com/elfmz/far2l/blob/64af534152606d99d4a4376fa6fc26b9c321f4e6/far2l/src/mix/processname.cpp#L232)), а часть процессинга — регистро**зависимо**. А именно здесь:

https://github.com/elfmz/far2l/blob/64af534152606d99d4a4376fa6fc26b9c321f4e6/far2l/src/mix/processname.cpp#L200-L205

(Как следствие оптимизации, при которой  сравнение хвоста строки и хвоста паттерна  производится функцией ```wmemcmp```, если после звёздочки в паттерне метасимволов больше нет.)


Отсюда получался интересный эффект, например, в раскраске файлов:
- не подсвечивались файлы вида ```archive.ZIP``` (потому что в настройках заданы маской ```*.zip```)
- при этом подсвечивались файлы вида ```archive.ARC``` (потому что в настройках заданы маской ```*.ar[cj]```)

Исходная логика в этой части сохранена для ветки регистрозависимого сравнения, добавлена ветка регистронезависимого сравнения.