### PR TITLE
tmppanel: tweak open/execute logic in ShowMenuFromList()

### DIFF
--- a/far2l/far2sdk/farplug-mb.h
+++ b/far2l/far2sdk/farplug-mb.h
@@ -1574,7 +1574,8 @@ namespace oldfar
 		EF_NOTIFY = 0x08,     // notify when command completed (if such notifications enabled in settings)
 		EF_NOCMDPRINT = 0x10, // dont print command in command line nor include it to history
 		EF_OPEN = 0x20,       // use desktop shell (if present) to open command (e.g. URLs, documents..)
-		EF_MAYBGND = 0x40     // allow put command to background mode
+		EF_MAYBGND = 0x40,     // allow put command to background mode
+		EF_EXTERNALTERM = 0x80 // execute command in configured external terminal
 	};
 
 	typedef int (WINAPI *FAREXECUTE)(const char *CmdStr, unsigned int ExecFlags);

--- a/far2l/far2sdk/farplug-wide.h
+++ b/far2l/far2sdk/farplug-wide.h
@@ -1984,7 +1984,8 @@ enum EXECUTEFLAGS
 	EF_NOTIFY = 0x08,     // notify when command completed (if such notifications enabled in settings)
 	EF_NOCMDPRINT = 0x10, // dont print command in command line nor include it to history
 	EF_OPEN = 0x20,       // use desktop shell (if present) to open command (e.g. URLs, documents..)
-	EF_MAYBGND = 0x40     // allow put command to background mode
+	EF_MAYBGND = 0x40,     // allow put command to background mode
+	EF_EXTERNALTERM = 0x80 // execute command in configured external terminal
 };
 
 typedef int (WINAPI *FAREXECUTE)(const wchar_t *CmdStr, unsigned int ExecFlags);

--- a/far2l/src/execute.cpp
+++ b/far2l/src/execute.cpp
@@ -298,6 +298,13 @@ static int farExecuteASynched(const char *CmdStr, unsigned int ExecFlags)
 		return farExecuteASynched(OpenCmd.c_str(), ExecFlags & (~EF_OPEN));
 	}
 
+	if (ExecFlags & EF_EXTERNALTERM) {
+		std::string OpenCmd = GetOpenShVerb("exec");
+		OpenCmd+= ' ';
+		OpenCmd+= CmdStr;
+		return farExecuteASynched(OpenCmd.c_str(), ExecFlags & (~EF_EXTERNALTERM));
+	}
+
 	const bool may_notify = (ExecFlags & (EF_NOTIFY | EF_NOWAIT)) == EF_NOTIFY && Opt.NotifOpt.OnConsole;
 	if (ExecFlags & (EF_HIDEOUT | EF_NOWAIT)) {
 		r = NotVTExecute(CmdStr, (ExecFlags & EF_NOWAIT) != 0, (ExecFlags & EF_SUDO) != 0);

--- a/tmppanel/src/TmpPanel.cpp
+++ b/tmppanel/src/TmpPanel.cpp
@@ -385,7 +385,7 @@ void ReadFileLines(int fd, DWORD FileSizeLow, TCHAR **argv, TCHAR *args, UINT *n
 					case ACTION_EXECUTE: {
 						std::wstring cmd = p;
 						QuoteCmdArgIfNeed(cmd);
-						FSF.Execute(cmd.c_str(), bShellExecute ? EF_NOWAIT : 0);
+						FSF.Execute(cmd.c_str(), bShellExecute ? EF_EXTERNALTERM | EF_NOCMDPRINT | EF_HIDEOUT: EF_MAYBGND);
 						break;
 					}
 

--- a/tmppanel/src/TmpPanel.cpp
+++ b/tmppanel/src/TmpPanel.cpp
@@ -341,29 +341,56 @@ void ReadFileLines(int fd, DWORD FileSizeLow, TCHAR **argv, TCHAR *args, UINT *n
 				ExpandEnvStrs(p, TMP);
 				p = TMP;
 
-				int bShellExecute = BreakCode != -1;
+				bool bShellExecute = BreakCode != -1;
 
-				if (!bShellExecute) {
-					FAR_FIND_DATA FindData = {};
-					if (TmpPanel::GetFileInfoAndValidate(p, &FindData, FALSE)) {
-						if (FindData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
-							Info.Control(INVALID_HANDLE_VALUE, FCTL_SETPANELDIR, 0, (LONG_PTR)p);
-						} else {
-							bShellExecute = TRUE;
-						}
+				enum { ACTION_NOP, ACTION_SETPANELDIR, ACTION_SETCMDLINE, ACTION_OPEN,
+					   ACTION_EXECUTE} Action = ACTION_NOP;
+
+				FAR_FIND_DATA FindData = {};
+
+				if (TmpPanel::GetFileInfoAndValidate(p, &FindData, FALSE)) {
+					if (FindData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
+						Action = bShellExecute ? ACTION_OPEN : ACTION_SETPANELDIR;
+					} else if (FindData.dwFileAttributes & FILE_ATTRIBUTE_EXECUTABLE) {
+						Action = ACTION_EXECUTE;
 					} else {
-						Info.Control(PANEL_ACTIVE, FCTL_SETCMDLINE, 0, (LONG_PTR)p);
+						Action = ACTION_OPEN;
 					}
-					if (FindData.lpwszFileName) {
-						free((void *)FindData.lpwszFileName);
-					}
+				} else {
+					Action = bShellExecute ? ACTION_OPEN : ACTION_SETCMDLINE;
 				}
 
-				if (bShellExecute) {
-					DWORD flags = EF_OPEN | EF_NOCMDPRINT | EF_NOWAIT;
-					std::wstring cmd = p;
-					QuoteCmdArgIfNeed(cmd);
-					FSF.Execute(cmd.c_str(), flags);
+				if (FindData.lpwszFileName) {
+					free((void *)FindData.lpwszFileName);
+				}
+
+				switch (Action) {
+					case ACTION_SETPANELDIR: {
+						Info.Control(INVALID_HANDLE_VALUE, FCTL_SETPANELDIR, 0, (LONG_PTR)p);
+						break;
+					}
+
+					case ACTION_SETCMDLINE: {
+						Info.Control(PANEL_ACTIVE, FCTL_SETCMDLINE, 0, (LONG_PTR)p);
+						break;
+					}
+
+					case ACTION_OPEN: {
+						std::wstring cmd = p;
+						QuoteCmdArgIfNeed(cmd);
+						FSF.Execute(cmd.c_str(), EF_OPEN | EF_NOCMDPRINT | EF_NOWAIT);
+						break;
+					}
+
+					case ACTION_EXECUTE: {
+						std::wstring cmd = p;
+						QuoteCmdArgIfNeed(cmd);
+						FSF.Execute(cmd.c_str(), bShellExecute ? EF_NOWAIT : 0);
+						break;
+					}
+
+					default:
+						;
 				}
 			}
 		}

--- a/tmppanel/src/TmpPanel.cpp
+++ b/tmppanel/src/TmpPanel.cpp
@@ -326,7 +326,7 @@ void ReadFileLines(int fd, DWORD FileSizeLow, TCHAR **argv, TCHAR *args, UINT *n
 			int BreakCode;
 			static const int BreakKeys[2] = {MAKELONG(VK_RETURN, PKF_SHIFT), 0};
 
-			int ExitCode = Info.Menu(Info.ModuleNumber, -1, -1, 0, FMENU_WRAPMODE, Title, NULL,
+			int ExitCode = Info.Menu(Info.ModuleNumber, -1, -1, 0, FMENU_WRAPMODE, Title, L"Enter Shift+Enter Esc Ctrl+Alt+F",
 					_T("Contents"), &BreakKeys[0], &BreakCode, fmi, argc);
 
 			for (int i = 0; i < argc; ++i)


### PR DESCRIPTION
tmppanel:
1. tweak open/execute logic in ShowMenuFromList()
2. added keyboard shortcut help in ShowMenuFromList() 
3. Add a new flag `EF_EXTERNALTERM` to the [EXECUTEFLAGS](https://github.com/elfmz/far2l/blob/2c03f3a1d547c1c771f1880134da6ce64630f967/far2l/far2sdk/farplug-wide.h#L1979-L1988) enum to make possible  running commands in an external terminal by invoking `open.sh` with `exec` param  within  [farExecuteASynched()](https://github.com/elfmz/far2l/blob/2c03f3a1d547c1c771f1880134da6ce64630f967/far2l/src/execute.cpp#L290-L319)