### PR TITLE
NetRocks: fix incorrect password parsing in SplitLocationSpecification()

### DIFF
--- a/NetRocks/src/Protocol/SplitLocationSpecification.cpp
+++ b/NetRocks/src/Protocol/SplitLocationSpecification.cpp
@@ -45,7 +45,7 @@ bool SplitLocationSpecification(const char *specification, std::string &protocol
 		username.assign(proto_end, at - proto_end);
 		size_t up_div = username.find(':');
 		if (up_div!=std::string::npos) {
-			password = username.substr(up_div);
+			password = username.substr(up_div + 1);
 			username.resize(up_div);
 		}
 		++at;


### PR DESCRIPTION
В коде разбора URL
https://github.com/elfmz/far2l/blob/1cf67b92894cae5176e8d45c60f0bcb401d037df/NetRocks/src/Protocol/SplitLocationSpecification.cpp#L43-L50
к паролю в начале цепляется лишний символ двоеточия, из-за чего набранные в командной строке адреса вида
`ftp://johndoe:123456@192.168.1.2:12345`
вызывают показ окна авторизации с просьбой ввести логин с паролем заново.

Фикс простой, но не уверен, что какой-то другой код не полагается на такой (неправильный) парсинг.

