### PR TITLE
fix #2394: autocompletion fix

### DIFF
--- a/far2l/src/vt/vtcompletor.cpp
+++ b/far2l/src/vt/vtcompletor.cpp
@@ -169,7 +169,7 @@ bool VTCompletor::TalkWithShell(const std::string &cmd, std::string &reply, cons
 	std::string done = "K2Ld8Gfg"; // another most unique string in Universe
 	AvoidMarkerCollision(done, cmd);  // if it still not enough unique
 	AvoidMarkerCollision(begin, cmd);  // if it still not enough unique
-	begin+= '\n';
+	//begin+= '\n';
 	// dont do that: done+= '\n'; otherwise proposed command is executed, see https://github.com/elfmz/far2l/issues/1244
 
 	std::string sendline = " PS1=''; PS2=''; PS3=''; PS4=''; PROMPT_COMMAND=''";
@@ -182,6 +182,7 @@ bool VTCompletor::TalkWithShell(const std::string &cmd, std::string &reply, cons
 	sendline+= '\n';
 
 	sendline+= begin;
+	sendline+= '\n';
 	sendline+= cmd;
 	sendline+= tabs;
 	sendline+= done;


### PR DESCRIPTION
fix #2394

**TL;DR**
[Очистка](https://github.com/elfmz/far2l/blob/adca1222934b1615ccde37cf41a9fa2c3a8022b0/far2l/src/vt/vtcompletor.cpp#L243-L245) переменной reply в VTCompletor::TalkWithShell() не срабатывает из-за '\n',  [добавленного](https://github.com/elfmz/far2l/blob/adca1222934b1615ccde37cf41a9fa2c3a8022b0/far2l/src/vt/vtcompletor.cpp#L172) к магическому маркеру begin, так как в содержимом reply — "\r\n".


<details>
  <summary> <b>Подробнее ...</b> </summary>

Проблема возникает в функции [VTCompletor::TalkWithShell()](https://github.com/elfmz/far2l/blob/adca1222934b1615ccde37cf41a9fa2c3a8022b0/far2l/src/vt/vtcompletor.cpp#L163-L258), используемой двумя другими, ExpandCommand() и GetPossibilities().

В первом случае из [issue #2394](https://github.com/elfmz/far2l/issues/2394) _(с /usr/bin)_ TalkWithShell() возвращает reply с содержимым:

`\e]0;testuser@testhost:/usr/bin\e[?2004h[testuser@testhost bin]$  PS1=''; PS2=''; PS3=''; PS4=''; PROMPT_COMMAND=''; bind -f "/tmp/far2l_3e8_0/vtc_inputrc"\r\n\e[?2004l\r\e[?2004h true jkJHYvgT\r\n\e[?2004l\r\e[?2004h/usr/`

Во втором случае _(с bind)_:

`\e]0;testuser@testhost:~\e[?2004h[testuser@testhost ~]$  PS1=''; PS2=''; PS3=''; PS4=''; PROMPT_COMMAND=''; bind -f "/tmp/far2l_3e8_0/vtc_inputrc"\r\n\e[?2004l\r\e[?2004h true jkJHYvgT\r\n\e[?2004l\r\e[?2004hbind `

И ExpandCommand(), и GetPossibilities() начинают искать "команду" с самого начала строки reply:
https://github.com/elfmz/far2l/blob/adca1222934b1615ccde37cf41a9fa2c3a8022b0/far2l/src/vt/vtcompletor.cpp#L267
https://github.com/elfmz/far2l/blob/adca1222934b1615ccde37cf41a9fa2c3a8022b0/far2l/src/vt/vtcompletor.cpp#L313

И находят — но не ту, что нужно. Первой оказывается подстрока, содержащая путь текущей панели или часть служебной последовательности команд. В итоге в автодополнение улетает весь этот "мусор".

Фрагмент кода в функции TalkWithShell(), призванный обрезать начало reply по конец [магического маркера](https://github.com/elfmz/far2l/blob/adca1222934b1615ccde37cf41a9fa2c3a8022b0/far2l/src/vt/vtcompletor.cpp#L168) " true jkJHYvgT"
https://github.com/elfmz/far2l/blob/adca1222934b1615ccde37cf41a9fa2c3a8022b0/far2l/src/vt/vtcompletor.cpp#L243-L245
не срабатывает, поскольку в строке 
https://github.com/elfmz/far2l/blob/adca1222934b1615ccde37cf41a9fa2c3a8022b0/far2l/src/vt/vtcompletor.cpp#L172
мы присоединили к нему "\n", а в reply у нас "\r\n". Поэтому функция TalkWithShell() возвращает вызывающим её функциям не очищенную переменную reply.

Так как переменная begin используется только в двух местах — при [формировании](https://github.com/elfmz/far2l/blob/adca1222934b1615ccde37cf41a9fa2c3a8022b0/far2l/src/vt/vtcompletor.cpp#L184) строки sendline и при собственно [очистке](https://github.com/elfmz/far2l/blob/adca1222934b1615ccde37cf41a9fa2c3a8022b0/far2l/src/vt/vtcompletor.cpp#L243-L246) переменной reply, — можно убрать `begin+= '\n';` и компенсировать явным добавлением `sendline+= '\n';`.

</details>






