### PR TITLE
Fix redraw in filtered menu (see Mantis 0001794)

### DIFF
--- a/far2l/src/vmenu.cpp
+++ b/far2l/src/vmenu.cpp
@@ -1584,6 +1584,7 @@ void VMenu::DrawEdges()
 {
 	if (!CheckFlags(VMENU_DISABLEDRAWBACKGROUND) && !CheckFlags(VMENU_LISTBOX)) {
 		if (BoxType == SHORT_DOUBLE_BOX || BoxType == SHORT_SINGLE_BOX) {
+			SetScreen(X1, Y1, X2, Y2, L' ', Colors[VMenuColorBody]);
 			Box(X1, Y1, X2, Y2, Colors[VMenuColorBox], BoxType);
 
 			if (!CheckFlags(VMENU_LISTBOX | VMENU_ALWAYSSCROLLBAR)) {


### PR DESCRIPTION
Fix redraw in filtered menu (see Mantis [#0001794](https://bugs.farmanager.com/view.php?id=0001794))
from https://github.com/shmuz/far2m/commit/c0778ae8a9952677e5c0cca548a6a54520803f8f