### PR TITLE
tmppanel: fixes, improvements, refactoring

### DIFF
--- a/tmppanel/src/TmpClass.cpp
+++ b/tmppanel/src/TmpClass.cpp
@@ -181,10 +181,12 @@ int TmpPanel::PutOneFile(const TCHAR *SrcPath, PluginPanelItem &PanelItem)
 	if (CurPanelItem->FindData.lpwszFileName == NULL)
 		return FALSE;
 
-	lstrcpy((TCHAR *)CurPanelItem->FindData.lpwszFileName, SrcPath);
-	if (*SrcPath) {
+	*(wchar_t*)CurPanelItem->FindData.lpwszFileName = L'\0';
+	if (*SrcPath && !wcschr(PanelItem.FindData.lpwszFileName, L'/')) {
+		lstrcpy((TCHAR *)CurPanelItem->FindData.lpwszFileName, SrcPath);
 		FSF.AddEndSlash((TCHAR *)CurPanelItem->FindData.lpwszFileName);
 	}
+
 	lstrcat((TCHAR *)CurPanelItem->FindData.lpwszFileName, PanelItem.FindData.lpwszFileName);
 	TmpItemsNumber++;
 	if (Opt.SelectedCopyContents && (CurPanelItem->FindData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY))

--- a/tmppanel/src/TmpClass.cpp
+++ b/tmppanel/src/TmpClass.cpp
@@ -664,10 +664,6 @@ void TmpPanel::ProcessSaveListKey()
 		Info.Control(PANEL_PASSIVE, FCTL_UPDATEPANEL, 0, 0);
 		Info.Control(PANEL_PASSIVE, FCTL_REDRAWPANEL, 0, 0);
 	}
-#undef _HANDLE
-#undef _UPDATE
-#undef _REDRAW
-#undef _GET
 }
 
 void TmpPanel::SaveListFile(const TCHAR *Path)
@@ -799,11 +795,11 @@ bool TmpPanel::GetFileInfoAndValidate(const TCHAR *FilePath, FAR_FIND_DATA *Find
 	StrBuf NtPath;
 	FormNtPath(FullPath, NtPath);
 
-	bool copyName = false;
+	bool Result = false;
 
 	if (!wcscmp(FileName, L"/")) {
 		FindData->dwFileAttributes = FILE_ATTRIBUTE_DIRECTORY;
-		copyName = true;
+		Result = true;
 	} else {
 		if (lstrlen(FileName)) {
 			DWORD dwAttr = GetFileAttributes(NtPath);
@@ -826,24 +822,23 @@ bool TmpPanel::GetFileInfoAndValidate(const TCHAR *FilePath, FAR_FIND_DATA *Find
 				}
 				WFD2FFD(wfd, *FindData);
 				FileName = FullPath;
-				copyName = true;
+				Result = true;
 			} else {
 				if (Any) {
 					FindData->dwFileAttributes = FILE_ATTRIBUTE_ARCHIVE;
-					copyName = true;
+					Result = true;
 				}
 			}
 		}
 	}
 
-	if (copyName) {
+	if (Result) {
 		if (FindData->lpwszFileName)
 			free((void *)FindData->lpwszFileName);
 		FindData->lpwszFileName = wcsdup(FileName);
-		return (TRUE);
 	}
 
-	return (FALSE);
+	return Result;
 }
 
 void TmpPanel::IfOptCommonPanel(void)

--- a/tmppanel/src/TmpClass.cpp
+++ b/tmppanel/src/TmpClass.cpp
@@ -484,8 +484,11 @@ bool TmpPanel::IsCurrentFileCorrect(TCHAR **pCurFileName)
 	if (lstrcmp(CurFileName, _T("..")) == 0) {
 		IsCorrectFile = true;
 	} else {
-		FAR_FIND_DATA TempFindData;
+		FAR_FIND_DATA TempFindData = {};
 		IsCorrectFile = GetFileInfoAndValidate(CurFileName, &TempFindData, FALSE);
+		if (TempFindData.lpwszFileName) {
+			free((void *)TempFindData.lpwszFileName);
+		}
 	}
 
 	if (pCurFileName) {

--- a/tmppanel/src/TmpClass.cpp
+++ b/tmppanel/src/TmpClass.cpp
@@ -7,7 +7,7 @@ Temporary panel plugin class implementation
 
 #include "TmpPanel.hpp"
 
-TmpPanel::TmpPanel()
+TmpPanel::TmpPanel(const wchar_t* pHostFile)
 {
 	LastOwnersRead = FALSE;
 	LastLinksRead = FALSE;
@@ -16,12 +16,24 @@ TmpPanel::TmpPanel()
 	TmpItemsNumber = 0;
 	PanelIndex = CurrentCommonPanel;
 	IfOptCommonPanel();
+
+
+	HostFile=nullptr;
+	if (pHostFile)
+	{
+		HostFile = (wchar_t*)malloc((wcslen(pHostFile)+1)*sizeof(wchar_t));
+		wcscpy(HostFile, pHostFile);
+	}
+
 }
 
 TmpPanel::~TmpPanel()
 {
 	if (!StartupOptCommonPanel)
 		FreePanelItems(TmpPanelItem, TmpItemsNumber);
+
+	if (HostFile)
+		free(HostFile);
 }
 
 int TmpPanel::GetFindData(PluginPanelItem **pPanelItem, int *pItemsNumber, int OpMode)
@@ -48,7 +60,7 @@ void TmpPanel::GetOpenPluginInfo(struct OpenPluginInfo *Info)
 	if (!Opt.SafeModePanel)
 		Info->Flags|= OPIF_REALNAMES;
 
-	Info->HostFile = NULL;
+	Info->HostFile=this->HostFile;
 	Info->CurDir = _T("");
 
 	Info->Format = (TCHAR *)GetMsg(MTempPanel);

--- a/tmppanel/src/TmpClass.cpp
+++ b/tmppanel/src/TmpClass.cpp
@@ -797,7 +797,6 @@ bool TmpPanel::GetFileInfoAndValidate(const TCHAR *FilePath, FAR_FIND_DATA *Find
 				WIN32_FIND_DATA wfd;
 				HANDLE fff = FindFirstFile(NtPath, &wfd);
 				if (fff != INVALID_HANDLE_VALUE) {
-					WFD2FFD(wfd, *FindData);
 					FindClose(fff);
 				} else {
 					memset(&wfd, 0, sizeof(wfd));
@@ -810,8 +809,8 @@ bool TmpPanel::GetFileInfoAndValidate(const TCHAR *FilePath, FAR_FIND_DATA *Find
 						wfd.nPhysicalSize = wfd.nFileSize = GetFileSize64(hFile);
 						CloseHandle(hFile);
 					}
-					WFD2FFD(wfd, *FindData);
 				}
+				WFD2FFD(wfd, *FindData);
 				FileName = FullPath;
 				copyName = true;
 			} else {

--- a/tmppanel/src/TmpClass.hpp
+++ b/tmppanel/src/TmpClass.hpp
@@ -33,9 +33,10 @@ private:
 	int LastOwnersRead;
 	int LastLinksRead;
 	int UpdateNotNeeded;
+	wchar_t* HostFile;
 
 public:
-	TmpPanel();
+	TmpPanel(const wchar_t *pHostFile = nullptr);
 	~TmpPanel();
 	int PanelIndex;
 	//    int OpenFrom;

--- a/tmppanel/src/TmpMix.cpp
+++ b/tmppanel/src/TmpMix.cpp
@@ -66,9 +66,6 @@ TCHAR *ParseParam(TCHAR *&str)
 
 void GoToFile(const TCHAR *Target, BOOL AnotherPanel)
 {
-#define FCTL_SetPanelDir  FCTL_SETPANELDIR
-#define FCTL_GetPanelInfo FCTL_GETPANELINFO
-#define FCTL_RedrawPanel  FCTL_REDRAWPANEL
 	HANDLE _PANEL_HANDLE = AnotherPanel ? PANEL_PASSIVE : PANEL_ACTIVE;
 
 	PanelRedrawInfo PRI;
@@ -90,25 +87,23 @@ void GoToFile(const TCHAR *Target, BOOL AnotherPanel)
 	FSF.Unquote(Dir);
 
 	if (*Dir.Ptr()) {
-		Info.Control(_PANEL_HANDLE, FCTL_SetPanelDir, 0, (LONG_PTR)Dir.Ptr());
+		Info.Control(_PANEL_HANDLE, FCTL_SETPANELDIR, 0, (LONG_PTR)Dir.Ptr());
 	}
 
-	Info.Control(_PANEL_HANDLE, FCTL_GetPanelInfo, 0, (LONG_PTR)&PInfo);
+	Info.Control(_PANEL_HANDLE, FCTL_GETPANELINFO, 0, (LONG_PTR)&PInfo);
 
 	PRI.CurrentItem = PInfo.CurrentItem;
 	PRI.TopPanelItem = PInfo.TopPanelItem;
 
 	for (int J = 0; J < PInfo.ItemsNumber; J++) {
 
-#define FileName (PPI ? PPI->FindData.lpwszFileName : NULL)
 		PluginPanelItem *PPI =
 				(PluginPanelItem *)malloc(Info.Control(_PANEL_HANDLE, FCTL_GETPANELITEM, J, 0));
 		if (PPI) {
 			Info.Control(_PANEL_HANDLE, FCTL_GETPANELITEM, J, (LONG_PTR)PPI);
 		}
 
-		if (!FSF.LStricmp(Name, FSF.PointToName(FileName)))
-#undef FileName
+		if (!FSF.LStricmp(Name, FSF.PointToName((PPI ? PPI->FindData.lpwszFileName : NULL))))
 		{
 			PRI.CurrentItem = J;
 			PRI.TopPanelItem = J;
@@ -117,11 +112,7 @@ void GoToFile(const TCHAR *Target, BOOL AnotherPanel)
 		}
 		free(PPI);
 	}
-	Info.Control(_PANEL_HANDLE, FCTL_RedrawPanel, 0, (LONG_PTR)&PRI);
-#undef _PANEL_HANDLE
-#undef FCTL_SetPanelDir
-#undef FCTL_GetPanelInfo
-#undef FCTL_RedrawPanel
+	Info.Control(_PANEL_HANDLE, FCTL_REDRAWPANEL, 0, (LONG_PTR)&PRI);
 }
 
 void WFD2FFD(WIN32_FIND_DATA &wfd, FAR_FIND_DATA &ffd)

--- a/tmppanel/src/TmpPanel.cpp
+++ b/tmppanel/src/TmpPanel.cpp
@@ -344,10 +344,10 @@ void ReadFileLines(int fd, DWORD FileSizeLow, TCHAR **argv, TCHAR *args, UINT *n
 				ExpandEnvStrs(p, TMP);
 				p = TMP;
 
-				FAR_FIND_DATA FindData = {};
 				int bShellExecute = BreakCode != -1;
 
 				if (!bShellExecute) {
+					FAR_FIND_DATA FindData = {};
 					if (TmpPanel::GetFileInfoAndValidate(p, &FindData, FALSE)) {
 						if (FindData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
 							Info.Control(INVALID_HANDLE_VALUE, FCTL_SETPANELDIR, 0, (LONG_PTR)p);
@@ -357,7 +357,6 @@ void ReadFileLines(int fd, DWORD FileSizeLow, TCHAR **argv, TCHAR *args, UINT *n
 					} else {
 						Info.Control(PANEL_ACTIVE, FCTL_SETCMDLINE, 0, (LONG_PTR)p);
 					}
-
 					if (FindData.lpwszFileName) {
 						free((void *)FindData.lpwszFileName);
 					}

--- a/tmppanel/src/TmpPanel.cpp
+++ b/tmppanel/src/TmpPanel.cpp
@@ -129,7 +129,7 @@ SHAREDSYMBOL HANDLE WINAPI EXP_NAME(OpenPlugin)(int OpenFrom, INT_PTR Item)
 						ShowMenuFromList(TmpOut);
 						return INVALID_HANDLE_VALUE;
 					} else {
-						hPlugin = new TmpPanel();
+						hPlugin = new TmpPanel(TmpOut);
 						if (hPlugin == NULL)
 							return INVALID_HANDLE_VALUE;
 
@@ -386,7 +386,7 @@ void ReadFileLines(int fd, DWORD FileSizeLow, TCHAR **argv, TCHAR *args, UINT *n
 			return INVALID_HANDLE_VALUE;
 
 		if (!Opt.MenuForFilelist) {
-			HANDLE hPlugin = new TmpPanel();
+			HANDLE hPlugin = new TmpPanel(pName);
 			if (hPlugin == NULL)
 				return INVALID_HANDLE_VALUE;
 

--- a/tmppanel/src/TmpPanel.cpp
+++ b/tmppanel/src/TmpPanel.cpp
@@ -344,19 +344,22 @@ void ReadFileLines(int fd, DWORD FileSizeLow, TCHAR **argv, TCHAR *args, UINT *n
 				ExpandEnvStrs(p, TMP);
 				p = TMP;
 
-				FAR_FIND_DATA FindData;
+				FAR_FIND_DATA FindData = {};
 				int bShellExecute = BreakCode != -1;
 
 				if (!bShellExecute) {
 					if (TmpPanel::GetFileInfoAndValidate(p, &FindData, FALSE)) {
 						if (FindData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
-						Info.Control(INVALID_HANDLE_VALUE, FCTL_SETPANELDIR, 0, (LONG_PTR)p);
+							Info.Control(INVALID_HANDLE_VALUE, FCTL_SETPANELDIR, 0, (LONG_PTR)p);
 						} else {
 							bShellExecute = TRUE;
 						}
 					} else {
+						Info.Control(PANEL_ACTIVE, FCTL_SETCMDLINE, 0, (LONG_PTR)p);
+					}
 
-					Info.Control(PANEL_ACTIVE, FCTL_SETCMDLINE, 0, (LONG_PTR)p);
+					if (FindData.lpwszFileName) {
+						free((void *)FindData.lpwszFileName);
 					}
 				}
 

--- a/tmppanel/src/TmpPanel.cpp
+++ b/tmppanel/src/TmpPanel.cpp
@@ -384,7 +384,7 @@ void ReadFileLines(int fd, DWORD FileSizeLow, TCHAR **argv, TCHAR *args, UINT *n
 	{
 	if (!Name) 
 		return INVALID_HANDLE_VALUE;
-
+	GetOptions();
 	StrBuf pName(NT_MAX_PATH);	// BUGBUG
 	lstrcpy(pName, Name);
 #define PNAME_ARG pName, pName.Size()

--- a/tmppanel/src/TmpPanel.cpp
+++ b/tmppanel/src/TmpPanel.cpp
@@ -95,11 +95,15 @@ SHAREDSYMBOL HANDLE WINAPI EXP_NAME(OpenPlugin)(int OpenFrom, INT_PTR Item)
 
 			StrBuf tmpTMP(k + 1);
 			TCHAR *TMP = tmpTMP;
-			lstrcpyn(TMP, argv - k, k + 1);
+			lstrcpyn(TMP, argv - k, k);
+			TMP[k] = L'\0';
 
-			for (int i = 0; i < OPT_COUNT; i++)
-				if (lstrcmpi(TMP + 1, ParamsStr[i]) == 0)
+			for (int i = 0; i < OPT_COUNT; i++) {
+				if (lstrcmpi(TMP + 1, ParamsStr[i]) == 0) {
 					*(int *)ParamsOpt[i] = *TMP == _T('+');
+					break;
+				}
+			}
 
 			if (*(TMP + 1) >= _T('0') && *(TMP + 1) <= _T('9'))
 				CurrentCommonPanel = *(TMP + 1) - _T('0');

--- a/tmppanel/src/TmpPanel.cpp
+++ b/tmppanel/src/TmpPanel.cpp
@@ -166,15 +166,14 @@ static HANDLE OpenPanelFromOutput(wchar_t *argv)
 
 	HANDLE hPlugin = INVALID_HANDLE_VALUE;
 
-	if (FSF.Execute(fullcmd.c_str(), flags) == 0) {
-		if (Opt.MenuForFilelist) {
-			ShowMenuFromList(tempfilename);
-		} else {
-			hPlugin = new TmpPanel();
-			if (hPlugin == NULL)
-				return INVALID_HANDLE_VALUE;
-			ProcessList(hPlugin, tempfilename, Opt.Mode);
-		}
+	FSF.Execute(fullcmd.c_str(), flags);
+	if (Opt.MenuForFilelist) {
+		ShowMenuFromList(tempfilename);
+	} else {
+		hPlugin = new TmpPanel();
+		if (hPlugin == NULL)
+			return INVALID_HANDLE_VALUE;
+		ProcessList(hPlugin, tempfilename, Opt.Mode);
 	}
 
 	DeleteFile(tempfilename);

--- a/tmppanel/src/TmpPanel.cpp
+++ b/tmppanel/src/TmpPanel.cpp
@@ -9,6 +9,7 @@ Temporary panel main plugin code
 #include <string>
 #include <sys/stat.h>
 #include <sys/mman.h>
+#include "utils.h"
 
 TCHAR *PluginRootKey;
 unsigned int CurrentCommonPanel;
@@ -359,8 +360,12 @@ void ReadFileLines(int fd, DWORD FileSizeLow, TCHAR **argv, TCHAR *args, UINT *n
 					}
 				}
 
-				if (bShellExecute)
-					fprintf(stderr, "TODO: ShellExecute: %ls\n", p);	// ShellExecute(NULL,_T("open"),p,NULL,NULL,SW_SHOW);
+				if (bShellExecute) {
+					DWORD flags = EF_OPEN | EF_NOCMDPRINT | EF_NOWAIT;
+					std::wstring cmd = p;
+					QuoteCmdArgIfNeed(cmd);
+					FSF.Execute(cmd.c_str(), flags);
+				}
 			}
 		}
 


### PR DESCRIPTION
**1.  Багфикс парсинга параметров командной строки**: fix #2518
Источником проблемы является фрагмент:
https://github.com/elfmz/far2l/blob/63ae9f69971be435945edf244cc124225057b8db/tmppanel/src/TmpPanel.cpp#L96-L102
В `tmpTMP` копируется подстрока из `argv`, не содержащая завершающий `'\0'` (на его месте — пробел). Это приводит к некорректному сравнению функцией `lstrcmpi` из-за выхода за пределы буфера.


**2. Реализован функционал OpenPanelFromOutput().**
Загрузка результатов выполнения команды во временную панель или меню, например:
`tmp:<ls -1a`
Из оригинальных фич плагина пока не реализовано произвольное задание рабочего каталога, т.е. такая команда не сработает:
`tmp:<|/bin|ls -1a`
(впрочем, описание такого синтаксиса в хелпе отсутствует).
Сделано по аналогии с https://github.com/elfmz/far2l/pull/2361.


**3. Исправлены утечки памяти и вызовы free с неинициализированным аргументом,**
возникающие при передаче ([1](https://github.com/elfmz/far2l/blob/63ae9f69971be435945edf244cc124225057b8db/tmppanel/src/TmpClass.cpp#L487-L488), [2](https://github.com/elfmz/far2l/blob/63ae9f69971be435945edf244cc124225057b8db/tmppanel/src/TmpPanel.cpp#L400-L404)) в метод [GetFileInfoAndValidate()](https://github.com/elfmz/far2l/blob/63ae9f69971be435945edf244cc124225057b8db/tmppanel/src/TmpClass.cpp#L772-L826) локального экземпляра структуры [FAR_FIND_DATA](https://github.com/elfmz/far2l/blob/63ae9f69971be435945edf244cc124225057b8db/far2l/far2sdk/farplug-wide.h#L736-L750). Поскольку GetFileInfoAndValidate() устанавливает ([1](https://github.com/elfmz/far2l/blob/63ae9f69971be435945edf244cc124225057b8db/tmppanel/src/TmpClass.cpp#L802), [2](https://github.com/elfmz/far2l/blob/63ae9f69971be435945edf244cc124225057b8db/tmppanel/src/TmpClass.cpp#L817)) значение второго аргумента вызовом функции [WFD2FFD()](https://github.com/elfmz/far2l/blob/63ae9f69971be435945edf244cc124225057b8db/tmppanel/src/TmpMix.cpp#L127-L137), в полях `lpwszFileName` локальных переменных [TempFindData](https://github.com/elfmz/far2l/blob/63ae9f69971be435945edf244cc124225057b8db/tmppanel/src/TmpClass.cpp#L487) и [FindData](https://github.com/elfmz/far2l/blob/63ae9f69971be435945edf244cc124225057b8db/tmppanel/src/TmpPanel.cpp#L400) окажутся строки с выделенной malloc'ом памятью, указатели на которые сразу же будут утеряны. В редком случае (если именем файла окажется "/") будет произведена [попытка](https://github.com/elfmz/far2l/blob/63ae9f69971be435945edf244cc124225057b8db/tmppanel/src/TmpClass.cpp#L785-L791) вызова free с неинициализированным аргументом.

**4. Реализован функционал ShellExecute** в функции [ShowMenuFromList()](https://github.com/elfmz/far2l/blob/63ae9f69971be435945edf244cc124225057b8db/tmppanel/src/TmpPanel.cpp#L416-L418) (срабатывает при нажатии `Shift+Enter`).

**5. Рефакторинг метода** [TmpPanel::GetFileInfoAndValidate()](https://github.com/elfmz/far2l/blob/63ae9f69971be435945edf244cc124225057b8db/tmppanel/src/TmpClass.cpp#L772-L826), исправлена интерпретация директории "/", удалены goto и немного сокращен код.

**6. Исправлено копирование имён файлов на панель с другой временной панели,** решение адаптировано из https://github.com/FarGroup/FarManager/commit/ce6e0ddb8d6408c291bb9b3a7b33df967f617d7c

**7. Исправлен прыжок курсора на .. после выхода из панели,** решение адаптировано из https://github.com/FarGroup/FarManager/commit/9f966d00625b90dc9fe972576d0362fa6c6be173
