### PR TITLE
fix #2410, Strange behavior for NumEnter (screen redraw issue)

### DIFF
--- a/far2l/src/console/scrbuf.hpp
+++ b/far2l/src/console/scrbuf.hpp
@@ -92,3 +92,12 @@ public:
 };
 
 extern ScreenBuf ScrBuf;
+
+class UnlockScreen
+{
+private:
+	int Count;
+public:
+	UnlockScreen() : Count(ScrBuf.GetLockCount()) { ScrBuf.Unlock(); }
+	~UnlockScreen() { ScrBuf.SetLockCount(Count); }
+};

--- a/far2l/src/execute.cpp
+++ b/far2l/src/execute.cpp
@@ -309,6 +309,7 @@ static int farExecuteASynched(const char *CmdStr, unsigned int ExecFlags)
 		}
 
 	} else {
+		UnlockScreen Unlock;
 		FarExecuteScope fes((ExecFlags & EF_NOCMDPRINT) ? "" : CmdStr);
 		r = VTShell_Execute(CmdStr, (ExecFlags & EF_SUDO) != 0, (ExecFlags & EF_MAYBGND) != 0, may_notify);
 	}


### PR DESCRIPTION
fix #2410
Решение позаимствовано у https://github.com/shmuz/far2m/commit/1a24cc0f5dca06ae40a3398c14c2a90879bed9f1, за исключением макроса [SCOPED_ACTION](https://github.com/shmuz/far2m/blob/5d26f64bd8f05ea284e5195d27aeeb4216635fc6/far/src/headers.hpp#L179-L187), его пока перетягивать не стал, хотя можно и подумать. Макрос, в свою очередь, пришел из FAR3.