### PR TITLE
fix #2581: Far2l crash in Quick view when try show broken symlink

### DIFF
--- a/far2l/src/panels/qview.cpp
+++ b/far2l/src/panels/qview.cpp
@@ -328,8 +328,9 @@ void QuickView::ShowFile(const wchar_t *FileName, int TempFile, HANDLE hDirPlugi
 
 	if (!hDirPlugin) {
 		FileAttr = apiGetFileAttributes(FileName);
-		if (FileAttr != INVALID_FILE_ATTRIBUTES && (FileAttr & FILE_ATTRIBUTE_DEVICE) != 0)		// avoid stuck
-			return;
+		if (FileAttr != INVALID_FILE_ATTRIBUTES
+			&& ((FileAttr & FILE_ATTRIBUTE_DEVICE) != 0 || (FileAttr & FILE_ATTRIBUTE_BROKEN) != 0) )
+			return; // avoid stuck
 	}
 
 	bool SameFile = !StrCmp(strCurFileName, FileName);


### PR DESCRIPTION
fix #2581

Пока быстрофикс. Но можно и заморочиться, сделать вывод инфы с именем ссылки и тем, что она битая.
И то же самое для сокетов, каналов, символьных и блочных устройств.
Как сейчас сделано — оно не очень красиво выходит: когда со включённым Quick View листаешь файлы и натыкаешься на эти исключения, то инфа не обновляется, остаётся для предыдущего файла/директории.