### PR TITLE
Make md_timestring accept time_t

### DIFF
--- a/multiarc/src/formats/ha/ha/machine.c
+++ b/multiarc/src/formats/ha/ha/machine.c
@@ -341,12 +341,12 @@ void md_listdat(void) {
     printf("\n %s",attrstring(mdhd.attr));
 }
 
-char *md_timestring(unsigned long t) {
+char *md_timestring(time_t t) {
     
     static char ts[40];
     struct tm *tim;	
     
-    tim=localtime((long *)&t);
+    tim=localtime(&t);
     sprintf(ts,"%04d-%02d-%02d  %02d:%02d",tim->tm_year+1900,tim->tm_mon+1,
 	    tim->tm_mday,tim->tm_hour,tim->tm_min);
     return ts;	

--- a/multiarc/src/formats/ha/ha/machine.h
+++ b/multiarc/src/formats/ha/ha/machine.h
@@ -60,7 +60,7 @@ int md_mkspecial(char *ofname,unsigned sdlen,unsigned char *sdata);
 int md_filetype(char *path,char *name);
 void md_listhdr(void);
 void md_listdat(void);
-char *md_timestring(unsigned long t);
+char *md_timestring(time_t t);
 void md_truncfile(int fh, U32B len);
 char *md_tohapath(char *mdpath);
 char *md_tomdpath(char *hapath);

--- a/multiarc/src/formats/ha/ha/md_funcs.txt
+++ b/multiarc/src/formats/ha/ha/md_funcs.txt
@@ -56,7 +56,7 @@ void md_listhdr(void)
 void md_listdat(void) 
 	print attribute information from machine specific header.
 
-char *md_timestring(unsigned long t) 
+char *md_timestring(time_t t) 
 	Return pointer to string representin "unix time" t.
 
 void md_truncfile(int fh, U32B len) 


### PR DESCRIPTION
In Debian and Ubuntu, `time_t` is now 64 bit (`long long`) on 32-bit architectures (except for deprecated i386 architecture).

So trying to pass `long *` to localtime(3) which accepts `time_t *` causes a compiler error, because trying to use such a pointer would cause out of bounds read:

https://buildd.debian.org/status/fetch.php?pkg=far2l&arch=armhf&ver=2.6.3%7Ebeta%2Bds-1&stamp=1723367125&raw=0

To fix this, change the signature of `md_timestring` and get rid of the pointer cast.