### PR TITLE
sync colorer with upstream

### DIFF
--- a/colorer/src/Colorer-library/src/CMakeLists.txt
+++ b/colorer/src/Colorer-library/src/CMakeLists.txt
@@ -80,6 +80,7 @@ set(SRC_COLORER
     colorer/parsers/VirtualEntry.h
     colorer/utils/Environment.cpp
     colorer/utils/Environment.h
+    colorer/utils/FileSystems.h
     colorer/version.h
     colorer/viewer/ParsedLineWriter.cpp
     colorer/viewer/ParsedLineWriter.h
@@ -226,11 +227,19 @@ target_include_directories(colorer_lib PUBLIC
     "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
 )
 
-set_target_properties(colorer_lib PROPERTIES
-    CXX_STANDARD 17
-    CXX_STANDARD_REQUIRED YES
-    CXX_EXTENSIONS YES
-)
+if(COLORER_BUILD_OLD_COMPILERS)
+  set_target_properties(colorer_lib PROPERTIES
+          CXX_STANDARD 17
+          CXX_STANDARD_REQUIRED YES
+          CXX_EXTENSIONS YES
+  )
+else()
+  set_target_properties(colorer_lib PROPERTIES
+          CXX_STANDARD 17
+          CXX_STANDARD_REQUIRED YES
+          CXX_EXTENSIONS NO
+  )
+endif()
 
 target_link_libraries(colorer_lib
         PUBLIC LibXml2::LibXml2

--- a/colorer/src/Colorer-library/src/colorer/base/BaseNames.h
+++ b/colorer/src/Colorer-library/src/colorer/base/BaseNames.h
@@ -6,6 +6,5 @@ const char16_t HrdClassRgb[] = u"rgb\0";
 const char16_t HrdClassText[] = u"text\0";
 
 UNICODE_LITERAL(jar, u"jar:")
-//inline const auto jar = UnicodeString(u"jar:");
 
 #endif  // COLORER_BASENAMES_H

--- a/colorer/src/Colorer-library/src/colorer/common/Logger.h
+++ b/colorer/src/Colorer-library/src/colorer/common/Logger.h
@@ -2,12 +2,11 @@
 #define COLORER_LOGGER_H
 
 #include <sstream>
-
-#if __cplusplus < 201703L
-# include <experimental/string_view>
+#if __cplusplus < 201703L && !defined(_MSC_VER)
+#include <experimental/string_view>
 namespace std
 {
-	typedef experimental::string_view string_view;
+typedef experimental::string_view string_view;
 }
 #endif
 

--- a/colorer/src/Colorer-library/src/colorer/utils/Environment.h
+++ b/colorer/src/Colorer-library/src/colorer/utils/Environment.h
@@ -4,15 +4,7 @@
 #include <regex>
 #include <vector>
 #include "colorer/Common.h"
-
-#ifdef COLORER_FEATURE_OLD_COMPILERS
-#include "colorer/platform/filesystem.hpp"
-namespace fs = ghc::filesystem;
-#else
-#include <filesystem>
-namespace fs = std::filesystem;
-#endif
-
+#include "colorer/utils/FileSystems.h"
 
 namespace colorer {
 

--- a/colorer/src/Colorer-library/src/colorer/utils/FileSystems.h
+++ b/colorer/src/Colorer-library/src/colorer/utils/FileSystems.h
@@ -1,0 +1,14 @@
+#ifndef COLORER_FILESYSTEMS_HPP
+#define COLORER_FILESYSTEMS_HPP
+
+#include <colorer/Common.h>
+
+#ifdef COLORER_FEATURE_OLD_COMPILERS
+#include "colorer/platform/filesystem.hpp"
+namespace fs = ghc::filesystem;
+#else
+#include <filesystem>
+namespace fs = std::filesystem;
+#endif
+
+#endif

--- a/colorer/src/Colorer-library/src/colorer/xml/libxml2/LibXmlReader.cpp
+++ b/colorer/src/Colorer-library/src/colorer/xml/libxml2/LibXmlReader.cpp
@@ -107,7 +107,7 @@ void LibXmlReader::getAttributes(const xmlNode* node, std::unordered_map<Unicode
 {
   for (xmlAttrPtr attr = node->properties; attr != nullptr; attr = attr->next) {
     const auto content = xmlNodeGetContent(attr->children);
-    data.emplace(std::make_pair(reinterpret_cast<const char*>(attr->name), reinterpret_cast<const char*>(content)));
+    data.emplace(reinterpret_cast<const char*>(attr->name), reinterpret_cast<const char*>(content));
     xmlFree(content);
   }
 }


### PR DESCRIPTION
Портировал к upstream Colorer-library себе изменения из 4369fb07405b2e81e0a4d92e6dcf1f44aea86bd1 , после чего проверил на разных платформах. Теперь автоматически проверяется на gcc7/clang7 , на которых ранее не собиралось.

рекоендуется применить после https://github.com/elfmz/far2l/pull/2515
