### PR TITLE
macro.cpp; panelselectFunc; allow to select multiple files

### DIFF
--- a/far2l/src/macro/macro.cpp
+++ b/far2l/src/macro/macro.cpp
@@ -2321,6 +2321,8 @@ static bool panelselectFunc(const TMacroFunction *)
 		if (Mode == 2 || Mode == 3) {
 			FARString strStr = ValItems.s();
 			ReplaceStrings(strStr, L"\r\n", L";");
+			ReplaceStrings(strStr, L"\r", L";");
+			ReplaceStrings(strStr, L"\n", L";");
 			ValItems = strStr.CPtr();
 		}
 


### PR DESCRIPTION
actual:
  panelselectFunc, ReplaceStrings "\r\n" (CRLF) with ;
added:
  panelselectFunc, ReplaceStrings "\r" (CR) with ;  
  panelselectFunc, ReplaceStrings "\n" (LF) with ;  
This allow to select multiple files separated by CRLF but also separated by CR or LF from FarEncyclopedia.ru.chm::/html/macro/macrocmd/prop_func/panels.html

N=panel.select(panelType,Action[,Mode[,Items]])
Panel.Select(0,1,2,clip(0))
выделить элементы, имена которых содержатся в буфере обмена 

;;
Can be used in
.config\far2l\settings\key_macros.ini

[KeyMacros/Shell/CtrlS]
Description=Select from clipboard
DisableOutput=0x1
EmptyCommandLine=0x1
Sequence=Panel.Select(0,1,2,clip(0))