### PR TITLE
ps.sh: improve posix sh compatibility

### DIFF
--- a/far2l/bootstrap/ps.sh
+++ b/far2l/bootstrap/ps.sh
@@ -22,8 +22,8 @@ else
 		N=$(printf '\e[0m')
 		echo "It is recommended to install <${B}htop${N}> utility."
 		echo "Without <${B}htop${N}> installed far2l will use <${B}top${N}>."
-		echo "Press any key to continue..."
-		read -r -n 1 k <&1
+		echo "Press Enter to continue..."
+		read k
 		touch ~/.config/far2l/ps.warned
 	fi
 	top


### PR DESCRIPTION
`read -n` is not supported in dash (Ubuntu's default) and is undefined in posix sh.

Another option was to change the shebang to bash (and leave the ability to interrupt the pause by pressing any key, not just `<Enter>`). But I think a more universal solution would be preferable.