### PR TITLE
tmppanel: fix #2518: missing null-terminator + fix free call with garbage argument + fix memory leak

### DIFF
--- a/tmppanel/src/TmpClass.cpp
+++ b/tmppanel/src/TmpClass.cpp
@@ -484,8 +484,11 @@ bool TmpPanel::IsCurrentFileCorrect(TCHAR **pCurFileName)
 	if (lstrcmp(CurFileName, _T("..")) == 0) {
 		IsCorrectFile = true;
 	} else {
-		FAR_FIND_DATA TempFindData;
+		FAR_FIND_DATA TempFindData = {};
 		IsCorrectFile = GetFileInfoAndValidate(CurFileName, &TempFindData, FALSE);
+		if (TempFindData.lpwszFileName) {
+			free((void *)TempFindData.lpwszFileName);
+		}
 	}
 
 	if (pCurFileName) {

--- a/tmppanel/src/TmpPanel.cpp
+++ b/tmppanel/src/TmpPanel.cpp
@@ -95,11 +95,15 @@ SHAREDSYMBOL HANDLE WINAPI EXP_NAME(OpenPlugin)(int OpenFrom, INT_PTR Item)
 
 			StrBuf tmpTMP(k + 1);
 			TCHAR *TMP = tmpTMP;
-			lstrcpyn(TMP, argv - k, k + 1);
+			lstrcpyn(TMP, argv - k, k);
+			TMP[k] = L'\0';
 
-			for (int i = 0; i < OPT_COUNT; i++)
-				if (lstrcmpi(TMP + 1, ParamsStr[i]) == 0)
+			for (int i = 0; i < OPT_COUNT; i++) {
+				if (lstrcmpi(TMP + 1, ParamsStr[i]) == 0) {
 					*(int *)ParamsOpt[i] = *TMP == _T('+');
+					break;
+				}
+			}
 
 			if (*(TMP + 1) >= _T('0') && *(TMP + 1) <= _T('9'))
 				CurrentCommonPanel = *(TMP + 1) - _T('0');


### PR DESCRIPTION
fix #2518 

Источником проблемы является фрагмент:

https://github.com/elfmz/far2l/blob/63ae9f69971be435945edf244cc124225057b8db/tmppanel/src/TmpPanel.cpp#L96-L102

В `tmpTMP` копируется подстрока из `argv`, не содержащая завершающий `'\0'` (на его месте — пробел). Это приводит к некорректному сравнению функцией `lstrcmpi` из-за выхода за пределы буфера.

<hr>

Дополнительно исправлена проблема, возникающая по причине [передачи](https://github.com/elfmz/far2l/blob/63ae9f69971be435945edf244cc124225057b8db/tmppanel/src/TmpClass.cpp#L487-L488) в метод [GetFileInfoAndValidate()]( https://github.com/elfmz/far2l/blob/63ae9f69971be435945edf244cc124225057b8db/tmppanel/src/TmpClass.cpp#L772) локального экземпляра структуры [FAR_FIND_DATA](https://github.com/elfmz/far2l/blob/63ae9f69971be435945edf244cc124225057b8db/far2l/far2sdk/farplug-wide.h#L736-L750).

В редком случае (если именем файла окажется "/") будет произведена [попытка](https://github.com/elfmz/far2l/blob/63ae9f69971be435945edf244cc124225057b8db/tmppanel/src/TmpClass.cpp#L785-L791) вызова free с неинициализированным аргументом.

Кроме того, поскольку GetFileInfoAndValidate() устанавливает ([1](https://github.com/elfmz/far2l/blob/63ae9f69971be435945edf244cc124225057b8db/tmppanel/src/TmpClass.cpp#L802), [2](https://github.com/elfmz/far2l/blob/63ae9f69971be435945edf244cc124225057b8db/tmppanel/src/TmpClass.cpp#L817)) значение второго аргумента вызовом функции [WFD2FFD()](https://github.com/elfmz/far2l/blob/63ae9f69971be435945edf244cc124225057b8db/tmppanel/src/TmpMix.cpp#L127-L137), в поле `lpwszFileName` локальной переменной [TempFindData](https://github.com/elfmz/far2l/blob/63ae9f69971be435945edf244cc124225057b8db/tmppanel/src/TmpClass.cpp#L487) окажется строка с выделенной malloc'ом памятью, указатель на которую сразу же будет утерян.
