### PR TITLE
fix #2425: autocomplete garbage if show-all-if-ambiguous is On

### DIFF
--- a/far2l/src/vt/vtcompletor.cpp
+++ b/far2l/src/vt/vtcompletor.cpp
@@ -27,7 +27,9 @@ static const char *vtc_inputrc = "set completion-query-items 0\n"
 	"set colored-completion-prefix off\n"
 	"set page-completions off\n"
 	"set colored-stats off\n"
-	"set colored-completion-prefix off\n";
+	"set colored-completion-prefix off\n"
+	"set show-all-if-ambiguous off\n"
+	"set show-all-if-unmodified off\n";
 
 std::string VTSanitizeHistcontrol();
 
@@ -169,7 +171,6 @@ bool VTCompletor::TalkWithShell(const std::string &cmd, std::string &reply, cons
 	std::string done = "K2Ld8Gfg"; // another most unique string in Universe
 	AvoidMarkerCollision(done, cmd);  // if it still not enough unique
 	AvoidMarkerCollision(begin, cmd);  // if it still not enough unique
-	//begin+= '\n';
 	// dont do that: done+= '\n'; otherwise proposed command is executed, see https://github.com/elfmz/far2l/issues/1244
 
 	std::string sendline = " PS1=''; PS2=''; PS3=''; PS4=''; PROMPT_COMMAND=''";


### PR DESCRIPTION
fix #2425

Согласно [readline(3)](https://www.man7.org/linux/man-pages/man3/readline.3.html):

>  show-all-if-ambiguous (Off)
> 
> This alters the default behavior of the completion functions. If set to On, words which have more than one possible completion cause the matches to be listed immediately instead of ringing the bell. 
>  
>  show-all-if-unmodified (Off)
> 
> This alters the default behavior of the completion functions in a fashion similar to show-all-if-ambiguous. If set to On, words which have more than one possible completion without any possible partial completion (the possible completions don't share a common prefix) cause the matches to be listed immediately instead of ringing the bell.

Код far2l не рассчитан на работу с такими настройками. Метод VTCompletor::ExpandCommand() [посылает](https://github.com/elfmz/far2l/blob/0b7aba47162be7e53eac9fb787bd743c79fb1045/far2l/src/vt/vtcompletor.cpp#L269) один `<Tab>` и ожидает, максимум, автодополнения команды до точки, где есть неоднозначность (а не весь возможный список сразу). В случае VTCompletor::GetPossibilities() ситуация похожая, там `<Tab>` [посылается](https://github.com/elfmz/far2l/blob/0b7aba47162be7e53eac9fb787bd743c79fb1045/far2l/src/vt/vtcompletor.cpp#L311) дважды, результатом чего будет список с дубликатами.