### PR TITLE
improvement: optional ability to use icu available on build system

### DIFF
--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -15,9 +15,17 @@ elseif("${ICU_MODE}" STREQUAL "build")
     message(STATUS "Buld-time character classes generaction due to ICU_MODE=${ICU_MODE}")
     # Not using CMAKE_CXX_COMPILER due to it can be cross-compilation but here we want to compile native executable
     # TODO: there must be some less lame way to use host's compiler and host's libicuuc
-    add_custom_target(utils_icu
-        c++ -O2 ${CMAKE_CURRENT_SOURCE_DIR}/src/CharClasses_mk.cpp -licuuc -o ${CMAKE_CURRENT_BINARY_DIR}/tmpCharClasses_mk && ${CMAKE_CURRENT_BINARY_DIR}/tmpCharClasses_mk > ${CMAKE_CURRENT_BINARY_DIR}/tmpCharClasses.cpp)
+    find_package(ICU COMPONENTS uc REQUIRED)
     set(CHAR_CLASSES_CPP ${CMAKE_CURRENT_BINARY_DIR}/tmpCharClasses.cpp)
+    add_custom_command(
+        OUTPUT ${CHAR_CLASSES_CPP}
+        COMMAND c++ ${CMAKE_CXX_FLAGS_${CMAKE_BUILD_TYPE}} ${CMAKE_CURRENT_SOURCE_DIR}/src/CharClasses_mk.cpp ${ICU_LIBRARY} -o ${CMAKE_CURRENT_BINARY_DIR}/tmpCharClasses_mk && ${CMAKE_CURRENT_BINARY_DIR}/tmpCharClasses_mk > ${CHAR_CLASSES_CPP}
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+        COMMENT ${CHAR_CLASSES_CPP}
+    )
+    add_custom_target(utils_icu
+        DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/tmpCharClasses.cpp
+    )
 
 elseif("${ICU_MODE}" STREQUAL "runtime")
     find_package(ICU COMPONENTS uc)


### PR DESCRIPTION
1. The `add_custom_target` command was replaced with `add_custom_command`.
2. ICU package is now found using `find_package(ICU COMPONENTS uc REQUIRED)`.
4. The command to generate character classes now uses ICU library (`${ICU_LIBRARY}`).

The custom target now depends on the generated character classes file, ensuring proper rebuilds when necessary.
