### PR TITLE
wxGetKeyState() fails to return correct Alt state under X11 in some cases

### DIFF
--- a/WinPort/src/Backend/WX/wxMain.cpp
+++ b/WinPort/src/Backend/WX/wxMain.cpp
@@ -1304,7 +1304,7 @@ void WinPortPanel::OnKeyDown( wxKeyEvent& event )
 	// also it didnt cause problems yet
 	if ( (_key_tracker.Shift() && !event.ShiftDown())
 		|| ((_key_tracker.LeftControl() || _key_tracker.RightControl()) && !event.ControlDown())) {
-		if (_key_tracker.CheckForSuddenModifiersUp()) {
+		if ((!_key_tracker.Alt() || g_wayland) && _key_tracker.CheckForSuddenModifiersUp()) {
 			_exclusive_hotkeys.Reset();
 		}
 	}
@@ -1438,7 +1438,7 @@ void WinPortPanel::OnKeyUp( wxKeyEvent& event )
 #endif
 		wxConsoleInputShim::Enqueue(&ir, 1);
 	}
-	if (_key_tracker.CheckForSuddenModifiersUp()) {
+	if ((!_key_tracker.Alt() || g_wayland) && _key_tracker.CheckForSuddenModifiersUp()) {
 		_exclusive_hotkeys.Reset();
 	}
 	//event.Skip();


### PR DESCRIPTION
 At least in Cinnamon and KDE.

Btw, [according to docs](https://docs.wxwidgets.org/3.2/group__group__funcmacro__misc.html#ga82a18ac43492bfb375604c41b71ce84f), it should not work under X11 at all. See #2294 for details.

Fixes #2294.