### PR TITLE
Use Alt+Tab instead of unavailable Alt+F1/2 in kernel console

### DIFF
--- a/far2l/src/filepanels.cpp
+++ b/far2l/src/filepanels.cpp
@@ -591,7 +591,10 @@ int FilePanels::ProcessKey(FarKey Key)
 			панели
 		*/
 		case (KEY_ALT | KEY_TAB): {
-			ActivePanel->ChangeDisk();
+			if (!getenv("DISPLAY") && !getenv("WAYLAND_DISPLAY")) {
+				// for kernel condole only
+				ActivePanel->ChangeDisk();
+			}
 
 			break;
 		}

--- a/far2l/src/filepanels.cpp
+++ b/far2l/src/filepanels.cpp
@@ -590,6 +590,11 @@ int FilePanels::ProcessKey(FarKey Key)
 			текущим для системы после смены диска может быть каталог и на пассивной
 			панели
 		*/
+		case (KEY_ALT | KEY_TAB): {
+			ActivePanel->ChangeDisk();
+
+			break;
+		}
 		case KEY_ALTF1: {
 			LeftPanel->ChangeDisk();
 


### PR DESCRIPTION
In graphic desktop environments Alt+Tab will be intercepted by DE to be used for switching between windows. In the same time, in kernel console this key combination is not used for any system purpose. And in the same time you can not use Alt+F1 and Alt+F2 to swtich paths on panels as those key combinations switch virtual consoles. So why not to use Alt+Tab to display Location menu for current panel? Much better UX