### PR TITLE
ConsoleInput: fix crash when dot is pressed in cyrillic layout

### DIFF
--- a/WinPort/src/ConsoleInput.cpp
+++ b/WinPort/src/ConsoleInput.cpp
@@ -304,7 +304,7 @@ void ConsoleInput::Enqueue(const INPUT_RECORD *data, DWORD size)
 				const auto uni = data[i].Event.KeyEvent.uChar.UnicodeChar;
 				fprintf(stderr, "ConsoleInput::Enqueue: %s %s \"%lc\" %s, %x %x %x %x\n",
 					FormatKeyState(data[i].Event.KeyEvent.dwControlKeyState),
-					VirtualKeyNames[data[i].Event.KeyEvent.wVirtualKeyCode],
+					data[i].Event.KeyEvent.wVirtualKeyCode < sizeof(VirtualKeyNames) / sizeof(const char*) ? VirtualKeyNames[data[i].Event.KeyEvent.wVirtualKeyCode] : "0x00",
 					(uni && (uni > 0x1f)) ? uni : L'?',
 					data[i].Event.KeyEvent.bKeyDown ? "DOWN" : "UP",
 


### PR DESCRIPTION
How to Reproduce:
FreeBSD 14.1-RELEASE-p6 amd64
Open any file in the internal editor, switch the layout to any cyrillic, type "." (the [?/] key in the latin layout), and get the application crash. The fix is quite obvious - always check array ranges before accessing an item. The patch may not be perfect (because "." is not working in cyrillic layout), but at least it prevents crashing.