### PR TITLE
fix incorrect interface locale on first render

### DIFF
--- a/far2l/src/main.cpp
+++ b/far2l/src/main.cpp
@@ -250,6 +250,18 @@ static int MainProcess(FARString strEditViewArg, FARString strDestName1, FARStri
 					UpdatePathOptions(strDestName2, false);
 			}
 
+			//нужно проверить локаль до начала отрисовки интерфейса
+			if (Opt.IsFirstStart)
+			{
+				const char *locale = setlocale(LC_CTYPE, NULL);
+				// Only Russian translation can be currently considered complete
+				if (IsLocaleMatches(locale, "ru_RU")) {
+					Opt.strLanguage = L"Russian";
+					Opt.strHelpLanguage = L"Russian";
+					ConfigOptSave(false);
+				}
+			}
+
 			// теперь все готово - создаем панели!
 			CtrlObj.Init();
 
@@ -306,15 +318,6 @@ static int MainProcess(FARString strEditViewArg, FARString strDestName1, FARStri
 			fprintf(stderr, "STARTUP: %llu\n", (unsigned long long)(clock() - cl_start));
 
 			if( Opt.IsFirstStart ) {
-
-				const char *locale = setlocale(LC_CTYPE, NULL);
-				// Only Russian translation can be currently considered complete
-				if (IsLocaleMatches(locale, "ru_RU")) {
-					Opt.strLanguage = L"Russian";
-					Opt.strHelpLanguage = L"Russian";
-					ConfigOptSave(false);
-				}
-
 				Help::Present(L"Far2lGettingStarted",L"",FHELP_NOSHOWERROR);
 
 				DWORD tweaks = WINPORT(SetConsoleTweaks)(TWEAKS_ONLY_QUERY_SUPPORTED);

--- a/far2l/src/main.cpp
+++ b/far2l/src/main.cpp
@@ -250,6 +250,7 @@ static int MainProcess(FARString strEditViewArg, FARString strDestName1, FARStri
 					UpdatePathOptions(strDestName2, false);
 			}
 
+			bool cfgNeedSave = false;
 			//нужно проверить локаль до начала отрисовки интерфейса
 			if (Opt.IsFirstStart)
 			{
@@ -258,7 +259,7 @@ static int MainProcess(FARString strEditViewArg, FARString strDestName1, FARStri
 				if (IsLocaleMatches(locale, "ru_RU")) {
 					Opt.strLanguage = L"Russian";
 					Opt.strHelpLanguage = L"Russian";
-					ConfigOptSave(false);
+					cfgNeedSave = true;
 				}
 			}
 
@@ -339,10 +340,12 @@ static int MainProcess(FARString strEditViewArg, FARString strDestName1, FARStri
 					} else {
 						Opt.OSC52ClipSet = 1;
 					}
-					ConfigOptSave(false);
+					cfgNeedSave = true;
 				}
 			}
 
+			if (cfgNeedSave) ConfigOptSave(false);
+			
 			FrameManager->EnterMainLoop();
 		}
 

--- a/far2l/src/main.cpp
+++ b/far2l/src/main.cpp
@@ -599,14 +599,26 @@ int FarAppMain(int argc, char **argv)
 	std::string kblo_path = StrPrintf("%lskblayouts.ini", far2l_path);
 	KeyboardLayouts.reset(new KeyFileHelper(kblo_path.c_str()));
 
-	const char *lc = setlocale(LC_CTYPE, NULL);
+	const char *locale = setlocale(LC_CTYPE, NULL);
 	char LangCode[3];
-	LangCode[0] = lc[0];
-	LangCode[1] = lc[1];
+	LangCode[0] = locale[0];
+	LangCode[1] = locale[1];
 	LangCode[2] = 0;
 
 	KbLayoutsTrIn = KeyboardLayouts->GetString(LangCode, "Latin");
 	KbLayoutsTrOut = KeyboardLayouts->GetString(LangCode, "Local");
+
+	bool cfgNeedSave = false;
+	//нужно проверить локаль до начала отрисовки интерфейса
+	if (Opt.IsFirstStart)
+	{
+		// Only Russian translation can be currently considered complete
+		if (IsLocaleMatches(locale, "ru_RU")) {
+			Opt.strLanguage = L"Russian";
+			Opt.strHelpLanguage = L"Russian";
+			cfgNeedSave = true;
+		}
+	}
 
 	// Настройка OEM сортировки. Должна быть после CopyGlobalSettings и перед InitKeysArray!
 	// LocalUpperInit();
@@ -631,19 +643,6 @@ int FarAppMain(int argc, char **argv)
 
 	InitConsole();
 	WINPORT(SetConsoleCursorBlinkTime)(NULL, Opt.CursorBlinkTime);
-
-	bool cfgNeedSave = false;
-	//нужно проверить локаль до начала отрисовки интерфейса
-	if (Opt.IsFirstStart)
-	{
-		const char *locale = setlocale(LC_CTYPE, NULL);
-		// Only Russian translation can be currently considered complete
-		if (IsLocaleMatches(locale, "ru_RU")) {
-			Opt.strLanguage = L"Russian";
-			Opt.strHelpLanguage = L"Russian";
-			cfgNeedSave = true;
-		}
-	}
 
 	static_assert(!IsPtr(Msg::NewFileName._id),
 			"Too many language messages. Need to refactor code to eliminate use of IsPtr.");

--- a/far2l/src/main.cpp
+++ b/far2l/src/main.cpp
@@ -608,18 +608,6 @@ int FarAppMain(int argc, char **argv)
 	KbLayoutsTrIn = KeyboardLayouts->GetString(LangCode, "Latin");
 	KbLayoutsTrOut = KeyboardLayouts->GetString(LangCode, "Local");
 
-	bool cfgNeedSave = false;
-	//нужно проверить локаль до начала отрисовки интерфейса
-	if (Opt.IsFirstStart)
-	{
-		// Only Russian translation can be currently considered complete
-		if (IsLocaleMatches(locale, "ru_RU")) {
-			Opt.strLanguage = L"Russian";
-			Opt.strHelpLanguage = L"Russian";
-			cfgNeedSave = true;
-		}
-	}
-
 	// Настройка OEM сортировки. Должна быть после CopyGlobalSettings и перед InitKeysArray!
 	// LocalUpperInit();
 	// InitLCIDSort();
@@ -643,6 +631,18 @@ int FarAppMain(int argc, char **argv)
 
 	InitConsole();
 	WINPORT(SetConsoleCursorBlinkTime)(NULL, Opt.CursorBlinkTime);
+
+	bool cfgNeedSave = false;
+	//нужно проверить локаль до начала отрисовки интерфейса
+	if (Opt.IsFirstStart)
+	{
+		// Only Russian translation can be currently considered complete
+		if (IsLocaleMatches(locale, "ru_RU")) {
+			Opt.strLanguage = L"Russian";
+			Opt.strHelpLanguage = L"Russian";
+			cfgNeedSave = true;
+		}
+	}
 
 	static_assert(!IsPtr(Msg::NewFileName._id),
 			"Too many language messages. Need to refactor code to eliminate use of IsPtr.");


### PR DESCRIPTION
Поднял проверку локализации выше по коду, чтобы она встала перед `CtrlObj.Init();` в 254 строке. 

Нам нужно, чтобы опция локализации была правильно установлена до начала отрисовки интерфейса, инче панели нарисуются согласно дефолтными параметрам на английском.

I raised the localization check higher in the code so that it comes before `CtrlObj.Init();` in line 254. We need the localization option to be set correctly before the interface begins to be drawn, otherwise the panels will be drawn according to the default parameters in English.