### PR TITLE
Miscellaneous fixes from far2m

### DIFF
--- a/far2l/src/dialog.cpp
+++ b/far2l/src/dialog.cpp
@@ -4041,7 +4041,7 @@ void Dialog::ChangeFocus2(unsigned SetFocusPos)
 				return;
 		}
 
-		if (FocusPosNeed != -1 && IsItemFocusable(Item[FocusPosNeed]))
+		if (FocusPosNeed >= 0 && FocusPosNeed < (int)ItemCount && IsItemFocusable(Item[FocusPosNeed]))
 			SetFocusPos = FocusPosNeed;
 
 		Item[FocusPos]->Focus = 0;

--- a/far2l/src/edit.cpp
+++ b/far2l/src/edit.cpp
@@ -545,7 +545,7 @@ int64_t Edit::VMProcess(MacroOpcode OpCode, void *vParam, int64_t iParam)
 		case MCODE_V_ITEMCOUNT:
 			return (int64_t)StrSize;
 		case MCODE_V_CURPOS:
-			return (int64_t)(CursorPos + 1);
+			return (int64_t)(CurPos + 1);
 		case MCODE_F_EDITOR_SEL: {
 			int Action = (int)((INT_PTR)vParam);
 

--- a/far2l/src/fileedit.cpp
+++ b/far2l/src/fileedit.cpp
@@ -2525,7 +2525,7 @@ int FileEditor::EditorControl(int Command, void *Param)
 			if (Param) {
 				EditorSaveFile *esf = (EditorSaveFile *)Param;
 
-				if (*esf->FileName)
+				if (esf->FileName)
 					strName = esf->FileName;
 
 				if (esf->FileEOL) {

--- a/far2l/src/fileedit.cpp
+++ b/far2l/src/fileedit.cpp
@@ -2525,7 +2525,7 @@ int FileEditor::EditorControl(int Command, void *Param)
 			if (Param) {
 				EditorSaveFile *esf = (EditorSaveFile *)Param;
 
-				if (esf->FileName)
+				if (esf->FileName && *esf->FileName)
 					strName = esf->FileName;
 
 				if (esf->FileEOL) {

--- a/far2l/src/fileview.cpp
+++ b/far2l/src/fileview.cpp
@@ -55,6 +55,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "mix.hpp"
 #include "fileholder.hpp"
 #include "GrepFile.hpp"
+#include "exitcode.hpp"
 
 FileViewer::FileViewer(FileHolderPtr NewFileHolder, int EnableSwitch, int DisableHistory, int DisableEdit,
 		long ViewStartPos, const wchar_t *PluginData, NamesList *ViewNamesList, int ToSaveAs, UINT aCodePage)
@@ -329,11 +330,19 @@ int FileViewer::ProcessKey(FarKey Key)
 								| (SaveToSaveAs ? FFILEEDIT_SAVETOSAVEAS : 0)
 								| (DisableHistory ? FFILEEDIT_DISABLEHISTORY : 0),
 						-2, static_cast<int>(FilePos), strPluginData);
-				ShellEditor->SetEnableF6(TRUE);
-				/* $ 07.05.2001 DJ сохраняем NamesList */
-				ShellEditor->SetNamesList(View.GetNamesList());
-				FrameManager->DeleteFrame(this);	// Insert уже есть внутри конструктора
-				ShowTime(2);
+				int load = ShellEditor->GetExitCode();
+				if (load == XC_LOADING_INTERRUPTED || load == XC_OPEN_ERROR)
+				{
+					delete ShellEditor;
+				}
+				else
+				{
+					ShellEditor->SetEnableF6(TRUE);
+					/* $ 07.05.2001 DJ сохраняем NamesList */
+					ShellEditor->SetNamesList(View.GetNamesList());
+					FrameManager->DeleteFrame(this);	// Insert уже есть внутри конструктора
+					ShowTime(2);
+				}
 			}
 
 			return TRUE;

--- a/far2l/src/mix/strmix.cpp
+++ b/far2l/src/mix/strmix.cpp
@@ -1180,7 +1180,7 @@ wchar_t GetDecimalSeparator()
 }
 
 FARString
-ReplaceBrackets(const FARString &SearchStr, const FARString &ReplaceStr, RegExpMatch *Match, int Count)
+ReplaceBrackets(const wchar_t* SearchStr, const FARString &ReplaceStr, RegExpMatch *Match, int Count)
 {
 	FARString result;
 	size_t pos = 0, length = ReplaceStr.GetLength();
@@ -1205,7 +1205,7 @@ ReplaceBrackets(const FARString &SearchStr, const FARString &ReplaceStr, RegExpM
 
 			if (index >= 0) {
 				if (index < Count) {
-					FARString bracket(SearchStr.CPtr() + Match[index].start,
+					FARString bracket(SearchStr + Match[index].start,
 							Match[index].end - Match[index].start);
 					result+= bracket;
 				}

--- a/far2l/src/mix/strmix.hpp
+++ b/far2l/src/mix/strmix.hpp
@@ -135,7 +135,7 @@ inline const wchar_t GetDecimalSeparatorDefault() { return L'.'; };
 inline const wchar_t* GetDecimalSeparatorDefaultStr() { return L"."; };
 
 FARString
-ReplaceBrackets(const FARString &SearchStr, const FARString &ReplaceStr, RegExpMatch *Match, int Count);
+ReplaceBrackets(const wchar_t *SearchStr, const FARString &ReplaceStr, RegExpMatch *Match, int Count);
 
 bool SearchString(const wchar_t *Source, int StrSize, const FARString &Str, FARString &ReplaceStr,
 		int &CurPos, int Position, int Case, int WholeWords, int Reverse, int Regexp, int *SearchLength,

--- a/far2l/src/panels/panel.cpp
+++ b/far2l/src/panels/panel.cpp
@@ -1601,6 +1601,7 @@ int Panel::SetPluginCommand(int Command, int Param1, LONG_PTR Param2)
 	ProcessingPluginCommand++;
 	FilePanels *FPanels = CtrlObject->Cp();
 	PluginCommand = Command;
+	auto DestFilePanel = dynamic_cast<FileList*>(this);
 
 	switch (Command) {
 		case FCTL_SETVIEWMODE:
@@ -1724,7 +1725,6 @@ int Panel::SetPluginCommand(int Command, int Param1, LONG_PTR Param2)
 			}
 
 			if (GetType() == FILE_PANEL) {
-				FileList *DestFilePanel = (FileList *)this;
 				static int Reenter = 0;
 
 				if (!Reenter && Info->Plugin) {
@@ -1763,7 +1763,6 @@ int Panel::SetPluginCommand(int Command, int Param1, LONG_PTR Param2)
 				GetCurDir(strTemp);
 
 			if (GetType() == FILE_PANEL) {
-				FileList *DestFilePanel = (FileList *)this;
 				static int Reenter = 0;
 
 				if (!Reenter && GetMode() == PLUGIN_PANEL) {
@@ -1800,7 +1799,7 @@ int Panel::SetPluginCommand(int Command, int Param1, LONG_PTR Param2)
 
 			if (GetType() == FILE_PANEL) {
 				FARString strColumnTypes, strColumnWidths;
-				((FileList *)this)->PluginGetColumnTypesAndWidths(strColumnTypes, strColumnWidths);
+				DestFilePanel->PluginGetColumnTypesAndWidths(strColumnTypes, strColumnWidths);
 
 				if (Command == FCTL_GETCOLUMNTYPES) {
 					if (Param1 && Param2)
@@ -1817,26 +1816,29 @@ int Panel::SetPluginCommand(int Command, int Param1, LONG_PTR Param2)
 			break;
 
 		case FCTL_GETPANELITEM: {
-			Result = (int)((FileList *)this)->PluginGetPanelItem(Param1, (PluginPanelItem *)Param2);
+			if (DestFilePanel)
+				Result = (int)DestFilePanel->PluginGetPanelItem(Param1, (PluginPanelItem *)Param2);
 			break;
 		}
 
 		case FCTL_GETSELECTEDPANELITEM: {
-			Result = (int)((FileList *)this)->PluginGetSelectedPanelItem(Param1, (PluginPanelItem *)Param2);
+			if (DestFilePanel)
+				Result = (int)DestFilePanel->PluginGetSelectedPanelItem(Param1, (PluginPanelItem *)Param2);
 			break;
 		}
 
 		case FCTL_GETCURRENTPANELITEM: {
-			PanelInfo Info;
-			FileList *DestPanel = ((FileList *)this);
-			DestPanel->PluginGetPanelInfo(Info);
-			Result = (int)DestPanel->PluginGetPanelItem(Info.CurrentItem, (PluginPanelItem *)Param2);
+			if (DestFilePanel) {
+				PanelInfo Info;
+				DestFilePanel->PluginGetPanelInfo(Info);
+				Result = (int)DestFilePanel->PluginGetPanelItem(Info.CurrentItem, (PluginPanelItem *)Param2);
+			}
 			break;
 		}
 
 		case FCTL_BEGINSELECTION: {
 			if (GetType() == FILE_PANEL) {
-				((FileList *)this)->PluginBeginSelection();
+				DestFilePanel->PluginBeginSelection();
 				Result = TRUE;
 			}
 			break;
@@ -1844,7 +1846,7 @@ int Panel::SetPluginCommand(int Command, int Param1, LONG_PTR Param2)
 
 		case FCTL_SETSELECTION: {
 			if (GetType() == FILE_PANEL) {
-				((FileList *)this)->PluginSetSelection(Param1, Param2 ? true : false);
+				DestFilePanel->PluginSetSelection(Param1, Param2 ? true : false);
 				Result = TRUE;
 			}
 			break;
@@ -1852,7 +1854,7 @@ int Panel::SetPluginCommand(int Command, int Param1, LONG_PTR Param2)
 
 		case FCTL_CLEARSELECTION: {
 			if (GetType() == FILE_PANEL) {
-				reinterpret_cast<FileList *>(this)->PluginClearSelection(Param1);
+				DestFilePanel->PluginClearSelection(Param1);
 				Result = TRUE;
 			}
 			break;
@@ -1860,7 +1862,7 @@ int Panel::SetPluginCommand(int Command, int Param1, LONG_PTR Param2)
 
 		case FCTL_ENDSELECTION: {
 			if (GetType() == FILE_PANEL) {
-				((FileList *)this)->PluginEndSelection();
+				DestFilePanel->PluginEndSelection();
 				Result = TRUE;
 			}
 			break;

--- a/far2l/src/plug/PluginA.cpp
+++ b/far2l/src/plug/PluginA.cpp
@@ -84,6 +84,8 @@ static const char szCache_ProcessEditorEvent[] = "ProcessEditorEvent";
 static const char szCache_ProcessViewerEvent[] = "ProcessViewerEvent";
 static const char szCache_ProcessDialogEvent[] = "ProcessDialogEvent";
 static const char szCache_Configure[] = "Configure";
+static const char szCache_GetFiles[] = "GetFiles";
+static const char szCache_ProcessHostFile[] = "ProcessHostFile";
 
 static const char NFMP_OpenPlugin[] = "OpenPlugin";
 static const char NFMP_OpenFilePlugin[] = "OpenFilePlugin";
@@ -163,6 +165,8 @@ bool PluginA::LoadFromCache()
 	pProcessViewerEvent = (PLUGINPROCESSVIEWEREVENT)(INT_PTR)kfh.GetUInt(szCache_ProcessViewerEvent, 0);
 	pProcessDialogEvent = (PLUGINPROCESSDIALOGEVENT)(INT_PTR)kfh.GetUInt(szCache_ProcessDialogEvent, 0);
 	pConfigure = (PLUGINCONFIGURE)(INT_PTR)kfh.GetUInt(szCache_Configure, 0);
+	pGetFiles = (PLUGINGETFILES)(INT_PTR)kfh.GetUInt(szCache_GetFiles, 0);
+	pProcessHostFile = (PLUGINPROCESSHOSTFILE)(INT_PTR)kfh.GetUInt(szCache_ProcessHostFile, 0);
 	WorkFlags.Set(PIWF_CACHED);		// too much "cached" flags
 
 	if (kfh.GetInt(szCache_Preopen) != 0)
@@ -232,6 +236,8 @@ bool PluginA::SaveToCache()
 	kfh.SetUInt(GetSettingsName(), szCache_ProcessViewerEvent, pProcessViewerEvent != nullptr);
 	kfh.SetUInt(GetSettingsName(), szCache_ProcessDialogEvent, pProcessDialogEvent != nullptr);
 	kfh.SetUInt(GetSettingsName(), szCache_Configure, pConfigure != nullptr);
+	kfh.SetUInt(GetSettingsName(), szCache_GetFiles, pGetFiles!=nullptr);
+	kfh.SetUInt(GetSettingsName(), szCache_ProcessHostFile, pProcessHostFile!=nullptr);
 	return true;
 }
 

--- a/far2l/src/plug/PluginW.cpp
+++ b/far2l/src/plug/PluginW.cpp
@@ -87,6 +87,8 @@ static const char szCache_ProcessMacroFunc[] = "ProcessMacroFuncW";
 static const char szCache_Configure[] = "ConfigureW";
 static const char szCache_Analyse[] = "AnalyseW";
 static const char szCache_GetCustomData[] = "GetCustomDataW";
+static const char szCache_GetFiles[] = "GetFilesW";
+static const char szCache_ProcessHostFile[] = "ProcessHostFileW";
 
 static const char NFMP_OpenPlugin[] = "OpenPluginW";
 static const char NFMP_OpenFilePlugin[] = "OpenFilePluginW";
@@ -200,6 +202,8 @@ bool PluginW::LoadFromCache()
 	pConfigureW = (PLUGINCONFIGUREW)(INT_PTR)kfh.GetUInt(szCache_Configure, 0);
 	pAnalyseW = (PLUGINANALYSEW)(INT_PTR)kfh.GetUInt(szCache_Analyse, 0);
 	pGetCustomDataW = (PLUGINGETCUSTOMDATAW)(INT_PTR)kfh.GetUInt(szCache_GetCustomData, 0);
+	pGetFilesW = (PLUGINGETFILESW)(INT_PTR)kfh.GetUInt(szCache_GetFiles, 0);
+	pProcessHostFileW = (PLUGINPROCESSHOSTFILEW)(INT_PTR)kfh.GetUInt(szCache_ProcessHostFile, 0);
 	WorkFlags.Set(PIWF_CACHED);		// too much "cached" flags
 
 	if (kfh.GetInt(szCache_Preopen) != 0)
@@ -279,6 +283,8 @@ bool PluginW::SaveToCache()
 	kfh.SetUInt(GetSettingsName(), szCache_Configure, pConfigureW != nullptr);
 	kfh.SetUInt(GetSettingsName(), szCache_Analyse, pAnalyseW != nullptr);
 	kfh.SetUInt(GetSettingsName(), szCache_GetCustomData, pGetCustomDataW != nullptr);
+	kfh.SetUInt(GetSettingsName(), szCache_GetFiles, pGetFilesW!=nullptr);
+	kfh.SetUInt(GetSettingsName(), szCache_ProcessHostFile, pProcessHostFileW!=nullptr);
 
 	return true;
 }

--- a/far2l/src/plug/plugins.cpp
+++ b/far2l/src/plug/plugins.cpp
@@ -474,6 +474,8 @@ HANDLE PluginManager::OpenFilePlugin(const wchar_t *Name, int OpMode, OPENFILEPL
 
 		if (!pPlugin->HasOpenFilePlugin() && !(pPlugin->HasAnalyse() && pPlugin->HasOpenPlugin()))
 			continue;
+		if ((Type == OFP_EXTRACT && !pPlugin->HasGetFiles()) || (Type == OFP_COMMANDS && !pPlugin->HasProcessHostFile()))
+			continue;
 
 		if (Name && !smm) {
 			try {

--- a/far2l/src/vmenu.cpp
+++ b/far2l/src/vmenu.cpp
@@ -943,7 +943,7 @@ int VMenu::ProcessKey(FarKey Key)
 		case KEY_NUMENTER:
 		case KEY_ENTER: {
 			if (!ParentDialog || CheckFlags(VMENU_COMBOBOX)) {
-				if (ItemCanBeEntered(Item[SelectPos]->Flags)) {
+				if (SelectPos < 0 || ItemCanBeEntered(Item[SelectPos]->Flags)) {
 					EndLoop = TRUE;
 					Modal::ExitCode = SelectPos;
 				}


### PR DESCRIPTION
* More accurate check index from plugin's dialog (from far2m)
  from https://github.com/shmuz/far2m/commit/a1011fffe7690ac9c200ce7d4fc7a78840f695eb

* Fix CmdLine.CurPos (from far2m)
  from https://github.com/shmuz/far2m/commit/f87f896d268e8f879d7fcbafedccc14e29e1c2bb

* Fix ShiftF2 & ShiftF3 operation when multiple plugins-archivers are present (from far2m)
  from https://github.com/shmuz/far2m/commit/8373f33d9d61fb0f30d873b2f2f3514b0d3958e6 & https://github.com/shmuz/far2m/commit/afed4357a5686dbe27b8ab0a7750f5ed4eae2037

* Fix a crash bug in VMenu (from far2m)
  from https://github.com/shmuz/far2m/commit/f569ac5aaaddadda32480bbd9d3bdda49cf1e823

* Free memory after canceling F6 in the Viewer (Mantis 2605) (from far2m)
  from https://github.com/shmuz/far2m/commit/d0469e3de45611040479881f0cf55e3c0c2e8f42

* Fix ECTL_SAVEFILE crash (see Mantis 2348) (from far2m)
  from https://github.com/shmuz/far2m/commit/a3683c8db4ab46f4b4fe4dcd91e411bbb188e8b5

* Fix FCTL_xxx Far crashes (see Mantis 2603) (from far2m)
  from https://github.com/shmuz/far2m/commit/9ae4b901eaff85186c2f39c9483feba96d0aec60

* Editor: fix replace with regexp (see Mantis 2465) (from far2m)
  from https://github.com/shmuz/far2m/commit/fd7e1f57ff31e02e00a5efa4b710fa1c76a0e8d5