### PR TITLE
fix newlines in wsl clipboard processing

### DIFF
--- a/far2l/bootstrap/wslgclip.sh
+++ b/far2l/bootstrap/wslgclip.sh
@@ -16,7 +16,9 @@ get)
 #    fi
 ;;
 set)
-    CONTENT="$(cat)"
+    // shell removes tailing newlines. we should take care of it
+    CONTENT=$(cat; echo -n .)
+    CONTENT=${CONTENT%.}
     echo -n "$CONTENT" | iconv -f utf-8 -t utf-16le | clip.exe
     echo -n "$CONTENT"
 ;;

--- a/far2l/bootstrap/wslgclip.sh
+++ b/far2l/bootstrap/wslgclip.sh
@@ -8,6 +8,8 @@ get)
     cscript.exe //Nologo //u $(wslpath -w "$script_path"/wslgclip.vbs) | iconv -f utf-16le -t utf-8
 
 #   powershell method is slower, also it have unsolved charset problems. disabled for now
+#   possible solution for charset problem:
+#   https://github.com/microsoft/terminal/issues/280#issuecomment-1728298632
 
 #    if command -v cscript.exe >/dev/null 2>&1; then
 #        cscript.exe //Nologo //u $(wslpath -w "$script_path"/wslgclip.vbs) | iconv -f utf-16le -t utf-8

--- a/far2l/bootstrap/wslgclip.sh
+++ b/far2l/bootstrap/wslgclip.sh
@@ -18,7 +18,7 @@ get)
 #    fi
 ;;
 set)
-    // shell removes tailing newlines. we should take care of it
+    # shell removes tailing newlines. we should take care of it
     CONTENT=$(cat; echo -n .)
     CONTENT=${CONTENT%.}
     echo -n "$CONTENT" | iconv -f utf-8 -t utf-16le | clip.exe


### PR DESCRIPTION
fixes weird issue in WSL clipboard processing. found in chat:
https://t.me/far2l_ru/26099

```
    CONTENT="$(cat)"
```

When we use this construct, the shell executes the `cat` command, reads its output, and assigns it to the `CONTENT` variable. However, the shell removes trailing newlines. This is the default behavior for variable assignments in the shell.

So we need to take care of it:
```
    CONTENT=$(cat; echo -n .)
    CONTENT=${CONTENT%.}
```
 