### PR TITLE
Fix CheckInsidePlugin for non-panel plugins

### DIFF
--- a/far2l/src/macro/macro.cpp
+++ b/far2l/src/macro/macro.cpp
@@ -6440,7 +6440,9 @@ BOOL KeyMacro::CheckEditSelected(DWORD CurFlags)
 
 BOOL KeyMacro::CheckInsidePlugin(DWORD CurFlags)
 {
-	if (CtrlObject && CtrlObject->Plugins.CurPluginItem && (CurFlags & MFLAGS_NOSENDKEYSTOPLUGINS))		// ?????
+	if (CtrlObject && (CtrlObject->Plugins.CurPluginItem ||
+	                   CtrlObject->Plugins.CheckFlags(PSIF_ENTERTOOPENPLUGIN)) &&
+		(CurFlags & MFLAGS_NOSENDKEYSTOPLUGINS))		// ?????
 		// if(CtrlObject && CtrlObject->Plugins.CurEditor && (CurFlags&MFLAGS_NOSENDKEYSTOPLUGINS))
 		return FALSE;
 

--- a/far2l/src/plug/plugins.cpp
+++ b/far2l/src/plug/plugins.cpp
@@ -1753,7 +1753,9 @@ Plugin *PluginManager::FindPlugin(DWORD SysID)
 
 HANDLE PluginManager::OpenPlugin(Plugin *pPlugin, int OpenFrom, INT_PTR Item)
 {
+	Flags.Set(PSIF_ENTERTOOPENPLUGIN);
 	HANDLE hPlugin = pPlugin->OpenPlugin(OpenFrom, Item);
+	Flags.Clear(PSIF_ENTERTOOPENPLUGIN);
 
 	if (hPlugin != INVALID_HANDLE_VALUE) {
 		PluginHandle *handle = new PluginHandle;

--- a/incsrch/REG/^#enter.reg
+++ b/incsrch/REG/^#enter.reg
@@ -8,3 +8,4 @@ REGEDIT4
 "DisableOutput"=dword:00000001
 "Description"="Search previous selection"
 "NoInsidePlugin"=dword:00000001
+"NoSendKeysToPlugins"=dword:00000001

--- a/incsrch/REG/^enter.reg
+++ b/incsrch/REG/^enter.reg
@@ -8,3 +8,4 @@ REGEDIT4
 "DisableOutput"=dword:00000001
 "Description"="Search next selection"
 "NoInsidePlugin"=dword:00000001
+"NoSendKeysToPlugins"=dword:00000001

--- a/incsrch/key_macros.ini
+++ b/incsrch/key_macros.ini
@@ -1,4 +1,4 @@
-# Incrememtal search
+# Incremental search
 [KeyMacros/Editor/CtrlI]
 DisableOutput=0x1
 Sequence=F11 I Home Enter

--- a/incsrch/key_macros.ini
+++ b/incsrch/key_macros.ini
@@ -1,0 +1,18 @@
+# Incrememtal search
+[KeyMacros/Editor/CtrlI]
+DisableOutput=0x1
+Sequence=F11 I Home Enter
+
+# Search selected next
+[KeyMacros/Editor/CtrlEnter]
+DisableOutput=0x1
+NoInsidePlugin=0x1
+NoSendKeysToPlugins=0x1
+Sequence=F11 I Home Down Down Enter
+
+# Search selected previous
+[KeyMacros/Editor/CtrlShiftEnter]
+DisableOutput=0x1
+NoInsidePlugin=0x1
+NoSendKeysToPlugins=0x1
+Sequence=F11 I Home Down Down Down Enter


### PR DESCRIPTION
We are checking if we are inside a plugin by testing CurPluginItem. This does not have a value until OpenPlugin returns a handle. It is a common practice to perform all work inside a non-panel, non-persistent plugin within its OpenPlugin call and return INVALID_HANDLE_VALUE.

There is PSIF_ENTERTOOPENPLUGIN flag, but we do not set it. The fix is to set it and check it.

Fixes https://github.com/elfmz/far2l/issues/2325, but it also needs a change in the ~/.config/far2l/settings/key_macros.ini to include NoSendKeysToPlugins=0x1 which has replaced NoInsidePlugin back in
2003. Added incsrch/key_macros.ini for convenience to add to the key_macros.ini. Please refer to bug #2325 for in deep details.