### PR TITLE
tmppanel: fix PANIC-PANIC crash in menu from file list

### DIFF
--- a/tmppanel/src/TmpPanel.cpp
+++ b/tmppanel/src/TmpPanel.cpp
@@ -360,14 +360,17 @@ void ReadFileLines(int fd, DWORD FileSizeLow, TCHAR **argv, TCHAR *args, UINT *n
 			for (int i = 0; i < argc; ++i) {
 				TCHAR *param, *p = TMP;
 				ExpandEnvStrs(argv[i], TMP);
-				param = ParseParam(p);
-				FSF.TruncStr(param ? param : p, 67);
+				param =  ParseParam(p);
+				if (!param) {
+					param = p;
+				}
 
-			    fmi[i].Text = wcsdup(param ? param : p);
-
-				fmi[i].Separator = !lstrcmp(param, _T("-"));
+				FSF.TruncStr(param, 67);
+				fmi[i].Text = wcsdup(param);
+				fmi[i].Separator = !lstrcmp(param, L"-");
 				fmi[i].Selected = FALSE;
 				fmi[i].Checked = FALSE;
+
 			}
 			//    fmi[0].Selected=TRUE;
 
@@ -389,9 +392,10 @@ void ReadFileLines(int fd, DWORD FileSizeLow, TCHAR **argv, TCHAR *args, UINT *n
 			free(fmi);
 
 			if ((unsigned)ExitCode < (unsigned)argc) {
-				ExpandEnvStrs(argv[ExitCode], TMP);
-				TCHAR *p = TMP;
+				TCHAR *p = argv[ExitCode];
 				ParseParam(p);
+				ExpandEnvStrs(p, TMP);
+				p = TMP;
 
 				FAR_FIND_DATA FindData;
 				int bShellExecute = BreakCode != -1;
@@ -445,7 +449,7 @@ void ReadFileLines(int fd, DWORD FileSizeLow, TCHAR **argv, TCHAR *args, UINT *n
 			return hPlugin;
 		} else {
 			ShowMenuFromList(pName);
-			return INVALID_HANDLE_VALUE;
+			return ((HANDLE)-2);
 		}
 #undef pName
 	}


### PR DESCRIPTION
Фикс функционала "Меню из файла-списка".

<details>
  <summary>Из справки.</summary>
<hr>
<p>При открытии файла списка его содержимое будет помещаться не в панель, а в меню. Нажатие Enter на каком-либо пункте меню либо переходит в соответствующий каталог (если он существует), либо копирует текст пункта в командную строку FAR. Заголовок меню равен имени файла-списка без расширения.</p>
<p>Каждая строка в файле-списке может начинаться на |&lt;string&gt;|. В таком случае отображаться в меню будет часть строки с первого до второго разделительного символа, а выполняться при выборе пункта - часть строки после второго разделительного символа.</p>
<p>|-| служит разделителем и будет отображаться в меню как горизонтальная линия.</p>
<hr>
</details>

1. В lstrcmp первым аргументом передавался param со значением nullptr, из-за чего far2l падал в PANIC-PANIC.
2. Не разворачивались переменные среды для строк, содержащих|&lt;string&gt;|.
3. После закрытия меню делалась попытка запуска файла списка.