### PR TITLE
fix redundant newlines appearing at the end of clipboard content

### DIFF
--- a/far2l/bootstrap/wslgclip.sh
+++ b/far2l/bootstrap/wslgclip.sh
@@ -14,8 +14,8 @@ get)
 ;;
 set)
     CONTENT=$(cat)
-    echo "$CONTENT" | clip.exe
-    echo "$CONTENT"
+    echo -n "$CONTENT" | clip.exe
+    echo -n "$CONTENT"
 ;;
 "")
     (far2l --clipboard=$(readlink -f $0) >/dev/null 2>&1 &)


### PR DESCRIPTION
fixes #2288