### PR TITLE
TTY/VT: focus change notifications  (touch #2563)

### DIFF
--- a/WinPort/src/Backend/TTY/TTYBackend.h
+++ b/WinPort/src/Backend/TTY/TTYBackend.h
@@ -66,6 +66,7 @@ class TTYBackend : IConsoleOutputBackend, ITTYInputSpecialSequenceHandler, IFar2
 	COORD _largest_window_size{};
 	std::atomic<bool> _largest_window_size_ready{false};
 	std::atomic<bool> _flush_input_queue{false};
+	std::atomic<bool> _focused{true}; // assume starting focused
 
 	struct BI : std::mutex { std::string flavor; } _backend_info;
 
@@ -145,6 +146,7 @@ protected:
 	// ITTYInputSpecialSequenceHandler
 	virtual void OnUsingExtension(char extension);
 	virtual void OnInspectKeyEvent(KEY_EVENT_RECORD &event);
+	virtual void OnFocusChange(bool focused);
 	virtual void OnFar2lEvent(StackSerializer &stk_ser);
 	virtual void OnFar2lReply(StackSerializer &stk_ser);
 	virtual void OnInputBroken();

--- a/WinPort/src/Backend/TTY/TTYInputSequenceParser.cpp
+++ b/WinPort/src/Backend/TTY/TTYInputSequenceParser.cpp
@@ -314,6 +314,11 @@ size_t TTYInputSequenceParser::ParseEscapeSequence(const char *s, size_t l)
 	fprintf(stderr, "\n");
 	*/
 
+	if (l > 1 && s[0] == '[' && (s[1] == 'I' || s[1] == 'O')) { // focus
+		_handler->OnFocusChange(s[1] == 'I');
+		return 2;
+	}
+
 	if (l > 2 && s[0] == '[' && s[2] == 'n') {
 		return 3;
 	}

--- a/WinPort/src/Backend/TTY/TTYInputSequenceParser.h
+++ b/WinPort/src/Backend/TTY/TTYInputSequenceParser.h
@@ -67,6 +67,7 @@ struct ITTYInputSpecialSequenceHandler
 {
 	virtual void OnUsingExtension(char extension) = 0;
 	virtual void OnInspectKeyEvent(KEY_EVENT_RECORD &event) = 0;
+	virtual void OnFocusChange(bool focused) = 0;
 	virtual void OnFar2lEvent(StackSerializer &stk_ser) = 0;
 	virtual void OnFar2lReply(StackSerializer &stk_ser) = 0;
 	virtual void OnInputBroken() = 0;

--- a/WinPort/src/Backend/TTY/TTYOutput.cpp
+++ b/WinPort/src/Backend/TTY/TTYOutput.cpp
@@ -174,7 +174,8 @@ TTYOutput::TTYOutput(int out, bool far2l_tty, bool norgb, DWORD nodetect)
 	}
 #endif
 
-	Format(ESC "7" ESC "[?47h" ESC "[?1049h" ESC "[?2004h");
+	// enable mouse and focus notifications
+	Format(ESC "7" ESC "[?47h" ESC "[?1049h" ESC "[?2004h" ESC "[?1004h");
 
 	if ((_nodetect & NODETECT_W) == 0) {
 		Format(ESC "[?9001h"); // win32-input-mode on
@@ -185,6 +186,7 @@ TTYOutput::TTYOutput(int out, bool far2l_tty, bool norgb, DWORD nodetect)
 	if ((_nodetect & NODETECT_K) == 0) {
 		Format(ESC "[=15;1u"); // kovidgoyal's kitty mode on
 	}
+
 	ChangeKeypad(true);
 	ChangeMouse(true);
 
@@ -215,7 +217,7 @@ TTYOutput::~TTYOutput()
 		if ((_nodetect & NODETECT_K) == 0) {
 			Format(ESC "[=0;1u" "\r"); // kovidgoyal's kitty mode off
 		}
-		Format(ESC "[0m" ESC "[?1049l" ESC "[?47l" ESC "8" ESC "[?2004l" "\r\n");
+		Format(ESC "[0m" ESC "[?1049l" ESC "[?47l" ESC "8" ESC "[?2004l" ESC "[?1004l" "\r\n");
 		if ((_nodetect & NODETECT_W) == 0) {
 			Format(ESC "[?9001l"); // win32-input-mode off
 		}

--- a/WinPort/src/Backend/WX/wxMain.cpp
+++ b/WinPort/src/Backend/WX/wxMain.cpp
@@ -2052,15 +2052,28 @@ void WinPortPanel::CheckPutText2CLip()
 void WinPortPanel::OnSetFocus( wxFocusEvent &event )
 {
 	//fprintf(stderr, "OnSetFocus\n");
+	const bool was_focused = (_focused_ts != 0);
 	const DWORD ts = WINPORT(GetTickCount)();
 	_focused_ts = ts ? ts : 1;
 	ResetTimerIdling();
+	if (!was_focused) {
+		INPUT_RECORD ir = {};
+		ir.EventType = FOCUS_EVENT;
+		ir.Event.FocusEvent.bSetFocus = TRUE;
+		g_winport_con_in->Enqueue(&ir, 1);
+	}
 }
 
 void WinPortPanel::OnKillFocus( wxFocusEvent &event )
 {
 	fprintf(stderr, "OnKillFocus\n");
-	_focused_ts = 0;
+	if (_focused_ts) {
+		_focused_ts = 0;
+		INPUT_RECORD ir = {};
+		ir.EventType = FOCUS_EVENT;
+		ir.Event.FocusEvent.bSetFocus = FALSE;
+		g_winport_con_in->Enqueue(&ir, 1);
+	}
 	ResetInputState();
 }
 

--- a/far2l/src/vt/IVTShell.h
+++ b/far2l/src/vt/IVTShell.h
@@ -15,6 +15,7 @@ struct IVTShell
 {
 	virtual void OnMouseExpectation(MouseExpectation mex, bool enabled) = 0;
 	virtual void OnBracketedPasteExpectation(bool enabled)              = 0;
+	virtual void OnFocusChangeExpectation(bool enabled)                 = 0;
 	virtual void OnWin32InputMode(bool enabled)                         = 0;
 	virtual void SetKittyFlags(int flags)                               = 0;
 	virtual int  GetKittyFlags()                                        = 0;

--- a/far2l/src/vt/vtansi.cpp
+++ b/far2l/src/vt/vtansi.cpp
@@ -800,6 +800,9 @@ struct VTAnsiContext
 	//					alternative_screen_buffer.Toggle(suffix == 'h');
 	//					break;
 
+					case 1004:
+						vt_shell->OnFocusChangeExpectation(suffix == 'h');
+						break;
 					case 2004:
 						vt_shell->OnBracketedPasteExpectation(suffix == 'h');
 						break;

--- a/far2l/src/vt/vtshell_ioreaders.cpp
+++ b/far2l/src/vt/vtshell_ioreaders.cpp
@@ -213,6 +213,9 @@ void *VTInputReader::ThreadProc()
 		} else if (ir.EventType == KEY_EVENT) {
 			_processor->OnInputKey(ir.Event.KeyEvent);
 
+		} else if (ir.EventType == FOCUS_EVENT) {
+			_processor->OnFocusChanged();
+
 		} else if (ir.EventType == BRACKETED_PASTE_EVENT) {
 			_processor->OnBracketedPaste(ir.Event.BracketedPaste.bStartPaste != FALSE);
 

--- a/far2l/src/vt/vtshell_ioreaders.h
+++ b/far2l/src/vt/vtshell_ioreaders.h
@@ -75,6 +75,7 @@ public:
 	{
 		virtual void OnInputMouse(const MOUSE_EVENT_RECORD &MouseEvent) = 0;
 		virtual void OnInputKey(const KEY_EVENT_RECORD &KeyEvent) = 0;
+		virtual void OnFocusChanged() = 0;
 		virtual void OnInputResized(const INPUT_RECORD &ir) = 0;
 		virtual void OnInputInjected(const std::string &str) = 0;
 		virtual void OnBracketedPaste(bool start) = 0;


### PR DESCRIPTION
WinPort: Implement FOCUS_EVENT  delivering on focus state changes, TTY backend uses [?1004h mode for this
VT: propogate FOCUS_EVENT to application if it requested focus events by [?1004h
! This change caused KEY_GOTFOCUS/KEY_KILLFOCUS to be delivered to all dialogs again, be aware as this events wasnt functional since porting moment