### PR TITLE
NetRocks: for site connections list don't use current far2l panel modes

### DIFF
--- a/NetRocks/src/PluginImpl.cpp
+++ b/NetRocks/src/PluginImpl.cpp
@@ -423,6 +423,19 @@ void PluginImpl::GetOpenPluginInfo(struct OpenPluginInfo *Info)
 			Info->Flags|= OPIF_COMPAREFATTIME;
 		}
 	}
+	else {
+		// for site connections list don't use current far2l panel modes
+		//  - always only 1 column (name) without dependence on panel Align file extensions
+		static struct PanelMode PanelModesArray[10] = {
+			{ .ColumnTypes = L"N", .ColumnWidths = L"0" }, { .ColumnTypes = L"N", .ColumnWidths = L"0" },
+			{ .ColumnTypes = L"N", .ColumnWidths = L"0" }, { .ColumnTypes = L"N", .ColumnWidths = L"0" },
+			{ .ColumnTypes = L"N", .ColumnWidths = L"0" }, { .ColumnTypes = L"N", .ColumnWidths = L"0" },
+			{ .ColumnTypes = L"N", .ColumnWidths = L"0" }, { .ColumnTypes = L"N", .ColumnWidths = L"0" },
+			{ .ColumnTypes = L"N", .ColumnWidths = L"0" }, { .ColumnTypes = L"N", .ColumnWidths = L"0" },
+		};
+		Info->PanelModesArray = PanelModesArray;
+		Info->PanelModesNumber = ARRAYSIZE(PanelModesArray);
+	}
 	Info->HostFile = _standalone_config.empty() ? NULL : _standalone_config.c_str();
 	Info->CurDir = _cur_dir;
 	Info->Format = _format;


### PR DESCRIPTION
For site connections list don't use current far2l panel modes:
always only 1 column (name) without dependence on panel Align file extensions

New behaviour close to far3 NetBox

Before was annoying if panel mode has Align file extensions
![image](https://github.com/user-attachments/assets/58e041ee-cf27-4ddb-aa94-a17b8df9733d)


Now: always all name together
![image](https://github.com/user-attachments/assets/b453fb68-b3cc-417c-a089-05405dbd5d3e)

