### PR TITLE
Localize usage of recent workarounds

### DIFF
--- a/WinPort/src/Backend/TTY/TTYInputSequenceParser.cpp
+++ b/WinPort/src/Backend/TTY/TTYInputSequenceParser.cpp
@@ -179,7 +179,7 @@ TTYInputSequenceParser::TTYInputSequenceParser(ITTYInputSpecialSequenceHandler *
 	AddStrF1F5(VK_F2, "Q"); AddStr(VK_F2, 0, "[[B");
 	AddStrF1F5(VK_F3, "R"); AddStr(VK_F3, 0, "[[C");
 	AddStrF1F5(VK_F4, "S"); AddStr(VK_F4, 0, "[[D");
-	AddStrF1F5(VK_F5, "E"); AddStr(VK_F5, 0, "[[E");
+	AddStrF1F5(VK_CLEAR, "E"); AddStr(VK_CLEAR, 0, "[[E"); // NumPad center (5)
 
 	AddStrTilde(VK_HOME, 1);
 	AddStrTilde(VK_INSERT, 2);

--- a/WinPort/src/Backend/TTY/TTYInputSequenceParserExts.cpp
+++ b/WinPort/src/Backend/TTY/TTYInputSequenceParserExts.cpp
@@ -345,7 +345,7 @@ size_t TTYInputSequenceParser::TryParseAsKittyEscapeSequence(const char *s, size
 			ir.Event.KeyEvent.dwControlKeyState |= ENHANCED_KEY; break;
 		case 'D': ir.Event.KeyEvent.wVirtualKeyCode = VK_LEFT;
 			ir.Event.KeyEvent.dwControlKeyState |= ENHANCED_KEY; break;
-		case 'E': ir.Event.KeyEvent.wVirtualKeyCode = VK_NUMPAD5; break;
+		case 'E': ir.Event.KeyEvent.wVirtualKeyCode = VK_CLEAR; break; // NumPad center (5)
 		case 'H': ir.Event.KeyEvent.wVirtualKeyCode = VK_HOME;
 			ir.Event.KeyEvent.dwControlKeyState |= ENHANCED_KEY; break;
 		case 'F': ir.Event.KeyEvent.wVirtualKeyCode = VK_END;

--- a/WinPort/src/Backend/WX/wxMain.cpp
+++ b/WinPort/src/Backend/WX/wxMain.cpp
@@ -1393,7 +1393,7 @@ void WinPortPanel::OnKeyDown( wxKeyEvent& event )
 	if ( (dwMods != 0 && event.GetUnicodeKey() < 32)
 		|| ((dwMods & (LEFT_CTRL_PRESSED | RIGHT_CTRL_PRESSED | LEFT_ALT_PRESSED))
 #ifndef __WXOSX__
-			&& (g_wayland || !event.AltDown() || !isLayoutDependentKey(event)) // workaround for wx issue #23421
+			&& (/*g_wayland ||*/ !event.AltDown() || !isLayoutDependentKey(event)) // workaround for wx issue #23421
 #endif
 			)
 		|| event.GetKeyCode() == WXK_DELETE || event.GetKeyCode() == WXK_RETURN
@@ -1503,7 +1503,7 @@ void WinPortPanel::OnKeyUp( wxKeyEvent& event )
 #endif
 
 #ifndef __WXOSX__
-		if (g_wayland || !event.AltDown() || !isLayoutDependentKey(event)) { // workaround for wx issue #23421
+		if (/*g_wayland ||*/ !event.AltDown() || !isLayoutDependentKey(event)) { // workaround for wx issue #23421
 #else
 		{
 #endif

--- a/WinPort/src/Backend/WX/wxMain.cpp
+++ b/WinPort/src/Backend/WX/wxMain.cpp
@@ -1392,7 +1392,7 @@ void WinPortPanel::OnKeyDown( wxKeyEvent& event )
 
 	if ( (dwMods != 0 && event.GetUnicodeKey() < 32)
 		|| ((dwMods & (LEFT_CTRL_PRESSED | RIGHT_CTRL_PRESSED | LEFT_ALT_PRESSED))
-#if !defined(__WXOSX__) && wxCHECK_VERSION(3, 2, 3) && !wxCHECK_VERSION(3, 2 ,6)
+#if !defined(__WXOSX__) && wxCHECK_VERSION(3, 2, 3)
 
 			&& (/*g_wayland ||*/ !event.AltDown() || !isLayoutDependentKey(event)) // workaround for wx issue #23421
 #endif
@@ -1503,7 +1503,7 @@ void WinPortPanel::OnKeyUp( wxKeyEvent& event )
 		}
 #endif
 
-#if !defined(__WXOSX__) && wxCHECK_VERSION(3, 2, 3) && !wxCHECK_VERSION(3, 2 ,6)
+#if !defined(__WXOSX__) && wxCHECK_VERSION(3, 2, 3)
 		if (/*g_wayland ||*/ !event.AltDown() || !isLayoutDependentKey(event)) { // workaround for wx issue #23421
 #else
 		{
@@ -1565,7 +1565,7 @@ void WinPortPanel::OnChar( wxKeyEvent& event )
 		}
 		ir.Event.KeyEvent.uChar.UnicodeChar = event.GetUnicodeKey();
 
-#if !defined(__WXOSX__) && wxCHECK_VERSION(3, 2, 3) && !wxCHECK_VERSION(3, 2 ,6)
+#if !defined(__WXOSX__) && wxCHECK_VERSION(3, 2, 3)
 		if (event.AltDown()) {
 
 			// workaround for wx issue #23421

--- a/WinPort/src/Backend/WX/wxMain.cpp
+++ b/WinPort/src/Backend/WX/wxMain.cpp
@@ -1392,7 +1392,8 @@ void WinPortPanel::OnKeyDown( wxKeyEvent& event )
 
 	if ( (dwMods != 0 && event.GetUnicodeKey() < 32)
 		|| ((dwMods & (LEFT_CTRL_PRESSED | RIGHT_CTRL_PRESSED | LEFT_ALT_PRESSED))
-#ifndef __WXOSX__
+#if !defined(__WXOSX__) && wxCHECK_VERSION(3, 2, 3) && !wxCHECK_VERSION(3, 2 ,6)
+
 			&& (/*g_wayland ||*/ !event.AltDown() || !isLayoutDependentKey(event)) // workaround for wx issue #23421
 #endif
 			)
@@ -1502,7 +1503,7 @@ void WinPortPanel::OnKeyUp( wxKeyEvent& event )
 		}
 #endif
 
-#ifndef __WXOSX__
+#if !defined(__WXOSX__) && wxCHECK_VERSION(3, 2, 3) && !wxCHECK_VERSION(3, 2 ,6)
 		if (/*g_wayland ||*/ !event.AltDown() || !isLayoutDependentKey(event)) { // workaround for wx issue #23421
 #else
 		{
@@ -1564,6 +1565,7 @@ void WinPortPanel::OnChar( wxKeyEvent& event )
 		}
 		ir.Event.KeyEvent.uChar.UnicodeChar = event.GetUnicodeKey();
 
+#if !defined(__WXOSX__) && wxCHECK_VERSION(3, 2, 3) && !wxCHECK_VERSION(3, 2 ,6)
 		if (event.AltDown()) {
 
 			// workaround for wx issue #23421
@@ -1577,6 +1579,7 @@ void WinPortPanel::OnChar( wxKeyEvent& event )
 
 			ir.Event.KeyEvent.dwControlKeyState |= LEFT_ALT_PRESSED;
 		}
+#endif
 
 		ir.Event.KeyEvent.bKeyDown = TRUE;
 		wxConsoleInputShim::Enqueue(&ir, 1);

--- a/WinPort/src/Backend/WX/wxMain.cpp
+++ b/WinPort/src/Backend/WX/wxMain.cpp
@@ -1242,6 +1242,50 @@ char* FormatWxKeyState(uint16_t state) {
 	return buffer;
 }
 
+bool isNumpadNumericKey(int keycode)
+{
+	switch (keycode) {
+		case WXK_NUMPAD0:
+		case WXK_NUMPAD1:
+		case WXK_NUMPAD2:
+		case WXK_NUMPAD3:
+		case WXK_NUMPAD4:
+		case WXK_NUMPAD5:
+		case WXK_NUMPAD6:
+		case WXK_NUMPAD7:
+		case WXK_NUMPAD8:
+		case WXK_NUMPAD9:
+		case WXK_NUMPAD_INSERT:
+		case WXK_NUMPAD_END:
+		case WXK_NUMPAD_DOWN:
+		case WXK_NUMPAD_PAGEDOWN:
+		case WXK_NUMPAD_LEFT:
+		case WXK_NUMPAD_BEGIN: // NumPad center (5)
+		case WXK_NUMPAD_RIGHT:
+		case WXK_NUMPAD_HOME:
+		case WXK_NUMPAD_UP:
+		case WXK_NUMPAD_PAGEUP:
+			return true;
+		default:
+			return false;
+	}
+}
+
+bool isLayoutDependentKey( wxKeyEvent& event ) {
+	switch (event.GetKeyCode()) {
+		// Those keys generate Unicode key codes, but they are not keyboard layout-dependent keys
+		case WXK_ESCAPE:
+		case WXK_DELETE:
+		case WXK_BACK:
+		case WXK_TAB:
+		case WXK_RETURN:
+		case WXK_SPACE:
+			return false;
+		default:
+			return event.GetUnicodeKey() > 0;
+	}
+}
+
 void WinPortPanel::OnKeyDown( wxKeyEvent& event )
 {
 	ResetTimerIdling();
@@ -1304,9 +1348,15 @@ void WinPortPanel::OnKeyDown( wxKeyEvent& event )
 	// also it didnt cause problems yet
 	if ( (_key_tracker.Shift() && !event.ShiftDown())
 		|| ((_key_tracker.LeftControl() || _key_tracker.RightControl()) && !event.ControlDown())) {
-		if ((!_key_tracker.Alt() || _key_tracker.Shift() || g_wayland) && // workaround for #2294, 2464
-			_key_tracker.CheckForSuddenModifiersUp()) {
-				_exclusive_hotkeys.Reset();
+
+		if (
+#ifndef __WXOSX__
+			(!_key_tracker.Alt() || _key_tracker.Shift() || _key_tracker.LeftControl() || _key_tracker.RightControl()
+			|| !isNumpadNumericKey(event.GetKeyCode()) || g_wayland) && // workaround for #2294, 2464
+#endif
+
+				_key_tracker.CheckForSuddenModifiersUp()) {
+					_exclusive_hotkeys.Reset();
 		}
 	}
 
@@ -1343,7 +1393,7 @@ void WinPortPanel::OnKeyDown( wxKeyEvent& event )
 	if ( (dwMods != 0 && event.GetUnicodeKey() < 32)
 		|| ((dwMods & (LEFT_CTRL_PRESSED | RIGHT_CTRL_PRESSED | LEFT_ALT_PRESSED))
 #ifndef __WXOSX__
-			&& (g_wayland || !event.AltDown() || !event.GetUnicodeKey()) // workaround for wx issue #23421
+			&& (g_wayland || !event.AltDown() || !isLayoutDependentKey(event)) // workaround for wx issue #23421
 #endif
 			)
 		|| event.GetKeyCode() == WXK_DELETE || event.GetKeyCode() == WXK_RETURN
@@ -1369,6 +1419,8 @@ void WinPortPanel::OnKeyDown( wxKeyEvent& event )
 	}
 #endif
 
+	_enqueued_in_onchar = false;
+
 	event.Skip();
 }
 
@@ -1383,6 +1435,11 @@ void WinPortPanel::OnKeyUp( wxKeyEvent& event )
 		uni, (uni > 0x1f) ? uni : L' ', event.GetTimestamp());
 
 	_exclusive_hotkeys.OnKeyUp(event);
+
+	if (_enqueued_in_onchar) {
+		_enqueued_in_onchar = false;
+		return;
+	}
 
 	if (event.GetSkipped()) {
 		fprintf(stderr, " SKIPPED\n");
@@ -1446,7 +1503,7 @@ void WinPortPanel::OnKeyUp( wxKeyEvent& event )
 #endif
 
 #ifndef __WXOSX__
-		if (g_wayland || !event.AltDown() || !event.GetUnicodeKey()) { // workaround for wx issue #23421
+		if (g_wayland || !event.AltDown() || !isLayoutDependentKey(event)) { // workaround for wx issue #23421
 #else
 		{
 #endif
@@ -1454,9 +1511,14 @@ void WinPortPanel::OnKeyUp( wxKeyEvent& event )
 		}
 
 	}
-	if ((!_key_tracker.Alt() || _key_tracker.Shift() || g_wayland) && // workaround for #2294, 2464
-		_key_tracker.CheckForSuddenModifiersUp()) {
-			_exclusive_hotkeys.Reset();
+	if (
+#ifndef __WXOSX__
+		(!_key_tracker.Alt() || _key_tracker.Shift() || _key_tracker.LeftControl() || _key_tracker.RightControl()
+		|| !isNumpadNumericKey(event.GetKeyCode()) || g_wayland) && // workaround for #2294, 2464
+#endif
+
+			_key_tracker.CheckForSuddenModifiersUp()) {
+				_exclusive_hotkeys.Reset();
 	}
 	//event.Skip();
 }
@@ -1521,7 +1583,8 @@ void WinPortPanel::OnChar( wxKeyEvent& event )
 		
 		ir.Event.KeyEvent.bKeyDown = FALSE;
 		wxConsoleInputShim::Enqueue(&ir, 1);
-		
+
+		_enqueued_in_onchar = true;
 	}
 	//event.Skip();
 }

--- a/WinPort/src/Backend/WX/wxMain.cpp
+++ b/WinPort/src/Backend/WX/wxMain.cpp
@@ -1392,7 +1392,7 @@ void WinPortPanel::OnKeyDown( wxKeyEvent& event )
 
 	if ( (dwMods != 0 && event.GetUnicodeKey() < 32)
 		|| ((dwMods & (LEFT_CTRL_PRESSED | RIGHT_CTRL_PRESSED | LEFT_ALT_PRESSED))
-#if !defined(__WXOSX__) && wxCHECK_VERSION(3, 2, 3)
+#if !defined(__WXOSX__) && wxCHECK_VERSION(3, 2, 3) // workaround is still needed at least in wx 3.2.6, see wx issue #24772
 
 			&& (/*g_wayland ||*/ !event.AltDown() || !isLayoutDependentKey(event)) // workaround for wx issue #23421
 #endif

--- a/WinPort/src/Backend/WX/wxMain.h
+++ b/WinPort/src/Backend/WX/wxMain.h
@@ -97,6 +97,7 @@ class WinPortPanel: public wxPanel, protected IConsoleOutputBackend
 	unsigned char _force_size_on_paint_state{0};
 	bool _extra_refresh{false};
 	bool _last_keydown_enqueued{false};
+	bool _enqueued_in_onchar{false};
 	bool _app_entry_started{false};
 	bool _adhoc_quickedit{false};
 	enum


### PR DESCRIPTION
Фикс для ввода кода символа через Alt+цифры теперь применяется только к цифрам NumPad'а — должно убрать риск глюков в других местах.

А обход неправильной раскладки клавиатуры для Alt+букв — только для клавиш, которые вводят буквы, и только на версиях wx, где оно надо. А ещё этот баг проявляется и на Wayland тоже, так что убрал лишнее условие про него.

И заодно поправил 5 на NumPad'е в kitty — без NumLock эта кнопка не работала на ввод кода символа.