### PR TITLE
Add support for SOURCE_DATE_EPOCH environment variable

### DIFF
--- a/far2l/bootstrap/scripts/far2l_m4.pl
+++ b/far2l/bootstrap/scripts/far2l_m4.pl
@@ -11,7 +11,8 @@ my $arch = shift;
 my $full_version = "$major.$minor.$patch $arch";
 
 # Получаем текущий год
-my $current_year = (localtime)[5] + 1900;
+my (@tm) = localtime($ENV{SOURCE_DATE_EPOCH} || time());
+my $current_year = $tm[5] + 1900;
 my $copyright_years = "2016-$current_year";
 
 # Открываем файл и читаем его содержимое

--- a/far2l/bootstrap/scripts/farver.pl
+++ b/far2l/bootstrap/scripts/farver.pl
@@ -10,7 +10,7 @@ my $patch = shift;
 
 die 'Bad args' if !defined($path) || !defined($arch) || !defined($major) || !defined($minor) || !defined($patch);
 
-my (@tm) = localtime(time());
+my (@tm) = localtime($ENV{SOURCE_DATE_EPOCH} || time());
 my $year = $tm[5] + 1900;
 
 my $tmp = "$path.tmp";


### PR DESCRIPTION
This fixes failure to build reproducibly, which can be seen in Debian: https://tests.reproducible-builds.org/debian/rb-pkg/unstable/amd64/far2l.html

See https://reproducible-builds.org/ for details.

Cc @alexmyczko