### PR TITLE
Artifacts in editor

### DIFF
--- a/colorer/src/pcolorer2/FarEditor.cpp
+++ b/colorer/src/pcolorer2/FarEditor.cpp
@@ -552,11 +552,11 @@ int FarEditor::editorEvent(int event, void* param)
     int llen = egs.StringLength;
 
     // fills back
-    if (lno == ei.CurLine && showHorizontalCross) {
-      addFARColor(lno, 0, 0, horzCrossColor);  // ei.LeftPos + ei.WindowSizeX
+    if (lno == ei.CurLine && showHorizontalCross){
+      addFARColor(lno, 0, ei.LeftPos + ei.WindowSizeX, horzCrossColor);
     }
-    else {
-      addFARColor(lno, 0, 0, convert(nullptr));  // ei.LeftPos + ei.WindowSizeX
+    else{
+      addFARColor(lno, 0, ei.LeftPos + ei.WindowSizeX, convert(nullptr));
     }
 
     if (showVerticalCross) {
@@ -615,8 +615,8 @@ int FarEditor::editorEvent(int event, void* param)
           //
           int lend = l1->end;
 
-          if (lend == -1) {
-            lend = fullBackground ? 0 : llen;  // ei.LeftPos+ei.WindowSizeX
+          if (lend == -1){
+            lend = fullBackground ? ei.LeftPos+ei.WindowSizeX : llen;
           }
 
           addFARColor(lno, l1->start, lend, col);
@@ -1370,8 +1370,17 @@ void FarEditor::cleanEditor()
 {
   color col;
   enterHandler();
-  for (int i = 0; i < ei.TotalLines; i++) {
-    addFARColor(i, -1, 0, col);
+  for (int i=0; i<ei.TotalLines; i++){
+    EditorGetString egs;
+    egs.StringNumber=i;
+    info->EditorControl(ECTL_GETSTRING,&egs);
+
+    if (ei.LeftPos + ei.WindowSizeX>egs.StringLength){
+      addFARColor(i,0,ei.LeftPos + ei.WindowSizeX,col);
+    }
+    else{
+      addFARColor(i,0,egs.StringLength,col);
+    }
   }
 }
 

--- a/colorer/src/pcolorer2/FarEditor.cpp
+++ b/colorer/src/pcolorer2/FarEditor.cpp
@@ -616,7 +616,10 @@ int FarEditor::editorEvent(int event, void* param)
           int lend = l1->end;
 
           if (lend == -1){
-            lend = fullBackground ? ei.LeftPos+ei.WindowSizeX : llen;
+            if (fullBackground) {
+              addFARColor(lno, llen, ei.LeftPos+ei.WindowSizeX * 2, col, false);
+            }
+            lend = llen;
           }
 
           addFARColor(lno, l1->start, lend, col);
@@ -1302,7 +1305,7 @@ bool FarEditor::backDefault(color col)
     return col.cbk == rdBackground->back;
 }
 
-void FarEditor::addFARColor(int lno, int s, int e, color col)
+void FarEditor::addFARColor(int lno, int s, int e, color col, bool add_style)
 {
   if (TrueMod) {
     EditorTrueColor ec {};
@@ -1341,11 +1344,13 @@ void FarEditor::addFARColor(int lno, int s, int e, color col)
       {
         ec.Base.Color = BACKGROUND_INTENSITY;
       }
-      if (col.style & StyledRegion::RD_UNDERLINE) {
-        ec.Base.Color |= COMMON_LVB_UNDERSCORE;
-      }
-      if (col.style & StyledRegion::RD_STRIKEOUT) {
-        ec.Base.Color |= COMMON_LVB_STRIKEOUT;
+      if (add_style) {
+        if (col.style & StyledRegion::RD_UNDERLINE) {
+          ec.Base.Color |= COMMON_LVB_UNDERSCORE;
+        }
+        if (col.style & StyledRegion::RD_STRIKEOUT) {
+          ec.Base.Color |= COMMON_LVB_STRIKEOUT;
+        }
       }
     }
 
@@ -1371,16 +1376,7 @@ void FarEditor::cleanEditor()
   color col;
   enterHandler();
   for (int i=0; i<ei.TotalLines; i++){
-    EditorGetString egs;
-    egs.StringNumber=i;
-    info->EditorControl(ECTL_GETSTRING,&egs);
-
-    if (ei.LeftPos + ei.WindowSizeX>egs.StringLength){
-      addFARColor(i,0,ei.LeftPos + ei.WindowSizeX,col);
-    }
-    else{
-      addFARColor(i,0,egs.StringLength,col);
-    }
+    addFARColor(i, -1,0, col);
   }
 }
 

--- a/colorer/src/pcolorer2/FarEditor.h
+++ b/colorer/src/pcolorer2/FarEditor.h
@@ -186,7 +186,7 @@ class FarEditor : public LineSource
   bool foreDefault(color col);
   bool backDefault(color col);
   void showOutliner(Outliner* outliner);
-  void addFARColor(int lno, int s, int e, color col);
+  void addFARColor(int lno, int s, int e, color col, bool add_style = true);
   const wchar_t* GetMsg(int msg);
 };
 #endif

--- a/far2l/far2sdk/farplug-wide.h
+++ b/far2l/far2sdk/farplug-wide.h
@@ -1789,7 +1789,7 @@ struct EditorColor
 	int StringNumber;
 	int ColorItem;
 	int StartPos;
-	int EndPos; // -1 means edge of visible screen part, otherwise wanted edge position
+	int EndPos;
 	int Color;
 };
 

--- a/far2l/src/editor.cpp
+++ b/far2l/src/editor.cpp
@@ -332,34 +332,6 @@ void Editor::ShowEditor(int CurLineOnly)
 		}
 	}
 
-	if (!CurLineOnly) {
-		LeftPos = CurLine->GetLeftPos();
-#if 0
-
-		// крайне эксперементальный кусок!
-		if (CurPos+LeftPos < XX2)
-			LeftPos=0;
-		else if (CurLine->X2 < XX2)
-			LeftPos=CurLine->GetLength()-CurPos;
-
-		if (LeftPos < 0)
-			LeftPos=0;
-
-#endif
-
-		for (CurPtr = TopScreen, Y = Y1; Y <= Y2; Y++)
-			if (CurPtr) {
-				CurPtr->SetEditBeyondEnd(TRUE);
-				CurPtr->SetPosition(X1, Y, XX2, Y);
-				// CurPtr->SetTables(UseDecodeTable ? &TableSet:nullptr);
-				//_D(SysLog(L"Setleftpos 3 to %i",LeftPos));
-				CurPtr->SetLeftPos(LeftPos);
-				CurPtr->SetCellCurPos(CurPos);
-				CurPtr->SetEditBeyondEnd(EdOpt.CursorBeyondEOL);
-				CurPtr = CurPtr->m_next;
-			}
-	}
-
 	if (!Pasting) {
 		/*
 			$ 10.08.2000 skv
@@ -396,9 +368,30 @@ void Editor::ShowEditor(int CurLineOnly)
 	DrawScrollbar();
 
 	if (!CurLineOnly) {
+		LeftPos = CurLine->GetLeftPos();
+#if 0
+
+		// крайне эксперементальный кусок!
+		if (CurPos+LeftPos < XX2)
+			LeftPos=0;
+		else if (CurLine->X2 < XX2)
+			LeftPos=CurLine->GetLength()-CurPos;
+
+		if (LeftPos < 0)
+			LeftPos=0;
+
+#endif
+
 		for (CurPtr = TopScreen, Y = Y1; Y <= Y2; Y++)
 			if (CurPtr) {
+				CurPtr->SetEditBeyondEnd(TRUE);
+				CurPtr->SetPosition(X1, Y, XX2, Y);
+				// CurPtr->SetTables(UseDecodeTable ? &TableSet:nullptr);
+				//_D(SysLog(L"Setleftpos 3 to %i",LeftPos));
+				CurPtr->SetLeftPos(LeftPos);
+				CurPtr->SetCellCurPos(CurPos);
 				CurPtr->FastShow();
+				CurPtr->SetEditBeyondEnd(EdOpt.CursorBeyondEOL);
 				CurPtr = CurPtr->m_next;
 			} else {
 				SetScreen(X1, Y, XX2, Y, L' ', FarColorToReal(COL_EDITORTEXT));		// Пустые строки после конца текста
@@ -5378,25 +5371,19 @@ int Editor::EditorControl(int Command, void *Param)
 				_ECTLLOG(SysLog(L"  EndPos      =%d", col->EndPos));
 				_ECTLLOG(SysLog(L"  Color       =%d (0x%08X)", col->Color, col->Color));
 				_ECTLLOG(SysLog(L"}"));
+				ColorItem newcol{0};
+				newcol.StartPos = col->StartPos + (col->StartPos != -1 ? X1 : 0);
+				newcol.EndPos = col->EndPos + X1;
+				newcol.Color = col->Color;
 				Edit *CurPtr = GetStringByNumber(col->StringNumber);
+
 				if (!CurPtr) {
 					_ECTLLOG(SysLog(L"GetStringByNumber(%d) return nullptr", col->StringNumber));
 					return FALSE;
 				}
 
-				ColorItem newcol{0};
-				newcol.StartPos = col->StartPos + (col->StartPos != -1 ? X1 : 0);
 				if (!col->Color)
 					return (CurPtr->DeleteColor(newcol.StartPos));
-
-				if (col->EndPos >= 0) {
-					newcol.EndPos = col->EndPos + X1;
-				} else {
-					newcol.EndPos = CurPtr->GetLeftPos() + CurPtr->CellPosToReal(X2 - X1);//CurPtr->GetLength();
-				}
-				newcol.Color = col->Color;
-
-
 
 				if (Command == ECTL_ADDTRUECOLOR) {
 					const EditorTrueColor *tcol = (EditorTrueColor *)Param;


### PR DESCRIPTION
При исправлении https://github.com/elfmz/far2l/commit/c2f9644c507ca9d70c02c8640c8ed4ee0b52ca80 для https://github.com/elfmz/far2l/issues/1941 было изменено API для задания цвета. Что стало приводить к проблемам с раскраской на некоторых типах файлов в Colorer. 
так же это Api не документиовано, и расходится с тем что есть в far3.

изначальаня поблема правится силами Colorer, по аналогии с far3.

так же тут поправлено заполнение части строки без текста, в случае использования truemod , подчеркивания текста