### PR TITLE
Update Findfmt.cmake for compatibility with fmt 11.x.x

### DIFF
--- a/cmake/modules/Findfmt.cmake
+++ b/cmake/modules/Findfmt.cmake
@@ -1,7 +1,9 @@
 find_path(fmt_INCLUDE_DIR NAMES fmt/format.h)
 
-if(fmt_INCLUDE_DIR)
-  set(_fmt_version_file "${fmt_INCLUDE_DIR}/fmt/core.h")
+  set(_fmt_version_file "${fmt_INCLUDE_DIR}/fmt/base.h")
+  if(NOT EXISTS "${_fmt_version_file}")
+    set(_fmt_version_file "${fmt_INCLUDE_DIR}/fmt/core.h")
+  endif()
   if(NOT EXISTS "${_fmt_version_file}")
     set(_fmt_version_file "${fmt_INCLUDE_DIR}/fmt/format.h")
   endif()

--- a/cmake/modules/Findfmt.cmake
+++ b/cmake/modules/Findfmt.cmake
@@ -1,5 +1,6 @@
 find_path(fmt_INCLUDE_DIR NAMES fmt/format.h)
 
+if(fmt_INCLUDE_DIR)
   set(_fmt_version_file "${fmt_INCLUDE_DIR}/fmt/base.h")
   if(NOT EXISTS "${_fmt_version_file}")
     set(_fmt_version_file "${fmt_INCLUDE_DIR}/fmt/core.h")


### PR DESCRIPTION
After upgrading from fmt 10.x.x to 11.x.x in openSUSE, compilation of the colorer plugin caused cmake errors.   fmt 11.x.x stores version in new file fmt/base.h.
Update Findfmt.cmake to be compatible with fmt 11.x.x