### PR TITLE
Use separate desktop files for TTY and GUI versions

### DIFF
--- a/far2l/CMakeLists.txt
+++ b/far2l/CMakeLists.txt
@@ -283,12 +283,17 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 else()
     configure_file("${CMAKE_CURRENT_SOURCE_DIR}/DE/far2l.desktop" "${CMAKE_CURRENT_BINARY_DIR}/DE/far2l.desktop")
     configure_file("${CMAKE_CURRENT_SOURCE_DIR}/DE/far2ledit.desktop" "${CMAKE_CURRENT_BINARY_DIR}/DE/far2ledit.desktop")
+    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/DE/far2l-wx.desktop" "${CMAKE_CURRENT_BINARY_DIR}/DE/far2l-wx.desktop")
+    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/DE/far2ledit-wx.desktop" "${CMAKE_CURRENT_BINARY_DIR}/DE/far2ledit-wx.desktop")
 
     install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/DE/icons" DESTINATION "share" USE_SOURCE_PERMISSIONS COMPONENT desktop FILES_MATCHING PATTERN "*")
 
 	# Have to make desktop files executable, see:
 	# https://wiki.ubuntu.com/SecurityTeam/Policies#Execute-Permission_Bit_Required
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/DE/far2l.desktop" "${CMAKE_CURRENT_BINARY_DIR}/DE/far2ledit.desktop"
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/DE/far2l.desktop"
+                  "${CMAKE_CURRENT_BINARY_DIR}/DE/far2ledit.desktop"
+                  "${CMAKE_CURRENT_BINARY_DIR}/DE/far2l-wx.desktop"
+                  "${CMAKE_CURRENT_BINARY_DIR}/DE/far2ledit-wx.desktop"
         DESTINATION "share/applications"
         COMPONENT desktop
         PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ GROUP_EXECUTE GROUP_READ WORLD_READ WORLD_EXECUTE)

--- a/far2l/DE/far2l-wx.desktop
+++ b/far2l/DE/far2l-wx.desktop
@@ -6,6 +6,6 @@ Comment=File and archive manager
 Exec=far2l --notty
 TryExec=far2l
 Terminal=false
-Categories=Utility;FileManager;
+Categories=Utility;FileManager;System;FileTools;
 Icon=far2l
 StartupNotify=true

--- a/far2l/DE/far2l-wx.desktop
+++ b/far2l/DE/far2l-wx.desktop
@@ -1,11 +1,11 @@
 [Desktop Entry]
 Type=Application
-Name=far2l (Terminal)
+Name=far2l (WX GUI)
 GenericName=far2l
 Comment=File and archive manager
-Exec=far2l --tty
+Exec=far2l --notty
 TryExec=far2l
-Terminal=true
+Terminal=false
 Categories=Utility;FileManager;
 Icon=far2l
 StartupNotify=true

--- a/far2l/DE/far2l.desktop
+++ b/far2l/DE/far2l.desktop
@@ -6,6 +6,6 @@ Comment=File and archive manager
 Exec=far2l --tty
 TryExec=far2l
 Terminal=true
-Categories=Utility;FileManager;
+Categories=Utility;FileManager;System;FileTools;
 Icon=far2l
 StartupNotify=true

--- a/far2l/DE/far2ledit-wx.desktop
+++ b/far2l/DE/far2ledit-wx.desktop
@@ -1,12 +1,12 @@
 [Desktop Entry]
 Type=Application
-Name=Far2l Editor (Terminal)
-Name[ru]=Редактор Far2l (Терминал)
+Name=Far2l Editor (WX GUI)
+Name[ru]=Редактор Far2l (WX GUI)
 Comment=Edit text files
 Comment[ru]=Редактирование текстовых файлов
-Exec=far2ledit --tty %f
+Exec=far2ledit --notty %f
 TryExec=far2ledit
-Terminal=true
+Terminal=false
 MimeType=text/plain;
 Categories=Utility;TextEditor;
 Icon=far2ledit


### PR DESCRIPTION
Terminal versions need `Terminal=true`, GUI versions need `Terminal=false`.

The old `far2l.desktop` had `Terminal=false`, which means that if WX interface is not available, far2l would start in background without any window.

The old `far2ledit.desktop` had `Terminal=true`, which means that if WX interface is available, far2l would open both terminal and its own window.

To fix these problems, create separate desktop files and pass `--tty` and `--notty` explicitly.

In the menu, there will be 4 items, like on this screenshot:
![screenshot](https://github.com/user-attachments/assets/d7021aad-0863-44d0-80a5-aa9a6cbcfa75)

As requested by @akruphi, also added `System` and `FileTools` categories to far2l desktop files, per analogy with `mc.desktop` which has them.