### PR TITLE
fix Plugin Colorer crashes #2277

### DIFF
--- a/colorer/src/pcolorer2/pcolorer.cpp
+++ b/colorer/src/pcolorer2/pcolorer.cpp
@@ -62,6 +62,9 @@ SHAREDSYMBOL void WINAPI SetStartupInfoW(const struct PluginStartupInfo* fei)
   Info = *fei;
   FSF = *fei->FSF;
   Info.FSF = &FSF;
+
+  editorSet = nullptr;
+  inEventProcess = false;
 }
 
 /**


### PR DESCRIPTION
init main variable on startup

ps. but I still don't understand why after unloading and loading the plugin the "old" memory was used