### PR TITLE
fix #2476

### DIFF
--- a/WinPort/src/Backend/TTY/TTYInputSequenceParser.cpp
+++ b/WinPort/src/Backend/TTY/TTYInputSequenceParser.cpp
@@ -179,7 +179,7 @@ TTYInputSequenceParser::TTYInputSequenceParser(ITTYInputSpecialSequenceHandler *
 	AddStrF1F5(VK_F2, "Q"); AddStr(VK_F2, 0, "[[B");
 	AddStrF1F5(VK_F3, "R"); AddStr(VK_F3, 0, "[[C");
 	AddStrF1F5(VK_F4, "S"); AddStr(VK_F4, 0, "[[D");
-	AddStrF1F5(VK_F5, "E"); AddStr(VK_F5, 0, "[[E");
+	AddStrF1F5(VK_CLEAR, "E"); AddStr(VK_CLEAR, 0, "[[E"); // NumPad center (5)
 
 	AddStrTilde(VK_HOME, 1);
 	AddStrTilde(VK_INSERT, 2);

--- a/WinPort/src/Backend/TTY/TTYInputSequenceParserExts.cpp
+++ b/WinPort/src/Backend/TTY/TTYInputSequenceParserExts.cpp
@@ -345,7 +345,7 @@ size_t TTYInputSequenceParser::TryParseAsKittyEscapeSequence(const char *s, size
 			ir.Event.KeyEvent.dwControlKeyState |= ENHANCED_KEY; break;
 		case 'D': ir.Event.KeyEvent.wVirtualKeyCode = VK_LEFT;
 			ir.Event.KeyEvent.dwControlKeyState |= ENHANCED_KEY; break;
-		case 'E': ir.Event.KeyEvent.wVirtualKeyCode = VK_NUMPAD5; break;
+		case 'E': ir.Event.KeyEvent.wVirtualKeyCode = VK_CLEAR; break; // NumPad center (5)
 		case 'H': ir.Event.KeyEvent.wVirtualKeyCode = VK_HOME;
 			ir.Event.KeyEvent.dwControlKeyState |= ENHANCED_KEY; break;
 		case 'F': ir.Event.KeyEvent.wVirtualKeyCode = VK_END;

--- a/WinPort/src/Backend/WX/wxMain.cpp
+++ b/WinPort/src/Backend/WX/wxMain.cpp
@@ -1242,6 +1242,35 @@ char* FormatWxKeyState(uint16_t state) {
 	return buffer;
 }
 
+bool isNumpadNumericKey(int keycode)
+{
+	switch (keycode) {
+		case WXK_NUMPAD0:
+		case WXK_NUMPAD1:
+		case WXK_NUMPAD2:
+		case WXK_NUMPAD3:
+		case WXK_NUMPAD4:
+		case WXK_NUMPAD5:
+		case WXK_NUMPAD6:
+		case WXK_NUMPAD7:
+		case WXK_NUMPAD8:
+		case WXK_NUMPAD9:
+		case WXK_NUMPAD_INSERT:
+		case WXK_NUMPAD_END:
+		case WXK_NUMPAD_DOWN:
+		case WXK_NUMPAD_PAGEDOWN:
+		case WXK_NUMPAD_LEFT:
+		case 0x17F: // numpad center
+		case WXK_NUMPAD_RIGHT:
+		case WXK_NUMPAD_HOME:
+		case WXK_NUMPAD_UP:
+		case WXK_NUMPAD_PAGEUP:
+			return true;
+		default:
+			return false;
+	}
+}
+
 void WinPortPanel::OnKeyDown( wxKeyEvent& event )
 {
 	ResetTimerIdling();
@@ -1304,7 +1333,7 @@ void WinPortPanel::OnKeyDown( wxKeyEvent& event )
 	// also it didnt cause problems yet
 	if ( (_key_tracker.Shift() && !event.ShiftDown())
 		|| ((_key_tracker.LeftControl() || _key_tracker.RightControl()) && !event.ControlDown())) {
-		if ((!_key_tracker.Alt() || _key_tracker.Shift() || g_wayland) && // workaround for #2294, 2464
+		if ((!_key_tracker.Alt() || _key_tracker.Shift() || !isNumpadNumericKey(event.GetKeyCode()) || g_wayland) && // workaround for #2294, 2464
 			_key_tracker.CheckForSuddenModifiersUp()) {
 				_exclusive_hotkeys.Reset();
 		}
@@ -1454,7 +1483,7 @@ void WinPortPanel::OnKeyUp( wxKeyEvent& event )
 		}
 
 	}
-	if ((!_key_tracker.Alt() || _key_tracker.Shift() || g_wayland) && // workaround for #2294, 2464
+	if ((!_key_tracker.Alt() || _key_tracker.Shift() || !isNumpadNumericKey(event.GetKeyCode()) || g_wayland) && // workaround for #2294, 2464
 		_key_tracker.CheckForSuddenModifiersUp()) {
 			_exclusive_hotkeys.Reset();
 	}

--- a/WinPort/src/Backend/WX/wxMain.cpp
+++ b/WinPort/src/Backend/WX/wxMain.cpp
@@ -1333,9 +1333,12 @@ void WinPortPanel::OnKeyDown( wxKeyEvent& event )
 	// also it didnt cause problems yet
 	if ( (_key_tracker.Shift() && !event.ShiftDown())
 		|| ((_key_tracker.LeftControl() || _key_tracker.RightControl()) && !event.ControlDown())) {
-		if ((!_key_tracker.Alt() || _key_tracker.Shift() || !isNumpadNumericKey(event.GetKeyCode()) || g_wayland) && // workaround for #2294, 2464
-			_key_tracker.CheckForSuddenModifiersUp()) {
-				_exclusive_hotkeys.Reset();
+
+		if ((!_key_tracker.Alt() || _key_tracker.Shift() || _key_tracker.LeftControl() || _key_tracker.RightControl()
+			|| !isNumpadNumericKey(event.GetKeyCode()) || g_wayland) && // workaround for #2294, 2464
+
+				_key_tracker.CheckForSuddenModifiersUp()) {
+					_exclusive_hotkeys.Reset();
 		}
 	}
 
@@ -1483,9 +1486,11 @@ void WinPortPanel::OnKeyUp( wxKeyEvent& event )
 		}
 
 	}
-	if ((!_key_tracker.Alt() || _key_tracker.Shift() || !isNumpadNumericKey(event.GetKeyCode()) || g_wayland) && // workaround for #2294, 2464
-		_key_tracker.CheckForSuddenModifiersUp()) {
-			_exclusive_hotkeys.Reset();
+	if ((!_key_tracker.Alt() || _key_tracker.Shift() || _key_tracker.LeftControl() || _key_tracker.RightControl()
+		|| !isNumpadNumericKey(event.GetKeyCode()) || g_wayland) && // workaround for #2294, 2464
+
+			_key_tracker.CheckForSuddenModifiersUp()) {
+				_exclusive_hotkeys.Reset();
 	}
 	//event.Skip();
 }

--- a/WinPort/src/Backend/WX/wxMain.cpp
+++ b/WinPort/src/Backend/WX/wxMain.cpp
@@ -1260,7 +1260,7 @@ bool isNumpadNumericKey(int keycode)
 		case WXK_NUMPAD_DOWN:
 		case WXK_NUMPAD_PAGEDOWN:
 		case WXK_NUMPAD_LEFT:
-		case 0x17F: // numpad center
+		case WXK_NUMPAD_BEGIN: // NumPad center (5)
 		case WXK_NUMPAD_RIGHT:
 		case WXK_NUMPAD_HOME:
 		case WXK_NUMPAD_UP:

--- a/WinPort/src/Backend/WX/wxMain.cpp
+++ b/WinPort/src/Backend/WX/wxMain.cpp
@@ -1271,6 +1271,21 @@ bool isNumpadNumericKey(int keycode)
 	}
 }
 
+bool isLayoutDependentKey( wxKeyEvent& event ) {
+	switch (event.GetKeyCode()) {
+		// Those keys generate Unicode key codes, but they are not keyboard layout-dependent keys
+		case WXK_ESCAPE:
+		case WXK_DELETE:
+		case WXK_BACK:
+		case WXK_TAB:
+		case WXK_RETURN:
+		case WXK_SPACE:
+			return false;
+		default:
+			return event.GetUnicodeKey() > 0;
+	}
+}
+
 void WinPortPanel::OnKeyDown( wxKeyEvent& event )
 {
 	ResetTimerIdling();
@@ -1375,7 +1390,7 @@ void WinPortPanel::OnKeyDown( wxKeyEvent& event )
 	if ( (dwMods != 0 && event.GetUnicodeKey() < 32)
 		|| ((dwMods & (LEFT_CTRL_PRESSED | RIGHT_CTRL_PRESSED | LEFT_ALT_PRESSED))
 #ifndef __WXOSX__
-			&& (g_wayland || !event.AltDown() || !event.GetUnicodeKey()) // workaround for wx issue #23421
+			&& (g_wayland || !event.AltDown() || !isLayoutDependentKey(event)) // workaround for wx issue #23421
 #endif
 			)
 		|| event.GetKeyCode() == WXK_DELETE || event.GetKeyCode() == WXK_RETURN
@@ -1478,7 +1493,7 @@ void WinPortPanel::OnKeyUp( wxKeyEvent& event )
 #endif
 
 #ifndef __WXOSX__
-		if (g_wayland || !event.AltDown() || !event.GetUnicodeKey()) { // workaround for wx issue #23421
+		if (g_wayland || !event.AltDown() || !isLayoutDependentKey(event)) { // workaround for wx issue #23421
 #else
 		{
 #endif

--- a/WinPort/src/Backend/WX/wxMain.h
+++ b/WinPort/src/Backend/WX/wxMain.h
@@ -97,6 +97,7 @@ class WinPortPanel: public wxPanel, protected IConsoleOutputBackend
 	unsigned char _force_size_on_paint_state{0};
 	bool _extra_refresh{false};
 	bool _last_keydown_enqueued{false};
+	bool _enqueued_in_onchar{false};
 	bool _app_entry_started{false};
 	bool _adhoc_quickedit{false};
 	enum


### PR DESCRIPTION
Фикс для ввода кода символа через Alt+цифры теперь применяется только к цифрам NumPad'а — должно убрать риск глюков в других местах.

И заодно поправил 5 на NumPad'е в kitty — без NumLock эта кнопка не работала на ввод кода символа.