### PR TITLE
(basic) support of kitty keyboard protocol in VT

### DIFF
--- a/far2l/src/vt/IVTShell.h
+++ b/far2l/src/vt/IVTShell.h
@@ -16,6 +16,8 @@ struct IVTShell
 	virtual void OnMouseExpectation(MouseExpectation mex, bool enabled) = 0;
 	virtual void OnBracketedPasteExpectation(bool enabled)              = 0;
 	virtual void OnWin32InputMode(bool enabled)                         = 0;
+	virtual void SetKittyFlags(int flags)                               = 0;
+	virtual int  GetKittyFlags()                                        = 0;
 	virtual void OnApplicationProtocolCommand(const char *str)          = 0;
 	virtual bool OnOSCommand(int id, std::string &str)                  = 0;
 	virtual void InjectInput(const char *str)                           = 0;

--- a/far2l/src/vt/vtansi.cpp
+++ b/far2l/src/vt/vtansi.cpp
@@ -803,36 +803,29 @@ struct VTAnsiContext
 				} }
 				return;
 			}
-			
-			if (suffix == 'u') { // kitty keys stuff
+
+		 	// kitty keys stuff	
+
+			if (suffix == 'u') {
+
 				if (prefix2 == '=') {
 
-					// es_argv[0] - флаги, уже числом
-					// es_argv[0] - способ их модификации, число 1-3, по умолчанию 1; если es_argc < 2, используем значение "по умолчанию"
-
-					// Format(ESC "[=15;1u"); // kovidgoyal's kitty mode on
-					// Format(ESC "[=0;1u" "\r"); // kovidgoyal's kitty mode off
-
-					// write(#27'[>31u'); { try to set up kitty keys }
-					// write(#27'[<u'); {if we have kitty keys, disable them for now}
-
-					//FILE* f = fopen("far2l_to_file.log", "a");
-					//fprintf(f, " ***40 %c %c %c    %i: %i %i\n", prefix, prefix2, suffix, es_argc, es_argv[0], es_argv[1]);
-					//fclose(f);
-
-					vt_shell->SetKittyFlags(es_argc > 0 ? es_argv[0] : 0); // assuming mode always 1; we do not support other modes now
+					// assuming mode always 1; we do not support other modes currently
+					vt_shell->SetKittyFlags(es_argc > 0 ? es_argv[0] : 0);
 
 					return;			
 
 				} else if (prefix2 == '>') {
 
-					vt_shell->SetKittyFlags(es_argc > 0 ? es_argv[0] : 0); // assuming mode always 1; we do not support other modes now
+					// assuming mode always 1; we do not support other modes currently
+					vt_shell->SetKittyFlags(es_argc > 0 ? es_argv[0] : 0);
 
 					return;			
 
 				} else if (prefix2 == '<') {
 
-					vt_shell->SetKittyFlags(0); // we do not support mode stack now, just reset flags
+					// we do not support mode stack currently, just reset flags
+					vt_shell->SetKittyFlags(0);
 
 					return;			
 

--- a/far2l/src/vt/vtansi.cpp
+++ b/far2l/src/vt/vtansi.cpp
@@ -804,7 +804,7 @@ struct VTAnsiContext
 				return;
 			}
 
-		 	// kitty keys stuff	
+			// kitty keys stuff
 
 			if (suffix == 'u') {
 
@@ -813,21 +813,21 @@ struct VTAnsiContext
 					// assuming mode always 1; we do not support other modes currently
 					vt_shell->SetKittyFlags(es_argc > 0 ? es_argv[0] : 0);
 
-					return;			
+					return;
 
 				} else if (prefix2 == '>') {
 
 					// assuming mode always 1; we do not support other modes currently
 					vt_shell->SetKittyFlags(es_argc > 0 ? es_argv[0] : 0);
 
-					return;			
+					return;
 
 				} else if (prefix2 == '<') {
 
 					// we do not support mode stack currently, just reset flags
 					vt_shell->SetKittyFlags(0);
 
-					return;			
+					return;
 
 				} else if (prefix2 == '?') {
 
@@ -836,7 +836,7 @@ struct VTAnsiContext
 					snprintf( buf, sizeof(buf), "\x1b[?%du", vt_shell->GetKittyFlags());
 					SendSequence( buf );
 
-					return;			
+					return;
 
 				}
 			}

--- a/far2l/src/vt/vtansi.cpp
+++ b/far2l/src/vt/vtansi.cpp
@@ -803,6 +803,51 @@ struct VTAnsiContext
 				} }
 				return;
 			}
+			
+			if (suffix == 'u') { // kitty keys stuff
+				if (prefix2 == '=') {
+
+					// es_argv[0] - флаги, уже числом
+					// es_argv[0] - способ их модификации, число 1-3, по умолчанию 1; если es_argc < 2, используем значение "по умолчанию"
+
+					// Format(ESC "[=15;1u"); // kovidgoyal's kitty mode on
+					// Format(ESC "[=0;1u" "\r"); // kovidgoyal's kitty mode off
+
+					// write(#27'[>31u'); { try to set up kitty keys }
+					// write(#27'[<u'); {if we have kitty keys, disable them for now}
+
+					//FILE* f = fopen("far2l_to_file.log", "a");
+					//fprintf(f, " ***40 %c %c %c    %i: %i %i\n", prefix, prefix2, suffix, es_argc, es_argv[0], es_argv[1]);
+					//fclose(f);
+
+					vt_shell->SetKittyFlags(es_argc > 0 ? es_argv[0] : 0); // assuming mode always 1; we do not support other modes now
+
+					return;			
+
+				} else if (prefix2 == '>') {
+
+					vt_shell->SetKittyFlags(es_argc > 0 ? es_argv[0] : 0); // assuming mode always 1; we do not support other modes now
+
+					return;			
+
+				} else if (prefix2 == '<') {
+
+					vt_shell->SetKittyFlags(0); // we do not support mode stack now, just reset flags
+
+					return;			
+
+				} else if (prefix2 == '?') {
+
+					// reply with "CSI ? flags u"
+					char buf[64] = {0};
+					snprintf( buf, sizeof(buf), "\x1b[?%du", vt_shell->GetKittyFlags());
+					SendSequence( buf );
+
+					return;			
+
+				}
+			}
+
 			// Ignore any other private sequences.
 			if (prefix2 != 0) {
 				fprintf(stderr, "Ignoring: %c %c %u %u\n", prefix2, suffix, es_argc, es_argv[0]);

--- a/far2l/src/vt/vtshell.cpp
+++ b/far2l/src/vt/vtshell.cpp
@@ -747,7 +747,7 @@ class VTShell : VTOutputReader::IProcessor, VTInputReader::IProcessor, IVTShell
 
 			if (KeyEvent.bKeyDown) {
 
-				if (!ctrl && !shift && !alt && KeyEvent.wVirtualKeyCode==VK_BACK) {
+				if (!ctrl && !shift && !alt && KeyEvent.wVirtualKeyCode==VK_BACK && !_kitty_kb_flags) {
 					//WCM has a setting for that, so probably in some cases backspace should be returned as is
 					char backspace[] = {127, 0};
 					return backspace;
@@ -920,6 +920,12 @@ class VTShell : VTOutputReader::IProcessor, VTInputReader::IProcessor, IVTShell
 				
 				// Финальный 0
 				len += snprintf(buffer + len, sizeof(buffer) - len, "%c", 0);
+
+				/*
+				FILE* f = fopen("far2l_k.log", "a");
+				fprintf(f, "%s\n", buffer);
+				fclose(f);
+				*/
 				
 				return buffer;
 			}

--- a/far2l/src/vt/vtshell.cpp
+++ b/far2l/src/vt/vtshell.cpp
@@ -787,7 +787,6 @@ class VTShell : VTOutputReader::IProcessor, VTInputReader::IProcessor, IVTShell
 
 				char buffer[64];
 
-				// fixme: CAPS LOCK неработает, причем для английского и русского по-разному
 				// fixme: KEYPAD 5 работает как F5, а надо чтоб как F3
 
 				int keycode = towlower(KeyEvent.uChar.UnicodeChar);
@@ -799,8 +798,14 @@ class VTShell : VTOutputReader::IProcessor, VTInputReader::IProcessor, IVTShell
 				}
 
 				int shifted = 0;
-				if (shift) {
-					shifted = toupper(KeyEvent.uChar.UnicodeChar);
+
+				// (KeyEvent.uChar.UnicodeChar && iswupper(KeyEvent.uChar.UnicodeChar))
+				// is workaround for far2l wx as it is not sending Shift state for Char events
+				// See
+				// ir.Event.KeyEvent.wVirtualKeyCode = VK_OEM_PERIOD;
+				// and below in wxMain.cpp: dwControlKeyState not set
+				if (shift || (KeyEvent.uChar.UnicodeChar && iswupper(KeyEvent.uChar.UnicodeChar))) {
+					shifted = KeyEvent.uChar.UnicodeChar;
 				}
 
 				int modifiers = 0;

--- a/far2l/src/vt/vtshell.cpp
+++ b/far2l/src/vt/vtshell.cpp
@@ -100,6 +100,7 @@ class VTShell : VTOutputReader::IProcessor, VTInputReader::IProcessor, IVTShell
 	std::atomic<unsigned char> _keypad{0};
 	std::atomic<bool> _bracketed_paste_expected{false};
 	std::atomic<bool> _win32_input_mode_expected{false};
+	std::atomic<int> _kitty_kb_flags{0};
 	INPUT_RECORD _last_window_info_ir;
 	std::unique_ptr<VTFar2lExtensios> _far2l_exts;
 	std::unique_ptr<VTMouse> _mouse;
@@ -437,7 +438,7 @@ class VTShell : VTOutputReader::IProcessor, VTInputReader::IProcessor, IVTShell
 		DWORD dw;
 		const std::string &translated = TranslateKeyEvent(KeyEvent);
 
-		if (!KeyEvent.bKeyDown && !_win32_input_mode_expected)
+		if (!KeyEvent.bKeyDown && !_win32_input_mode_expected && !(_kitty_kb_flags & 2))
 			return;
 
 		if (!translated.empty()) {
@@ -556,6 +557,16 @@ class VTShell : VTOutputReader::IProcessor, VTInputReader::IProcessor, IVTShell
 	virtual void OnWin32InputMode(bool enabled)
 	{
 		_win32_input_mode_expected = enabled;
+	}
+
+	virtual void SetKittyFlags(int flags)
+	{
+		_kitty_kb_flags = flags;
+	}
+
+	virtual int GetKittyFlags()
+	{
+		return _kitty_kb_flags;
 	}
 
 	virtual void OnApplicationProtocolCommand(const char *str)//NB: called not from main thread!
@@ -766,6 +777,146 @@ class VTShell : VTOutputReader::IProcessor, VTInputReader::IProcessor, IVTShell
 					OnConsoleLog(CLK_VIEW);
 					return "";
 				}
+			}
+
+			if (_kitty_kb_flags) {
+
+				// References:
+				// https://sw.kovidgoyal.net/kitty/keyboard-protocol/
+				// https://learn.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes
+
+				char buffer[64];
+
+				// fixme: CAPS LOCK неработает, причем для английского и русского по-разному
+				// fixme: KEYPAD 5 работает как F5, а надо чтоб как F3
+
+				int keycode = towlower(KeyEvent.uChar.UnicodeChar);
+
+				int base = 0;
+				if ((KeyEvent.wVirtualKeyCode >= 'A') && (KeyEvent.wVirtualKeyCode <= 'Z')) {
+					base = towlower(KeyEvent.wVirtualKeyCode);
+					if (base == keycode) { base = 0; }
+				}
+
+				int shifted = 0;
+				if (shift) {
+					shifted = toupper(KeyEvent.uChar.UnicodeChar);
+				}
+
+				int modifiers = 0;
+
+				if (shift) modifiers |= 1; 
+				if (alt)   modifiers |= 2; 
+				if (ctrl)  modifiers |= 4; 
+				if (KeyEvent.dwControlKeyState & CAPSLOCK_ON) modifiers |= 64; 
+				if (KeyEvent.dwControlKeyState & NUMLOCK_ON)  modifiers |= 128; 
+
+				modifiers += 1; // as spec requres
+
+				char suffix = 'u';
+
+				// apply modifications for special keys
+
+				switch (KeyEvent.wVirtualKeyCode) {
+					case VK_ESCAPE:    keycode = 27;  break;
+					case VK_RETURN:    keycode = 13;  break;
+
+					case VK_TAB:       keycode = 9;   break;
+					case VK_BACK:      keycode = 127; break;
+
+					case VK_INSERT:    keycode = 2;   suffix = '~'; break;
+					case VK_DELETE:    keycode = 3;   suffix = '~'; break;
+
+					case VK_LEFT:      keycode = 1;   suffix = 'D'; break;
+					case VK_RIGHT:     keycode = 1;   suffix = 'C'; break;
+					case VK_UP:        keycode = 1;   suffix = 'A'; break;
+					case VK_DOWN:      keycode = 1;   suffix = 'B'; break;
+
+					case VK_PRIOR:     keycode = 5;   suffix = '~'; break;
+					case VK_NEXT:      keycode = 6;   suffix = '~'; break;
+
+					case VK_HOME:      keycode = 1;   suffix = 'H'; break;
+					case VK_END:       keycode = 1;   suffix = 'F'; break;
+
+					case VK_F1:        keycode = 11;  suffix = '~'; break;
+					case VK_F2:        keycode = 12;  suffix = '~'; break;
+					case VK_F3:        keycode = 13;  suffix = '~'; break;
+					case VK_F4:        keycode = 14;  suffix = '~'; break;
+					case VK_F5:        keycode = 15;  suffix = '~'; break;
+
+					case VK_F6:        keycode = 17;  suffix = '~'; break;
+					case VK_F7:        keycode = 18;  suffix = '~'; break;
+					case VK_F8:        keycode = 19;  suffix = '~'; break;
+					case VK_F9:        keycode = 20;  suffix = '~'; break;
+					case VK_F10:       keycode = 21;  suffix = '~'; break;
+
+					case VK_F11:       keycode = 23;  suffix = '~'; break;
+					case VK_F12:       keycode = 24;  suffix = '~'; break;
+				}
+
+				int flags = _kitty_kb_flags;
+
+
+				// Записываем ESC-последовательность
+
+				// CSI unicode-key-code:shifted-key:base-layout-key ; modifiers:event-type ; text-as-codepoints u
+
+				// Переменная для отслеживания текущей длины строки в буфере
+				int len = 0;
+
+				// Старт последовательности
+				len += snprintf(buffer + len, sizeof(buffer) - len, "\x1B[");
+
+				// Часть 1
+
+				// Добавляем значение keycode
+				len += snprintf(buffer + len, sizeof(buffer) - len, "%i", keycode);
+
+				if ((flags & 4) && (shifted || base)) { // "report alternative keys" enabled
+
+					len += snprintf(buffer + len, sizeof(buffer) - len, ":");
+	
+					if (shifted) {
+						// Добавляем значение shifted
+						len += snprintf(buffer + len, sizeof(buffer) - len, "%i", shifted);
+					}
+
+					if (base) {
+
+						// Добавляем значение base
+						len += snprintf(buffer + len, sizeof(buffer) - len, ":%i", base);
+					}
+				}
+
+				len += snprintf(buffer + len, sizeof(buffer) - len, ";");
+
+				// Часть 2
+
+				// Добавляем значение modifiers
+				len += snprintf(buffer + len, sizeof(buffer) - len, "%i", modifiers);
+
+				if ((flags & 2) && !KeyEvent.bKeyDown) {
+					// Добавляем значение для типа события (1 для keydown, 2 для repeat, 3 для keyup)
+					// fixme: repeat unimplemented
+					len += snprintf(buffer + len, sizeof(buffer) - len, ":%i", 3);
+				}
+
+				// Часть 3
+
+				if (flags & 16) { // "text as code points" enabled
+					// Добавляем значение keycode как кодовые точки
+					len += snprintf(buffer + len, sizeof(buffer) - len, ";%i", keycode);
+				}
+
+				// Финал
+
+				// Добавляем значение suffix
+				len += snprintf(buffer + len, sizeof(buffer) - len, "%c", suffix);
+				
+				// Финальный 0
+				len += snprintf(buffer + len, sizeof(buffer) - len, "%c", 0);
+				
+				return buffer;
 			}
 
 			if (_win32_input_mode_expected) {

--- a/far2l/src/vt/vtshell.cpp
+++ b/far2l/src/vt/vtshell.cpp
@@ -785,7 +785,7 @@ class VTShell : VTOutputReader::IProcessor, VTInputReader::IProcessor, IVTShell
 				// https://sw.kovidgoyal.net/kitty/keyboard-protocol/
 				// https://learn.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes
 
-				char buffer[64];
+				char buffer[64] = {0};
 
 				// fixme: KEYPAD 5 работает как F5, а надо чтоб как F3
 
@@ -958,7 +958,7 @@ class VTShell : VTOutputReader::IProcessor, VTInputReader::IProcessor, IVTShell
 			}
 
 			if (_win32_input_mode_expected) {
-				char buffer[64];
+				char buffer[64] = {0};
 				snprintf(buffer, sizeof(buffer), "\x1B[%i;%i;%i;%i;%i;%i_",
 						 KeyEvent.wVirtualKeyCode,
 						 KeyEvent.wVirtualScanCode,

--- a/far2l/src/vt/vtshell.cpp
+++ b/far2l/src/vt/vtshell.cpp
@@ -813,11 +813,11 @@ class VTShell : VTOutputReader::IProcessor, VTInputReader::IProcessor, IVTShell
 
 				int modifiers = 0;
 
-				if (shift) modifiers |= 1; 
-				if (alt)   modifiers |= 2; 
-				if (ctrl)  modifiers |= 4; 
-				if (KeyEvent.dwControlKeyState & CAPSLOCK_ON) modifiers |= 64; 
-				if (KeyEvent.dwControlKeyState & NUMLOCK_ON)  modifiers |= 128; 
+				if (shift) modifiers |= 1;
+				if (alt)   modifiers |= 2;
+				if (ctrl)  modifiers |= 4;
+				if (KeyEvent.dwControlKeyState & CAPSLOCK_ON) modifiers |= 64;
+				if (KeyEvent.dwControlKeyState & NUMLOCK_ON)  modifiers |= 128;
 
 				modifiers += 1; // as spec requres
 
@@ -893,7 +893,7 @@ class VTShell : VTOutputReader::IProcessor, VTInputReader::IProcessor, IVTShell
 				if ((flags & 4) && (shifted || base)) { // "report alternative keys" enabled
 
 					len += snprintf(buffer + len, sizeof(buffer) - len, ":");
-	
+
 					if (shifted) {
 						// Добавляем значение shifted
 						len += snprintf(buffer + len, sizeof(buffer) - len, "%i", shifted);
@@ -944,7 +944,7 @@ class VTShell : VTOutputReader::IProcessor, VTInputReader::IProcessor, IVTShell
 					// just send text
 					len = snprintf(buffer, sizeof(buffer), "%lc", KeyEvent.uChar.UnicodeChar);
 				}
-				
+
 				// Финальный 0
 				len += snprintf(buffer + len, sizeof(buffer) - len, "%c", 0);
 
@@ -953,7 +953,7 @@ class VTShell : VTOutputReader::IProcessor, VTInputReader::IProcessor, IVTShell
 				fprintf(f, "%s\n", buffer);
 				fclose(f);
 				*/
-				
+
 				return buffer;
 			}
 

--- a/far2l/src/vt/vtshell.cpp
+++ b/far2l/src/vt/vtshell.cpp
@@ -909,14 +909,19 @@ class VTShell : VTOutputReader::IProcessor, VTInputReader::IProcessor, IVTShell
 				// Часть 3
 
 				if (flags & 16) { // "text as code points" enabled
-					// Добавляем значение keycode как кодовые точки
-					len += snprintf(buffer + len, sizeof(buffer) - len, ";%i", keycode);
+					// Добавляем значение UnicodeChar
+					len += snprintf(buffer + len, sizeof(buffer) - len, ";%i", KeyEvent.uChar.UnicodeChar);
 				}
 
 				// Финал
 
 				// Добавляем значение suffix
 				len += snprintf(buffer + len, sizeof(buffer) - len, "%c", suffix);
+
+				if (!(flags & 8) && KeyEvent.uChar.UnicodeChar && !alt && !ctrl) { // "Report all keys as escape codes" disabled
+					// just send text
+					len = snprintf(buffer, sizeof(buffer), "%lc", KeyEvent.uChar.UnicodeChar);
+				}
 				
 				// Финальный 0
 				len += snprintf(buffer + len, sizeof(buffer) - len, "%c", 0);


### PR DESCRIPTION
Enough to use far2l comfortably though.

Test with
```
far2l --tty --nodetect
```
under far2l with this improvement applied.

Tested with [FreeVision kitty protocol implementation](https://gitlab.com/freepascal.org/fpc/source/-/issues/40673) and [turbo](https://github.com/magiblot/turbo) also.

Fixes #2035.
