### PR TITLE
inside: add PE format

### DIFF
--- a/inside/configs/plug/config.ini
+++ b/inside/configs/plug/config.ini
@@ -56,6 +56,9 @@ Info.txt=exiftool $F
 ASCIIArt.txt=jp2a $F
 ASCIIArt.ans=jp2a --colors $F
 
+[PNG]
+Info.txt=exiftool $F
+
 [MP3]
 Info.txt=exiftool $F
 
@@ -67,3 +70,11 @@ Info.txt=exiftool $F
 
 [WV]
 Info.txt=exiftool $F
+
+[OGG]
+Info.txt=exiftool $F
+mediainfo.txt=mediainfo $F
+
+[M4A]
+Info.txt=exiftool $F
+mediainfo.txt=mediainfo $F

--- a/inside/configs/plug/config.ini
+++ b/inside/configs/plug/config.ini
@@ -6,6 +6,9 @@ ProgramHeaders.txt=readelf -W -l $F
 Symbols.txt=nm $F
 SymbolsDynamic.txt=nm --dynamic $F
 
+[PE]
+Info.txt=readpe -A $F
+
 [Disasm_20]
 PPC.s=powerpc-linux-gnu-objdump -d -w -z $F
 PPC_VLE.s=powerpc-eabivle-objdump -d -w -z $F

--- a/inside/src/inside.cpp
+++ b/inside/src/inside.cpp
@@ -79,13 +79,17 @@ static const char *DetectPlainKind(const char *Name, const unsigned char *Data, 
 		&& ext && (strcasecmp(ext, ".jpg") == 0 || strcasecmp(ext, ".jpeg") == 0)) {
 			return "JPG";
 
+	} else if (DataSize >= 8 && Data[0] == 0x89 && Data[1] == 0x50 && Data[2] == 0x4e && Data[3] == 0x47
+		&& ext && strcasecmp(ext, ".png") == 0) {
+		return "PNG";
+
 	} else if (DataSize >= 8 && Data[0] == 'A' && Data[1] == 'T' && Data[2] == '&' && Data[3] == 'T'
 		&& Data[4] == 'F' && Data[5] == 'O' && Data[6] == 'R' && Data[7] == 'M'
 		&& ext && strcasecmp(ext, ".djvu") == 0) { // Ensure
-
 		return "DJVU";
 
-	} else if (DataSize >= 8 && ext && strcasecmp(ext, ".mp3") == 0) {
+	} else if (DataSize >= 8 && Data[0] == 0x49 && Data[1] == 0x44 && Data[2] == 0x33
+		&& ext && strcasecmp(ext, ".mp3") == 0) {
 		return "MP3";
 
 	} else if (DataSize >= 8 && Data[0] == 'M' && Data[1] == 'A' && Data[2] == 'C'
@@ -99,6 +103,15 @@ static const char *DetectPlainKind(const char *Name, const unsigned char *Data, 
 	} else if (DataSize >= 8 && Data[0] == 'f' && Data[1] == 'L' && Data[2] == 'a' && Data[3] == 'C'
 		&& ext && strcasecmp(ext, ".flac") == 0) {
 		return "FLAC";
+
+	} else if (DataSize >= 8 && Data[0] == 'O' && Data[1] == 'g' && Data[2] == 'g' && Data[3] == 'S'
+		&& ext && (strcasecmp(ext, ".ogg") == 0 || strcasecmp(ext, ".oga") == 0 || strcasecmp(ext, ".opus") == 0)) {
+		return "OGG";
+
+	} else if (DataSize >= 12 && memcmp(Data + 4, "ftypM4A ", 8) == 0
+		&& ext && strcasecmp(ext, ".m4a") == 0) {
+		return "M4A";
+
 	} else if (DataSize >= 4 && Data[0] == 0x4d && Data[1] == 0x5a
 		&& ext && (strcasecmp(ext, ".exe") == 0 || strcasecmp(ext, ".dll") == 0 || strcasecmp(ext, ".sys") == 0
 			|| strcasecmp(ext, ".drv") == 0 || strcasecmp(ext, ".ocx") == 0 || strcasecmp(ext, ".efi") == 0)) {

--- a/inside/src/inside.cpp
+++ b/inside/src/inside.cpp
@@ -99,6 +99,10 @@ static const char *DetectPlainKind(const char *Name, const unsigned char *Data, 
 	} else if (DataSize >= 8 && Data[0] == 'f' && Data[1] == 'L' && Data[2] == 'a' && Data[3] == 'C'
 		&& ext && strcasecmp(ext, ".flac") == 0) {
 		return "FLAC";
+	} else if (DataSize >= 4 && Data[0] == 0x4d && Data[1] == 0x5a
+		&& ext && (strcasecmp(ext, ".exe") == 0 || strcasecmp(ext, ".dll") == 0 || strcasecmp(ext, ".sys") == 0
+			|| strcasecmp(ext, ".drv") == 0 || strcasecmp(ext, ".ocx") == 0 || strcasecmp(ext, ".efi") == 0)) {
+		return "PE";
 	}
 
 	return nullptr;


### PR DESCRIPTION
It would be useful to support reading PE format. [readpe](https://repology.org/project/readpe/versions) is available in debian/ubuntu.
Also added for png, ogg, m4a.