### PR TITLE
Crash on overflow when searching in a large file

### DIFF
--- a/far2l/src/editor.cpp
+++ b/far2l/src/editor.cpp
@@ -50,6 +50,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "syslog.hpp"
 #include "interf.hpp"
 #include "message.hpp"
+#include "mix.hpp"
 #include "clipboard.hpp"
 #include "xlat.hpp"
 #include "datetime.hpp"
@@ -3427,7 +3428,7 @@ BOOL Editor::Search(int Next)
 				SetCursorType(FALSE, -1);
 				int Total = ReverseSearch ? StartLine : NumLastLine - StartLine;
 				int Current = abs(NewNumLine - StartLine);
-				EditorShowMsg(Msg::EditSearchTitle, Msg::EditSearchingFor, strMsgStr, Current * 100 / Total);
+				EditorShowMsg(Msg::EditSearchTitle, Msg::EditSearchingFor, strMsgStr, ToPercent64(Current, Total));
 
 				if (CheckForEscSilent()) {
 					if (ConfirmAbortOp()) {
@@ -6246,7 +6247,7 @@ void Editor::EditorShowMsg(const wchar_t *Title, const wchar_t *Msg, const wchar
 {
 	FARString strProgress;
 
-	if (Percent != -1) {
+	if (Percent > -1) {
 		FormatString strPercent;
 		strPercent << Percent;
 


### PR DESCRIPTION
around line number 21475226 which gives integer overflow when multiplied by 100

```
Process 23391 stopped
* thread #8, stop reason = EXC_BAD_ACCESS (code=1, address=0x0)
    frame #0: 0x000000010031a21c far2l`FARString::Content::Create(nCapacity=184467440737095499) at FARString.cpp:125:19
   122 		Content *out = (Content *)malloc(sizeof(Content) + sizeof(wchar_t) * nCapacity);
   123 		//Так как ни где выше в коде мы не готовы на случай что памяти не хватит
   124 		//то уж лучше и здесь не проверять, а сразу падать
-> 125 		out->m_nRefCount = 1;
   126 		out->m_nCapacity = (unsigned int)std::min(nCapacity, (size_t)std::numeric_limits<unsigned int>::max());
   127 		out->m_nLength = 0;
   128 		out->m_Data[0] = 0;
Target 0: (far2l) stopped.
(lldb) bt
* thread #8, stop reason = EXC_BAD_ACCESS (code=1, address=0x0)
  * frame #0: 0x000000010031a21c far2l`FARString::Content::Create(nCapacity=184467440737095499) at FARString.cpp:125:19
    frame #1: 0x000000010031af2c far2l`FARString::Replace(this=0x00000001701cacf8, Pos=0, Len=0, Ch=L'█', Count=184467440737095499) at FARString.cpp:293:22
    frame #2: 0x00000001000a84f4 far2l`FARString::Append(this=0x00000001701cacf8, Ch=L'█', Count=184467440737095499) at FARString.hpp:173:59
    frame #3: 0x0000000100119414 far2l`Editor::EditorShowMsg(Title=L"Search", Msg=L"Searching for", Name=L"\"user= \"", Percent=-47) at editor.cpp:6259:15
    frame #4: 0x0000000100115e94 far2l`Editor::Search(this=0x000000012b20c530, Next=0) at editor.cpp:3430:5
    frame #5: 0x0000000100110964 far2l`Editor::ProcessKey(this=0x000000012b20c530, Key=2097270) at editor.cpp:1874:9
```