### PR TITLE
fix #2430: Incorrect files processing in far2l command line

### DIFF
--- a/far2l/src/main.cpp
+++ b/far2l/src/main.cpp
@@ -263,14 +263,14 @@ static int MainProcess(FARString strEditViewArg, FARString strDestName1, FARStri
 						AnotherPanel->SetFocus();
 						CtrlObject->CmdLine->ExecString(strDestName2, 0);
 						ActivePanel->SetFocus();
-					} else {
+					} /* else {
 						strPath = strDestName2;
 
 						if (!strPath.IsEmpty()) {
 							if (AnotherPanel->GoToFile(strPath))
 								AnotherPanel->ProcessKey(KEY_CTRLPGDN);
 						}
-					}
+					} */
 				}
 
 				ActivePanel->GetCurDir(strCurDir);
@@ -278,14 +278,14 @@ static int MainProcess(FARString strEditViewArg, FARString strDestName1, FARStri
 
 				if (IsPluginPrefixPath(strDestName1)) {
 					CtrlObject->CmdLine->ExecString(strDestName1, 0);
-				} else {
+				} /* else {
 					strPath = strDestName1;
 
 					if (!strPath.IsEmpty()) {
 						if (ActivePanel->GoToFile(strPath))
 							ActivePanel->ProcessKey(KEY_CTRLPGDN);
 					}
-				}
+				} */
 
 				// !!! ВНИМАНИЕ !!!
 				// Сначала редравим пассивную панель, а потом активную!

--- a/far2l/src/main.cpp
+++ b/far2l/src/main.cpp
@@ -138,6 +138,40 @@ static FARString ReconstructCommandLine(int argc, char **argv)
 	return cmd;
 }
 
+static void UpdatePathOptions(const FARString &strDestName, bool IsActivePanel)
+{
+	FARString *outFolder, *outCurFile;
+
+	// Та панель, которая имеет фокус - активна (начнем по традиции с Левой Панели ;-)
+	if ((IsActivePanel && Opt.LeftPanel.Focus) || (!IsActivePanel && !Opt.LeftPanel.Focus)) {
+		Opt.LeftPanel.Type = FILE_PANEL;  // сменим моду панели
+		Opt.LeftPanel.Visible = TRUE;     // и включим ее
+		outFolder = &Opt.strLeftFolder;
+		outCurFile = &Opt.strLeftCurFile;
+	}
+	else {
+		Opt.RightPanel.Type = FILE_PANEL;
+		Opt.RightPanel.Visible = TRUE;
+		outFolder = &Opt.strRightFolder;
+		outCurFile = &Opt.strRightCurFile;
+	}
+
+	auto Attr = apiGetFileAttributes(strDestName);
+	if (Attr != INVALID_FILE_ATTRIBUTES) {
+		if (Attr & FILE_ATTRIBUTE_DIRECTORY) {
+			outCurFile->Clear();
+			*outFolder = strDestName;
+		}
+		else {
+			*outCurFile = PointToName(strDestName);
+			*outFolder = strDestName;
+			CutToSlash(*outFolder, true);
+			if (outFolder->IsEmpty())
+				*outFolder = L"/";
+		}
+	}
+}
+
 static int MainProcess(FARString strEditViewArg, FARString strDestName1, FARString strDestName2,
 		int StartLine, int StartChar)
 {
@@ -202,46 +236,12 @@ static int MainProcess(FARString strEditViewArg, FARString strDestName1, FARStri
 
 			// воспользуемся тем, что ControlObject::Init() создает панели
 			// юзая Opt.*
-			if (strDestName1.GetLength())		// актиная панель
+			if (strDestName1.GetLength())  // активная панель
 			{
-				Opt.SetupArgv++;
-				strPath = strDestName1;
+				UpdatePathOptions(strDestName1, true);
 
-				if (strPath != "/") {
-					DeleteEndSlash(strPath);	// BUGBUG!! если конечный слешь не убрать - получаем забавный эффект - отсутствует ".."
-				}
-
-				// Та панель, которая имеет фокус - активна (начнем по традиции с Левой Панели ;-)
-				if (Opt.LeftPanel.Focus) {
-					Opt.LeftPanel.Type = FILE_PANEL;	// сменим моду панели
-					Opt.LeftPanel.Visible = TRUE;		// и включим ее
-					Opt.strLeftFolder = strPath;
-				} else {
-					Opt.RightPanel.Type = FILE_PANEL;
-					Opt.RightPanel.Visible = TRUE;
-					Opt.strRightFolder = strPath;
-				}
-
-				if (strDestName2.GetLength())		// пассивная панель
-				{
-					Opt.SetupArgv++;
-					strPath = strDestName2;
-
-					if (strPath != "/") {
-						DeleteEndSlash(strPath);	// BUGBUG!! если конечный слешь не убрать - получаем забавный эффект - отсутствует ".."
-					}
-
-					// а здесь с точнотью наоборот - обрабатываем пассивную панель
-					if (Opt.LeftPanel.Focus) {
-						Opt.RightPanel.Type = FILE_PANEL;	// сменим моду панели
-						Opt.RightPanel.Visible = TRUE;		// и включим ее
-						Opt.strRightFolder = strPath;
-					} else {
-						Opt.LeftPanel.Type = FILE_PANEL;
-						Opt.LeftPanel.Visible = TRUE;
-						Opt.strLeftFolder = strPath;
-					}
-				}
+				if (strDestName2.GetLength())  // пассивная панель
+					UpdatePathOptions(strDestName2, false);
 			}
 
 			// теперь все готово - создаем панели!

--- a/far2l/src/main.cpp
+++ b/far2l/src/main.cpp
@@ -263,7 +263,7 @@ static int MainProcess(FARString strEditViewArg, FARString strDestName1, FARStri
 						AnotherPanel->SetFocus();
 						CtrlObject->CmdLine->ExecString(strDestName2, 0);
 						ActivePanel->SetFocus();
-					} /* else {
+					} /* else { // positioning on the file in UpdatePathOptions() is enough
 						strPath = strDestName2;
 
 						if (!strPath.IsEmpty()) {
@@ -278,7 +278,7 @@ static int MainProcess(FARString strEditViewArg, FARString strDestName1, FARStri
 
 				if (IsPluginPrefixPath(strDestName1)) {
 					CtrlObject->CmdLine->ExecString(strDestName1, 0);
-				} /* else {
+				} /* else { // positioning on the file in UpdatePathOptions() is enough
 					strPath = strDestName1;
 
 					if (!strPath.IsEmpty()) {


### PR DESCRIPTION
fix #2430

Решение позаимствовано из far2m: [1](https://github.com/shmuz/far2m/blob/5d26f64bd8f05ea284e5195d27aeeb4216635fc6/far/src/main.cpp#L137-L169) [2](https://github.com/shmuz/far2m/blob/5d26f64bd8f05ea284e5195d27aeeb4216635fc6/far/src/main.cpp#L246-L252)

Поскольку текущий файл на панели теперь устанавливается в функции `UpdatePathOptions()` через `Opt.strLeftCurFile`/`Opt.strRightCurFile`, ветки с вызовом `GoToFile()` стали неактуальными и (возможно временно) закомментированы. 
Также под раздачу попал вызов `ProcessKey(KEY_CTRLPGDN)` в этих же ветках. 
Не уверен, стоит ли его оставлять. Inside по `Ctrl+PgDn` будет пытаться также зайти, например, в elf-ы вместо простого позиционирования на выполняемом файле. Не уверен, что это то, что нужно.