### PR TITLE
Fix CtrlAdd/AltAdd in consistency with full view mode (LeftCtrl-3)

### DIFF
--- a/far2l/src/panels/filelist.cpp
+++ b/far2l/src/panels/filelist.cpp
@@ -3297,30 +3297,46 @@ long FileList::SelectFiles(int Mode, const wchar_t *Mask)
 	CurPtr = ListData[CurFile];
 	FARString strCurName = CurPtr->strName;
 
+	bool SkipPath = false;
+
 	if (Mode == SELECT_ADDEXT || Mode == SELECT_REMOVEEXT) {
+		if (strCurName == L"..")
+			return 0;
+		strCurName = PointToName(strCurName);
 		size_t pos;
 
-		if (strCurName.RPos(pos, L'.')) {
+		if (strCurName.RPos(pos, L'.') && pos != strCurName.GetLength() - 1 &&  pos != 0) {
 			// Учтем тот момент, что расширение может содержать символы-разделители
-			strRawMask.Format(L"\"*.%ls\"", strCurName.CPtr() + pos + 1);
+			strRawMask.Format(L"\"?*.%ls\"", strCurName.CPtr() + pos + 1);
 			WrapBrackets = true;
-		} else {
-			strMask = L"*.";
-		}
 
+		} else {
+			// file without extension, e.g.: "readme", ".readme" & "readme."
+			strMask = L"/^(?:[^.]+|\\.[^.]+|.+\\.)$/";
+		}
+		SkipPath = true;
 		Mode = (Mode == SELECT_ADDEXT) ? SELECT_ADD : SELECT_REMOVE;
 	} else {
 		if (Mode == SELECT_ADDNAME || Mode == SELECT_REMOVENAME) {
-			// Учтем тот момент, что имя может содержать символы-разделители
-			strRawMask = L"\"";
-			strRawMask+= strCurName;
+			if (strCurName == L"..")
+				return 0;
+			strCurName = PointToName(strCurName);
+
 			size_t pos;
 
-			if (strRawMask.RPos(pos, L'.') && pos != strRawMask.GetLength() - 1)
-				strRawMask.Truncate(pos);
+			if (strCurName.RPos(pos, L'.') && pos != strCurName.GetLength() - 1 &&  pos != 0) {
+				strCurName.Truncate(pos);
+			}
 
-			strRawMask+= L".*\"";
-			WrapBrackets = true;
+			auto fName = EscapeCmdStr(strCurName.CPtr(), L".^$*+-?()[]{}\\|");    // special PCRE characters
+
+			strMask.Format(L"/^%ls(?:\\.[^.]+)", fName.c_str());
+			if (!strCurName.RPos(pos, '.') || (pos == 0 || pos == strCurName.GetLength() - 1)) {
+				strMask += L"?";  // allow empty extension
+			}
+			strMask += L"$/";
+			if (!Opt.PanelCaseSensitiveCompareSelect) strMask+=L"i";
+			SkipPath = true;
 			Mode = (Mode == SELECT_ADDNAME) ? SELECT_ADD : SELECT_REMOVE;
 		} else {
 			if (Mode == SELECT_ADD || Mode == SELECT_REMOVE) {
@@ -3405,7 +3421,8 @@ long FileList::SelectFiles(int Mode, const wchar_t *Mask)
 				if (bUseFilter)
 					Match = Filter.FileInFilter(*CurPtr);
 				else {
-					Match = FileMask.Compare(CurPtr->strName, !Opt.PanelCaseSensitiveCompareSelect);
+					// TODO: uncomment ", SkipPath" after merging https://github.com/elfmz/far2l/pull/2452
+					Match = FileMask.Compare(CurPtr->strName, !Opt.PanelCaseSensitiveCompareSelect /*, SkipPath*/);
 				}
 			}
 

--- a/far2l/src/panels/filelist.cpp
+++ b/far2l/src/panels/filelist.cpp
@@ -3330,12 +3330,12 @@ long FileList::SelectFiles(int Mode, const wchar_t *Mask)
 
 			auto fName = EscapeCmdStr(strCurName.CPtr(), L".^$*+-?()[]{}\\|");    // special PCRE characters
 
-			strMask.Format(L"/^%ls(?:\\.[^.]+)", fName.c_str());
-			if (!strCurName.RPos(pos, '.') || (pos == 0 || pos == strCurName.GetLength() - 1)) {
-				strMask += L"?";  // allow empty extension
-			}
-			strMask += L"$/";
-			if (!Opt.PanelCaseSensitiveCompareSelect) strMask+=L"i";
+			bool allowEmptyExtension = (!strCurName.RPos(pos, '.') || (pos == 0 || pos == strCurName.GetLength() - 1));
+			bool caseSensitive = Opt.PanelCaseSensitiveCompareSelect;
+
+			strMask.Format(L"/^%ls(?:\\.[^.]+)%ls$/", fName.c_str(), allowEmptyExtension ? L"?" : L"");
+			if (!caseSensitive) strMask+=L"i";
+
 			SkipPath = true;
 			Mode = (Mode == SELECT_ADDNAME) ? SELECT_ADD : SELECT_REMOVE;
 		} else {
@@ -3421,8 +3421,9 @@ long FileList::SelectFiles(int Mode, const wchar_t *Mask)
 				if (bUseFilter)
 					Match = Filter.FileInFilter(*CurPtr);
 				else {
-					// TODO: uncomment ", SkipPath" after merging https://github.com/elfmz/far2l/pull/2452
-					Match = FileMask.Compare(CurPtr->strName, !Opt.PanelCaseSensitiveCompareSelect /*, SkipPath*/);
+					// TODO: change Compare call after merging https://github.com/elfmz/far2l/pull/2452 :
+					// Match = FileMask.Compare(CurPtr->strName, !Opt.PanelCaseSensitiveCompareSelect, SkipPath);
+					Match = FileMask.Compare(CurPtr->strName, !Opt.PanelCaseSensitiveCompareSelect);
 				}
 			}
 


### PR DESCRIPTION
Исправляет поведение функционала, описанного в помощи —

>    Ctrl-<Gray +> и Ctrl-<Gray -> выбирают или снимают пометку со всех файлов с тем же расширением, что и у файла под курсором.
>     Alt-<Gray +> и Alt-<Gray -> выбирают или снимают пометку со всех файлов с тем же именем, что и у файла под курсором.

— в соответствии с тем, как far2l показывает имена и расширения файлов, скажем в **Полном режиме просмотра** (`ЛевыйCtrl-3`). В частности, файлы "readme", ".readme" и "readme." интерпретируются как файлы без расширений.

Вот, например, несколько "странностей", наблюдающихся сейчас:

1. `Ctrl-<Gray +>` по родительской папке ".." пометит, скажем, файлы "..." или "foobar." 
2. `Alt-<Gray +>` по родительской папке ".." пометит  "...txt".
3. `Alt-<Gray +>` по файлу "script" пометит файлы "script.py" и "script.sh", но не сам файл "script".
4. `Alt-<Gray +>` по файлу "help.txt" зачем-то помечает "help.rus.pdf" (хотя у него имя "help.rus"), но при этом игнорирует файл "help" без расширения.
5. `Alt-<Gray +>` по файлу ".bash_history" помечает так же ".bash_profile", ".fonts.conf", ".viminfo" и т.д., хотя это всё файлы с разными именами.
6. `Ctrl-<Gray +>` по файлу "foo" пометит только файлы, оканчивающиеся на точку, например, "foo.", но не другие файлы без расширений, например "bar".

После принятия PR https://github.com/elfmz/far2l/pull/2452 нужно будет изменить помеченный // TODO вызов  FileMask.Compare() для корректной работы на временной панели (так как PR бэкпортирует https://github.com/shmuz/far2m/commit/73eab7d065dddbb35ea81d5a628609e9645a836f по мотивам Mantis [#0001801](https://bugs.farmanager.com/view.php?id=0001801)).
