### PR TITLE
fix #2344: escape backtick character

### DIFF
--- a/utils/include/Escaping.h
+++ b/utils/include/Escaping.h
@@ -9,8 +9,8 @@ std::string EscapeQuotes(const std::string &str);
 std::wstring EscapeQuotes(const std::wstring &str);
 
 /* by default escapes those chars as if whole string is a double-quoted command argument */
-std::string EscapeCmdStr(const std::string &str, const char *escaped_chars = "\\\"$");
-std::wstring EscapeCmdStr(const std::wstring &str, const wchar_t *escaped_chars = L"\\\"$");
+std::string EscapeCmdStr(const std::string &str, const char *escaped_chars = "\\\"$`");
+std::wstring EscapeCmdStr(const std::wstring &str, const wchar_t *escaped_chars = L"\\\"$`");
 
 void QuoteCmdArg(std::string &str);
 void QuoteCmdArg(std::wstring &str);


### PR DESCRIPTION
fix #2344 (Incorrect work with folder named with `)  :  escape backticks too