### PR TITLE
Issue #2052: migrate dependencies from pcre3 back to pcre2 library

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
          libuchardet-dev libxml2-dev libwxgtk3.0-gtk3-dev
          libx11-dev libxi-dev
          libssl-dev libsmbclient-dev libnfs-dev libneon27-dev libssh-dev
-         libarchive-dev libpcre3-dev
+         libarchive-dev libpcre2-dev
   
       - name: Create Build Environment
         # Create a separate build directory as working directory for all subsequent commands
@@ -114,7 +114,7 @@ jobs:
           libuchardet-dev libxml2-dev libwxgtk3.0-gtk3-dev
           libx11-dev libxi-dev
           libssl-dev libsmbclient-dev libnfs-dev libneon27-dev libssh-dev
-          libarchive-dev libpcre3-dev
+          libarchive-dev libpcre2-dev
   
       - name: Create Build Environment
         # Create a separate build directory as working directory for all subsequent commands
@@ -165,7 +165,7 @@ jobs:
           libuchardet-dev libxml2-dev libwxgtk3.2-dev
           libx11-dev libxi-dev
           libssl-dev libsmbclient-dev libnfs-dev libneon27-dev libssh-dev
-          libarchive-dev libpcre3-dev
+          libarchive-dev libpcre2-dev
   
       - name: Create Build Environment
         # Create a separate build directory as working directory for all subsequent commands

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,7 @@ matrix:
             - libnfs-dev
             - libneon27-dev
             - libarchive-dev
-            - libpcre3-dev
+            - libpcre2-dev
             - zlib1g-dev
             - ninja-build
       env: CXX=clang++-3.7

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ See also [Community packages & binaries](#community_bins)
 * `libneon27-dev` (or later, _optional_ - needed for **NetRocks/WebDAV**)
 * `libarchive-dev` (_optional_ - needed for better archives support in **multiarc**)
 * `libunrar-dev` (_optional_ - needed for RAR archives support in **multiarc**, see `UNRAR` command line option)
-* `libpcre3-dev` (or `libpcre2-dev` in older distributions, _optional_ - needed for advanced custom archive formats support in **multiarc**)
+* `libpcre2-dev` (_optional_ - needed for advanced custom archive formats support in **multiarc**)
 * `libpython3-dev` (_optional_ - needed for **python plugins** support, see `-DPYTHON` command line option)
 * `libffi-dev` (_optional_ - needed for **python plugins** support, see `-DPYTHON` command line option)
 * `python3-venv` (_optional_ - needed for **python plugins** support, see `-DPYTHON` command line option)
@@ -133,7 +133,7 @@ See also [Community packages & binaries](#community_bins)
 
 #### Or simply on Debian/Ubuntu:
 ``` sh
-apt-get install libwxgtk3.0-gtk3-dev libx11-dev libxi-dev libpcre3-dev libxml2-dev libuchardet-dev libssh-dev libssl-dev libsmbclient-dev libnfs-dev libneon27-dev libarchive-dev cmake pkg-config g++ git
+apt-get install libwxgtk3.0-gtk3-dev libx11-dev libxi-dev libpcre2-dev libxml2-dev libuchardet-dev libssh-dev libssl-dev libsmbclient-dev libnfs-dev libneon27-dev libarchive-dev cmake pkg-config g++ git
 ```
 
 A simple sid back port should be as easy as (build your own binary deb from the official source deb package):
@@ -146,7 +146,7 @@ debuild
 # cd .. and install your self built far2l*.deb
 ```
 
-In older distributions: use libpcre2-dev and libwxgtk3.0-dev instead of libpcre3-dev and libwxgtk3.0-gtk3-dev
+In older distributions: use libwxgtk3.0-dev instead of libwxgtk3.0-gtk3-dev
 
 #### Clone and Build
  * Clone current master

--- a/packaging/CMakeLists.txt
+++ b/packaging/CMakeLists.txt
@@ -16,7 +16,7 @@ set(CPACK_PACKAGE_FILE_NAME ${CPACK_PACKAGE_NAME}-${VERSION})
 LIST(APPEND PACKAGE_DEPENDENCIES libc6)
 LIST(APPEND PACKAGE_DEPENDENCIES libglib2.0-0 libstdc++6)
 LIST(APPEND PACKAGE_DEPENDENCIES "libgcc-s1 | libgcc | libgcc1")
-LIST(APPEND PACKAGE_DEPENDENCIES libminizip1 libpcre3)
+LIST(APPEND PACKAGE_DEPENDENCIES libminizip1 libpcre2)
 # from main project
 IF (${USEWX})
     find_package(wxWidgets REQUIRED core base)

--- a/packaging/CMakeLists.txt
+++ b/packaging/CMakeLists.txt
@@ -16,7 +16,7 @@ set(CPACK_PACKAGE_FILE_NAME ${CPACK_PACKAGE_NAME}-${VERSION})
 LIST(APPEND PACKAGE_DEPENDENCIES libc6)
 LIST(APPEND PACKAGE_DEPENDENCIES libglib2.0-0 libstdc++6)
 LIST(APPEND PACKAGE_DEPENDENCIES "libgcc-s1 | libgcc | libgcc1")
-LIST(APPEND PACKAGE_DEPENDENCIES libminizip1 libpcre2)
+LIST(APPEND PACKAGE_DEPENDENCIES libminizip1 libpcre2-8-0)
 # from main project
 IF (${USEWX})
     find_package(wxWidgets REQUIRED core base)


### PR DESCRIPTION
#2052
В дистрибутивах возвращаются к истокам и отказываются от ложного переименования пакетов.