### PR TITLE
esc expiration on by default, officially

### DIFF
--- a/WinPort/src/Backend/TTY/TTYBackend.cpp
+++ b/WinPort/src/Backend/TTY/TTYBackend.cpp
@@ -307,26 +307,6 @@ void TTYBackend::ReaderLoop()
 
 		int rs;
 
-		// Enable esc expiration on Wayland as Xi not work there
-		// Also enable if we've got no TTY|X or got TTY|X without Xi
-		if (!_esc_expiration && (UnderWayland() || !_ttyx || !(_ttyx->HasXi()))) {
-			_esc_expiration = 100;
-		}
-
-		// Also in kernel console
-		#if defined(__linux__) || defined(__FreeBSD__) || defined(__DragonFly__)
-				if (!_esc_expiration) {
-					int kd_mode;
-					#if defined(__linux__)
-					if (ioctl(_stdin, KDGETMODE, &kd_mode) == 0) {
-					#else
-					if (ioctl(_stdin, KDGKBMODE, &kd_mode) == 0) {
-					#endif
-						_esc_expiration = 100;
-					}
-				}
-		#endif
-
 		if (!idle_expired && _esc_expiration > 0 && !_far2l_tty) {
 			struct timeval tv;
 			tv.tv_sec = _esc_expiration / 1000;

--- a/WinPort/src/Backend/TTY/TTYBackend.h
+++ b/WinPort/src/Backend/TTY/TTYBackend.h
@@ -35,7 +35,7 @@ class TTYBackend : IConsoleOutputBackend, ITTYInputSpecialSequenceHandler, IFar2
 		FKS_NOT_SUPPORTED
 	} _fkeys_support = FKS_UNKNOWN;
 
-	unsigned int _esc_expiration = 0;
+	unsigned int _esc_expiration = 100;
 	int _notify_pipe = -1;
 	int *_result = nullptr;
 	int _kickass[2] = {-1, -1};

--- a/WinPort/src/Backend/TTY/TTYBackend.h
+++ b/WinPort/src/Backend/TTY/TTYBackend.h
@@ -35,7 +35,7 @@ class TTYBackend : IConsoleOutputBackend, ITTYInputSpecialSequenceHandler, IFar2
 		FKS_NOT_SUPPORTED
 	} _fkeys_support = FKS_UNKNOWN;
 
-	unsigned int _esc_expiration = 100;
+	unsigned int _esc_expiration = 0;
 	int _notify_pipe = -1;
 	int *_result = nullptr;
 	int _kickass[2] = {-1, -1};

--- a/WinPort/src/Backend/WinPortMain.cpp
+++ b/WinPort/src/Backend/WinPortMain.cpp
@@ -261,7 +261,7 @@ struct ArgOptions
 	bool x11 = false;
 	bool wayland = false;
 	std::string ext_clipboard;
-	unsigned int esc_expiration = 0;
+	unsigned int esc_expiration = 100;
 	std::vector<char *> filtered_argv;
 
 	ArgOptions() = default;

--- a/WinPort/src/Backend/WinPortMain.cpp
+++ b/WinPort/src/Backend/WinPortMain.cpp
@@ -244,13 +244,13 @@ extern "C" void WinPortHelp()
 	printf("\t--immortal - go to background instead of terminating on getting SIGHUP (default if not in Linux TTY)\n");
 	printf("\t--x11 - force GUI backend to run on X11\n");
 	printf("\t--wayland - force GUI backend to run on Wayland\n");
-	printf("\t--ee or --ee=N - ESC expiration in msec (100 if unspecified) to avoid need for double ESC presses (valid only in TTY mode without FAR2L extensions)\n");
+	printf("\t--ee=N - ESC expiration in msec (default is 100, 0 to disable) to avoid need for double ESC presses (valid only in TTY mode without FAR2L extensions)\n");
 	printf("\t--primary-selection - use PRIMARY selection instead of CLIPBOARD X11 selection (only for GUI backend)\n");
 	printf("\t--maximize - force maximize window upon launch (only for GUI backend)\n");
 	printf("\t--nomaximize - dont maximize window upon launch even if its has saved maximized state (only for GUI backend)\n");
 	printf("\t--clipboard=SCRIPT - use external clipboard handler script that implements get/set text clipboard data via its stdin/stdout\n");
     printf("    Backend-specific options also can be set via the FAR2L_ARGS environment variable\n");
-    printf("     (for example: export FAR2L_ARGS=\"--tty --nodetect --ee\" and then simple far2l to force start only TTY backend)\n");
+    printf("     (for example: export FAR2L_ARGS=\"--tty\" to start far2l in tty mode by default)\n");
 }
 
 struct ArgOptions
@@ -313,8 +313,8 @@ struct ArgOptions
 		} else if (strstr(a, "--clipboard=") == a) {
 			ext_clipboard = a + 12;
 
-		} else if (strstr(a, "--ee") == a) {
-			esc_expiration = (a[4] == '=') ? atoi(&a[5]) : 100;
+		} else if (strstr(a, "--ee=") == a) {
+			esc_expiration = atoi(&a[5]);
 
 		} else if (need_strdup) {
 			char *a_dup = strdup(a);


### PR DESCRIPTION
As number of users who prefer not to press ESC twice is probably much greater than number of users who want to send custom escape sequences to far2l (can't even imagine a use case for that), let's enable --ee=100 by default, allowing user to disable this feature if needed for some reason