### PR TITLE
Crash on concurrent access to temp directory

### DIFF
--- a/far2l/src/findfile.cpp
+++ b/far2l/src/findfile.cpp
@@ -1173,18 +1173,16 @@ static void AnalyzeFileItem(HANDLE hDlg, PluginPanelItem *FileItem, const wchar_
 
 	FARString FileToScan;
 	if (hPlugin != INVALID_HANDLE_VALUE) {
+		PluginLocker Lock;
 		if (!CtrlObject->Plugins.UseFarCommand(hPlugin, PLUGIN_FARGETFILES)) {
 			FARString strTempDir;
 			FarMkTempEx(strTempDir);
 			apiCreateDirectory(strTempDir, nullptr);
 
 			bool GetFileResult = false;
-			{
-				PluginLocker Lock;
-				GetFileResult = CtrlObject->Plugins.GetFile(hPlugin, FileItem, strTempDir, FileToScan,
+			GetFileResult = CtrlObject->Plugins.GetFile(hPlugin, FileItem, strTempDir, FileToScan,
 										OPM_SILENT | OPM_FIND)
 						!= FALSE;
-			}
 			if (!GetFileResult) {
 				apiRemoveDirectory(strTempDir);
 				return;


### PR DESCRIPTION
Fix #2526
Crash report on Mac shows the following callstaks
```
Thread 4 Crashed:
0   libsystem_kernel.dylib        	       0x1842ce600 __pthread_kill + 8
1   libsystem_pthread.dylib       	       0x184306f70 pthread_kill + 288
2   libsystem_c.dylib             	       0x184213908 abort + 128
3   libsystem_malloc.dylib        	       0x18411d524 malloc_vreport + 896
4   libsystem_malloc.dylib        	       0x1841454a8 malloc_zone_error + 100
5   libsystem_malloc.dylib        	       0x18414433c free_tiny_botch + 40
6   far2l                         	       0x100dfe060 PluginA::FreeOpenPluginInfo() + 56 (PluginA.cpp:998)
7   far2l                         	       0x100e02128 PluginA::ConvertOpenPluginInfo(oldfar::OpenPluginInfo&, OpenPluginInfo*) + 36 (PluginA.cpp:1034)
8   far2l                         	       0x100e02498 PluginA::GetOpenPluginInfo(void*, OpenPluginInfo*) + 140 (PluginA.cpp:1090)
9   far2l                         	       0x100de0fb0 PluginManager::GetOpenPluginInfo(void*, OpenPluginInfo*) + 104 (plugins.cpp:953)
10  far2l                         	       0x100c7e184 GetPluginFile(unsigned long, FAR_FIND_DATA_EX const&, wchar_t const*, FARString&) + 112 (findfile.cpp:973)
11  far2l                         	       0x100c7b240 FindDlgProc(void*, int, int, long long) + 4276 (findfile.cpp:1529)
12  far2l                         	       0x100be708c Dialog::DlgProc(void*, int, int, long long) + 220 (dialog.cpp:4692)
13  far2l                         	       0x100bee618 Dialog::ProcessKey(unsigned int) + 804 (dialog.cpp:2689)
14  far2l                         	       0x100cc5918 Manager::ProcessKey(unsigned int) + 2284 (manager.cpp:1012)
15  far2l                         	       0x100cc3930 Manager::ProcessMainLoop() + 396 (manager.cpp:742)
16  far2l                         	       0x100cc3a54 Manager::ExecuteModal(Frame*) + 272 (manager.cpp:318)
17  far2l                         	       0x100bf6dc0 Dialog::Process() + 180 (dialog.cpp:4529)
18  far2l                         	       0x100c76c70 FindFilesProcess(Vars&) + 2772 (findfile.cpp:2508)
19  far2l                         	       0x100c74b14 FindFiles::FindFiles() + 5712 (findfile.cpp:2889)
20  far2l                         	       0x100c77e98 FindFiles::FindFiles() + 28 (findfile.cpp:2691)
21  far2l                         	       0x100c77f84 FindFiles::Present() + 24 (findfile.cpp:2906)
22  far2l                         	       0x100c62324 FilePanels::ProcessKey(unsigned int) + 3916 (filepanels.cpp:689)
23  far2l                         	       0x100cc5918 Manager::ProcessKey(unsigned int) + 2284 (manager.cpp:1012)
24  far2l                         	       0x100cc3930 Manager::ProcessMainLoop() + 396 (manager.cpp:742)
25  far2l                         	       0x100cc4fcc Manager::EnterMainLoop() + 116 (manager.cpp:706)
26  far2l                         	       0x100cc0d98 MainProcess(FARString, FARString, FARString, int, int) + 2756 (main.cpp:327)
27  far2l                         	       0x100cbfc28 FarAppMain(int, char**) + 4988 (main.cpp:654)
28  far2l_gui.so                  	       0x10167f4f4 WinPortAppThread::Entry() + 52 (wxMain.cpp:81)
29  libwx_baseu-3.2.0.3.0.dylib   	       0x101a37f24 wxThreadInternal::PthreadStart(wxThread*) + 1312
30  libsystem_pthread.dylib       	       0x1843072e4 _pthread_start + 136
31  libsystem_pthread.dylib       	       0x1843020fc thread_start + 8

Thread 8:
0   libc++abi.dylib               	       0x1842c1694 DYLD-STUB$$free + 8
1   libc++.1.dylib                	       0x1842351ac std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>::~basic_string() + 36
2   far2l                         	       0x100b522fc RectifyPath(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&) + 560 (PathHelpers.cpp:77)
3   far2l                         	       0x100b52374 ConsumeWinPath(wchar_t const*) + 60 (PathHelpers.cpp:82)
4   far2l                         	       0x100b21a64 WINPORT_GetFileAttributes + 40 (APIFiles.cpp:634)
5   far2l                         	       0x100b230c0 WINPORT_GetTempFileName + 92 (APIFiles.cpp:989)
6   far2l                         	       0x100e414d0 FarMkTempEx(FARString&, wchar_t const*, int, wchar_t const*) + 404 (mix.cpp:161)
7   far2l                         	       0x100c8358c AnalyzeFileItem(void*, PluginPanelItem*, wchar_t const*, FAR_FIND_DATA_EX const&) + 744 (findfile.cpp:1178)
8   far2l                         	       0x100c82dc0 AnalyzeFileItem(void*, PluginPanelItem*, wchar_t const*, FAR_FIND_DATA const&) + 108 (findfile.cpp:1216)
9   far2l                         	       0x100c82768 ScanPluginTree(void*, void*, unsigned int, int&) + 816 (findfile.cpp:2231)
10  far2l                         	       0x100c82acc ScanPluginTree(void*, void*, unsigned int, int&) + 1684 (findfile.cpp:2258)
11  far2l                         	       0x100c82acc ScanPluginTree(void*, void*, unsigned int, int&) + 1684 (findfile.cpp:2258)
12  far2l                         	       0x100c801ac DoPreparePluginList(void*) + 552 (findfile.cpp:2346)
13  far2l                         	       0x100c83094 ArchiveSearch(void*, wchar_t const*) + 668 (findfile.cpp:2088)
14  far2l                         	       0x100c86f30 DoScanTree(void*, FARString&) + 1268 (findfile.cpp:2185)
15  far2l                         	       0x100c8054c DoPrepareFileList(void*) + 624 (findfile.cpp:2318)
16  far2l                         	       0x100c7fb64 FindFileThread::ThreadProc() + 200 (findfile.cpp:2388)
17  far2l                         	       0x100ea01cc Threaded::sThreadProc(void*) + 40 (Threaded.cpp:22)
18  libsystem_pthread.dylib       	       0x1843072e4 _pthread_start + 136
19  libsystem_pthread.dylib       	       0x1843020fc thread_start + 8

Thread 9:
0   libsystem_kernel.dylib        	       0x1842c95cc __psynch_cvwait + 8
1   libsystem_pthread.dylib       	       0x184307894 _pthread_cond_wait + 1204
2   libc++.1.dylib                	       0x18423d578 std::__1::condition_variable::wait(std::__1::unique_lock<std::__1::mutex>&) + 28
3   far2l                         	       0x100ea15a0 ThreadedWorkQueue::WorkerThreadProc() + 640 (ThreadedWorkQueue.cpp:102)
4   far2l                         	       0x100ea571c ThreadedWorker::ThreadProc() + 28 (ThreadedWorkQueue.cpp:13)
5   far2l                         	       0x100ea01cc Threaded::sThreadProc(void*) + 40 (Threaded.cpp:22)
6   libsystem_pthread.dylib       	       0x1843072e4 _pthread_start + 136
7   libsystem_pthread.dylib       	       0x1843020fc thread_start + 8
```