### PR TITLE
set FAR2L_NOEXTKB env var to 1 to disable extended kb input (winterm iterm2, kitty)

### DIFF
--- a/WinPort/src/Backend/TTY/TTYOutput.cpp
+++ b/WinPort/src/Backend/TTY/TTYOutput.cpp
@@ -174,9 +174,11 @@ TTYOutput::TTYOutput(int out, bool far2l_tty, bool norgb)
 #endif
 
 	Format(ESC "7" ESC "[?47h" ESC "[?1049h" ESC "[?2004h");
-	Format(ESC "[?9001h"); // win32-input-mode on
-	Format(ESC "[?1337h"); // iTerm2 input mode on
-	Format(ESC "[=15;1u"); // kovidgoyal's kitty mode on
+	if (!getenv("FAR2L_NOEXTKB")) {
+		Format(ESC "[?9001h"); // win32-input-mode on
+		Format(ESC "[?1337h"); // iTerm2 input mode on
+		Format(ESC "[=15;1u"); // kovidgoyal's kitty mode on
+	}
 	ChangeKeypad(true);
 	ChangeMouse(true);
 


### PR DESCRIPTION
currently by env var, not command line switch, as i am not sure how to pass nodetect var to TTYOutput in best way

Touch #2320