### PR TITLE
Fix potential NULL dereference in clipboard.cpp

### DIFF
--- a/far2l/src/clipboard.cpp
+++ b/far2l/src/clipboard.cpp
@@ -233,7 +233,7 @@ wchar_t *Clipboard::Paste(bool &IsVertical, int MaxChars)
 
 	IsVertical = false;
 
-	if (wcsstr(ClipText, NATIVE_EOLW)) {
+	if (ClipText && wcsstr(ClipText, NATIVE_EOLW)) {
 		UINT FormatType = RegisterFormat(FAR_VerticalBlock_Unicode);
 		if (FormatType && IsFormatAvailable(FormatType)) {
 			IsVertical = true;


### PR DESCRIPTION
The return value of malloc() is often checked for NULL in far2l code.
The value ```CharsCount``` in Clipboard::Paste() could be large, causing malloc() to return NULL.
There is a check ```if (ClipText) {``` on line 229.
Therefore, I added an additional check.
