### PR TITLE
Add bash-completion & minor readme

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -536,6 +536,7 @@ endif()
 add_subdirectory (packaging)
 
 add_subdirectory(man)
+add_subdirectory(bash-completion)
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     set(FIXUP_SCRIPT packaging/osx/FixupBundle.cmake)

--- a/README.md
+++ b/README.md
@@ -39,13 +39,23 @@ emulators](#terminals), which provide clipboard access and has their advanced ke
 
 | Mode<br>(UI Backends) | TTY<br>(plain far2l) | TTY\|X | TTY\|Xi | GUI |
 | ---: | --- | --- | --- | --- |
-| **Works:** | in terminal | in terminal | in terminal | in Desktop<br>environment<br><sub>(X11<br>or Wayland<br>or macOS)</sub> |
+| **Works:** | in terminal | in terminal | in terminal | in Desktop<br>environment<br><sub>(X11<br>or Wayland<br>or macOS)<br>via wxWidgets</sub> |
 | **Binaries:** | far2l | far2l<br>far2l_ttyx.broker | far2l<br>far2l_ttyx.broker | far2l<br>far2l_gui.so |
 | **[Dependencies](#required-dependencies):** | minimal | + libx11 | + libx11, libxi | + wxWidgets, GTK |
 | **Keyboard:** | <sub>_Typical terminals_:<br>**only essential<br>key combinations**<br><br>_KiTTY_ (putty fork),<br>_kitty_ (*nix one),<br>_iTerm2_,<br>_Windows Terminal_,<br>far2l’s VT: **full support**</sub> | <sub>_Typical terminals_:<br>**only essential<br>key combinations**<br><br>_KiTTY_ (putty fork),<br>_kitty_ (*nix one),<br>_iTerm2_,<br>_Windows Terminal_,<br>far2l’s VT: **full support**</sub> | <sub>_Typical terminals_:<br>**most of key<br>combinations under x11**;<br>**only essential key<br>combinations<br>under Wayland**<br><br>_KiTTY_ (putty fork),<br>_kitty_ (*nix one),<br>_iTerm2_,<br>_Windows Terminal_,<br>far2l’s VT: **full support**</sub> | **All key<br>combinations** |
 | **Clipboard<br>access:** | <sub>_Typical terminals_:<br>via command line<br>tools like xclip<br><br>_kitty_ (*nix one),<br>_iTerm2_:<br>via **OSC52**<br><br>_Windows Terminal_:<br>via **OSC52**<br>or via **command line<br>tools under WSL**<br><br>_KiTTY_ (putty fork),<br>far2l’s VT:<br>via **far2l extensions**</sub> | <sub>_Typical terminals_,<br>_kitty_ (*nix one):<br>via **x11 interaction**<br><br>_iTerm2_:<br>via **OSC52**<br><br>_Windows Terminal_:<br>via **OSC52**<br>or via **command line<br>tools under WSL**<br><br>_KiTTY_ (putty fork),<br>far2l’s VT:<br>via **far2l extensions**</sub> | <sub>_Typical terminals_,<br>_kitty_ (*nix one):<br>via **x11 interaction**<br><br>_iTerm2_:<br>via **OSC52**<br><br>_Windows Terminal_:<br>via **OSC52**<br>or via **command line<br>tools under WSL**<br><br>_KiTTY_ (putty fork),<br>far2l’s VT:<br>via **far2l extensions**</sub> | via<br>**wxWidgets API**<br><br><sub>via command line<br>tools under WSL</sub> |
 | **Typical<br>use case:** | **Servers**,<br>embedded | <sub>Run far2l in<br>favorite terminal<br>but with<br>**better UX**</sub> | <sub>Run far2l in<br>favorite terminal<br>but with<br>**best UX**</sub> | **Desktop** |
 | **Mandatory:** | yes | no | no | no |
+
+<sub>_Note_: When running far2l automatically downgrade
+if its components are not installed (or system libs are not available):
+**GUI** ⇒ **TTY|Xi** ⇒ **TTY|X** ⇒ **TTY**.
+To force run only specific backend use in command line:
+for **GUI**: `far2l --notty`;
+for **TTY|Xi** use in command line: `far2l --tty`;
+for **TTY|X**: `far2l --tty --nodetect=xi`;
+for plain **TTY**: `far2l --tty --nodetect=x`
+(see details via `far2l --help`).</sub>
 
 <sub>_Note about use OSC 52 in TTY/TTY|X_:
 to interact with the system clipboard you must **not forget to enable OSC 52**

--- a/README.md
+++ b/README.md
@@ -111,8 +111,11 @@ See also [Community packages & binaries](#community_bins)
 * `libnfs-dev` (_optional_ - needed for **NetRocks/NFS**)
 * `libneon27-dev` (or later, _optional_ - needed for **NetRocks/WebDAV**)
 * `libarchive-dev` (_optional_ - needed for better archives support in **multiarc**)
-* `libunrar-dev` (_optional_ - needed for RAR archives support in **multiarc**, see UNRAR command line option)
+* `libunrar-dev` (_optional_ - needed for RAR archives support in **multiarc**, see `UNRAR` command line option)
 * `libpcre3-dev` (or `libpcre2-dev` in older distributions, _optional_ - needed for advanced custom archive formats support in **multiarc**)
+* `libpython3-dev` (_optional_ - needed for **python plugins** support, see `-DPYTHON` command line option)
+* `libffi-dev` (_optional_ - needed for **python plugins** support, see `-DPYTHON` command line option)
+* `python3-venv` (_optional_ - needed for **python plugins** support, see `-DPYTHON` command line option)
 * `cmake` ( >= 3.2.2 )
 * `pkg-config`
 * `g++`
@@ -172,10 +175,11 @@ To force-disable TTY|X and TTY|Xi backends: add argument `-DTTYX=no`; to disable
 
 To eliminate libuchardet requirement to reduce far2l dependencies by cost of losing automatic charset detection functionality: add `-DUSEUCD=no`
 
-To build with Python plugin: add argument `-DPYTHON=yes`  but you must have installed additional packages within yours system:
-libpython3-dev
-libffi-dev
-python3-venv
+To build with Python plugin: add argument `-DPYTHON=yes`
+but you must have installed additional packages within yours system:
+`libpython3-dev`,
+`libffi-dev`,
+`python3-venv`.
 
 
 To control how RAR archives will be handled in multiarc:

--- a/bash-completion/CMakeLists.txt
+++ b/bash-completion/CMakeLists.txt
@@ -1,0 +1,4 @@
+if (NOT CMAKE_BASH_COMP_DIR)
+  set(CMAKE_BASH_COMP_DIR ${CMAKE_XDGDATA_DIR}/bash-completion/completions)
+endif()
+install(FILES far2l DESTINATION ${CMAKE_BASH_COMP_DIR})

--- a/bash-completion/far2l
+++ b/bash-completion/far2l
@@ -1,0 +1,27 @@
+# bash completion for far2l                                   -*- shell-script -*-
+
+_far2l_completions()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+
+    case $prev in
+        -!(-*)[ev])
+            _filedir
+            return
+            ;;
+    esac
+
+    $split && return
+
+    if [[ $cur == -* ]]; then
+        COMPREPLY=($(compgen -W '$(_parse_help "$1" -h)' -- "$cur"))
+        [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
+        [[ ${COMPREPLY-} == *: ]] && compopt -o nospace
+    else
+        _filedir -d
+    fi
+} &&
+    complete -F _far2l_completions far2l
+
+# ex: filetype=sh


### PR DESCRIPTION
Не уверен, что такое безусловное включение bash-completion в CMakeLists.txt будет корректно во всех системах.
Может надо какие-то доп.проверки на `CMAKE_XDGDATA_DIR`?

У меня закидывание файла bash-completion/far2l в `/usr/share/bash-completion/completions/` даёт вроде адекватное автодополнение для far2l в bash.