### PR TITLE
win32-input-mode double encoding fix

### DIFF
--- a/WinPort/src/Backend/TTY/TTYInput.cpp
+++ b/WinPort/src/Backend/TTY/TTYInput.cpp
@@ -48,7 +48,7 @@ void TTYInput::OnBufUpdated(bool idle)
 
 		//work-around for double encoded mouse events in win32-input mode
 		//here we parse mouse sequence from accumulated buffer
-		_parser.ParseWinMouseBuffer(idle);
+		_parser.ParseWinDoubleBuffer(idle);
 
 		switch (decoded) {
 			case TTY_PARSED_PLAINCHARS:

--- a/WinPort/src/Backend/TTY/TTYInputSequenceParser.h
+++ b/WinPort/src/Backend/TTY/TTYInputSequenceParser.h
@@ -120,8 +120,8 @@ class TTYInputSequenceParser
 		_ctrl_ind  = 0x10;
 
 	//work-around for double encoded mouse events in win32-input mode
-	std::vector<char> _win_mouse_buffer; // buffer for accumulate unpacked chras
-	bool _win32_accumulate = false;      // flag for parse win32-input sequence into _win_mouse_buffer
+	std::vector<char> _win_double_buffer; // buffer for accumulate unpacked chras
+	bool _win32_accumulate = false;      // flag for parse win32-input sequence into _win_double_buffer
 
 	void AssertNoConflicts();
 
@@ -156,7 +156,7 @@ class TTYInputSequenceParser
 
 	void ParseAPC(const char *s, size_t l);
 	size_t TryParseAsWinTermEscapeSequence(const char *s, size_t l);
-	size_t TryUnwrappWinMouseEscapeSequence(const char *s, size_t l);
+	size_t TryUnwrappWinDoubleEscapeSequence(const char *s, size_t l);
 	size_t ReadUTF8InHex(const char *s, wchar_t *uni_char);
 	size_t TryParseAsITerm2EscapeSequence(const char *s, size_t l);
 	size_t TryParseAsKittyEscapeSequence(const char *s, size_t l);
@@ -181,10 +181,10 @@ public:
 	size_t Parse(const char *s, size_t l, bool idle_expired);
 
 	/**
-	 * parse and schedule mouse sequence from _win_mouse_buffer.
-	 * executed only if _win_mouse_buffer contains valid number of characters
+	 * parse and schedule mouse sequence from _win_double_buffer.
+	 * executed only if _win_double_buffer contains valid number of characters
 	 * for X10 mouse sequence
 	*/
-	void ParseWinMouseBuffer(bool idle_expired);
+	void ParseWinDoubleBuffer(bool idle_expired);
 	char UsingExtension() const { return _using_extension; };
 };

--- a/WinPort/src/Backend/TTY/TTYInputSequenceParserExts.cpp
+++ b/WinPort/src/Backend/TTY/TTYInputSequenceParserExts.cpp
@@ -447,6 +447,18 @@ size_t TTYInputSequenceParser::TryParseAsWinTermEscapeSequence(const char *s, si
 		ir.Event.KeyEvent.wRepeatCount = args[5];
 		_ir_pending.emplace_back(ir);
 	}
+	else if ((args[0] == 0) && (args[1] == 0) && (args[2] != 0)) {
+		// it can be non-latin paste char event
+		INPUT_RECORD ir = {};
+		ir.EventType = KEY_EVENT;
+		ir.Event.KeyEvent.wVirtualKeyCode = VK_UNASSIGNED;
+		ir.Event.KeyEvent.wVirtualScanCode = 0;
+		ir.Event.KeyEvent.uChar.UnicodeChar = args[2];
+		ir.Event.KeyEvent.bKeyDown = (args[3] ? TRUE : FALSE);
+		ir.Event.KeyEvent.dwControlKeyState = args[4];
+		ir.Event.KeyEvent.wRepeatCount = args[5];
+		_ir_pending.emplace_back(ir);
+	}
 
 	if (!_using_extension) {
 		fprintf(stderr, "TTYInputSequenceParser: using WinTerm extension\n");

--- a/WinPort/src/Backend/TTY/TTYInputSequenceParserExts.cpp
+++ b/WinPort/src/Backend/TTY/TTYInputSequenceParserExts.cpp
@@ -460,7 +460,7 @@ size_t TTYInputSequenceParser::TryParseAsWinTermEscapeSequence(const char *s, si
 //maybe it will be better not copy/paste TryParseAsWinTermEscapeSequence here
 //but passing yet another flag to it is less readable.
 //so keep it this way until microsoft fix their stuff in the win32-input protocol
-size_t TTYInputSequenceParser::TryUnwrappWinMouseEscapeSequence(const char *s, size_t l)
+size_t TTYInputSequenceParser::TryUnwrappWinDoubleEscapeSequence(const char *s, size_t l)
 {
 	int args[6] = {0};
 	int args_cnt = 0;
@@ -491,7 +491,7 @@ size_t TTYInputSequenceParser::TryUnwrappWinMouseEscapeSequence(const char *s, s
 
 	if(args[2] > 0 && args[3] == 1){ // only KeyDown and valid char should pass
 		//fprintf(stderr, "Parsed: ==%c==\n", (unsigned char)(args[2]));
-		_win_mouse_buffer.push_back((unsigned char)args[2]);
+		_win_double_buffer.push_back((unsigned char)args[2]);
 	}
 
 	return n;


### PR DESCRIPTION
Fix for a https://github.com/elfmz/far2l/pull/2085 fix, which fixes #2072. Also fixes #2329.

Actually, #2329 was `ESC [200~` and `ESC [201~` (bracketed paste mode) double encoding problem. I made universal double encoding handling, not mouse only.