### PR TITLE
F5 is broken in Linux kernel console and recent KDE Konsole. This PR fixes that

### DIFF
--- a/WinPort/src/Backend/TTY/TTYInputSequenceParser.cpp
+++ b/WinPort/src/Backend/TTY/TTYInputSequenceParser.cpp
@@ -178,7 +178,7 @@ TTYInputSequenceParser::TTYInputSequenceParser(ITTYInputSpecialSequenceHandler *
 	AddStrF1F5(VK_F2, "Q"); AddStr(VK_F2, 0, "[[B");
 	AddStrF1F5(VK_F3, "R"); AddStr(VK_F3, 0, "[[C");
 	AddStrF1F5(VK_F4, "S"); AddStr(VK_F4, 0, "[[D");
-	AddStrF1F5(VK_CLEAR, "E"); AddStr(VK_CLEAR, 0, "[[E"); // NumPad center (5)
+	AddStrF1F5(VK_CLEAR, "E"); AddStr(VK_F5, 0, "[[E"); // VK_CLEAR is NumPad center (5)
 
 	AddStrTilde(VK_HOME, 1);
 	AddStrTilde(VK_INSERT, 2);


### PR DESCRIPTION
Konsole 24.12 / KDE Plasma 6.2.4 / X11 generates `\x1b[[E` on F5

Also does Linux kernel console.