### PR TITLE
Chattr / chflags dialog + misc

### DIFF
--- a/far2l/CMakeLists.txt
+++ b/far2l/CMakeLists.txt
@@ -5,6 +5,7 @@ add_subdirectory (bootstrap)
 set(SOURCES
 src/farversion.cpp
 src/cache.cpp
+src/chattr.cpp
 src/clipboard.cpp
 src/cmdline.cpp
 src/copy.cpp

--- a/far2l/bootstrap/scripts/farlang.templ.m4
+++ b/far2l/bootstrap/scripts/farlang.templ.m4
@@ -17240,6 +17240,17 @@ upd:"Chattr/chflags only applicable to a real object accessible locally.\nCurren
 upd:"Chattr/chflags only applicable to a real object accessible locally.\nCurrently, the plugin panel does not have a real file system object."
 upd:"Chattr/chflags only applicable to a real object accessible locally.\nCurrently, the plugin panel does not have a real file system object."
 
+ChAttrWarnNoSymlinks
+"Не применимо к символьным ссылкам"
+"Chattr/chflags not applicable to symlinks"
+upd:"Chattr/chflags not applicable to symlinks"
+upd:"Chattr/chflags not applicable to symlinks"
+upd:"Chattr/chflags not applicable to symlinks"
+upd:"Chattr/chflags not applicable to symlinks"
+upd:"Chattr/chflags not applicable to symlinks"
+upd:"Chattr/chflags not applicable to symlinks"
+upd:"Chattr/chflags not applicable to symlinks"
+
 ChAttrErrorGetFlags
 "Не удается получить флаги для \"%ls\":\n"
 "Cannot get flags of \"%ls\":\n"

--- a/far2l/bootstrap/scripts/farlang.templ.m4
+++ b/far2l/bootstrap/scripts/farlang.templ.m4
@@ -14497,15 +14497,15 @@ MenuAttributes
 "А&трыбуты файлаў       Ctrl+A"
 
 MenuChattr
-"cha&ttr / chflags      Ctrl+Alt+A"
-"cha&ttr / chflags   Ctrl+Alt+A"
-upd:"cha&ttr / chflags           Ctrl+Alt+A"
-upd:"cha&ttr / chflags     Ctrl+Alt+A"
-upd:"cha&ttr / chflags     Ctrl+Alt+A"
-upd:"cha&ttr / chflags          Ctrl+Alt+A"
-upd:"cha&ttr / chflags      Ctrl+Alt+A"
-upd:"cha&ttr / chflags      Ctrl+Alt+A"
-upd:"cha&ttr / chflags      Ctrl+Alt+A"
+"chattr / chflag&s      Ctrl+Alt+A"
+"chattr / ch&flags   Ctrl+Alt+A"
+upd:"chattr / ch&flags           Ctrl+Alt+A"
+upd:"chattr / ch&flags     Ctrl+Alt+A"
+upd:"c&hattr / chflags     Ctrl+Alt+A"
+upd:"chattr / ch&flags          Ctrl+Alt+A"
+upd:"chattr / ch&flags      Ctrl+Alt+A"
+upd:"chattr / chflag&s      Ctrl+Alt+A"
+upd:"c&hattr / chflags      Ctrl+Alt+A"
 
 MenuApplyCommand
 "Применить коман&ду     Ctrl+G"

--- a/far2l/bootstrap/scripts/farlang.templ.m4
+++ b/far2l/bootstrap/scripts/farlang.templ.m4
@@ -228,6 +228,17 @@ upd:"Change"
 upd:"Change"
 upd:"Change"
 
+Reset
+"Сбросить"
+"Reset"
+upd:"Reset"
+upd:"Reset"
+upd:"Reset"
+upd:"Reset"
+"Reiniciar"
+"Скинути"
+"Зкінуць"
+
 HCancel
 l:
 "&Отмена"

--- a/far2l/bootstrap/scripts/farlang.templ.m4
+++ b/far2l/bootstrap/scripts/farlang.templ.m4
@@ -14485,6 +14485,17 @@ MenuAttributes
 "А&трибути файлів       Ctrl+A"
 "А&трыбуты файлаў       Ctrl+A"
 
+MenuChattr
+"cha&ttr / chflags      Ctrl+Alt+A"
+"cha&ttr / chflags   Ctrl+Alt+A"
+upd:"cha&ttr / chflags           Ctrl+Alt+A"
+upd:"cha&ttr / chflags     Ctrl+Alt+A"
+upd:"cha&ttr / chflags     Ctrl+Alt+A"
+upd:"cha&ttr / chflags          Ctrl+Alt+A"
+upd:"cha&ttr / chflags      Ctrl+Alt+A"
+upd:"cha&ttr / chflags      Ctrl+Alt+A"
+upd:"cha&ttr / chflags      Ctrl+Alt+A"
+
 MenuApplyCommand
 "Применить коман&ду     Ctrl+G"
 "A&pply command      Ctrl+G"
@@ -17173,6 +17184,73 @@ upd:"  are displayed and will be modified for the original object"
 upd:"  are displayed and will be modified for the original object"
 upd:"  are displayed and will be modified for the original object"
 upd:"  are displayed and will be modified for the original object"
+
+ChAttrTitle
+"chattr / chflags"
+"chattr / chflags"
+"chattr / chflags"
+"chattr / chflags"
+"chattr / chflags"
+"chattr / chflags"
+"chattr / chflags"
+"chattr / chflags"
+"chattr / chflags"
+
+ChAttrWarnSystem
+"Far2l пока ещё не умеет работать с флагами на Вашей системе"
+"Far2l doesn't know how to handle flags on your system yet"
+upd:"Far2l doesn't know how to handle flags on your system yet"
+upd:"Far2l doesn't know how to handle flags on your system yet"
+upd:"Far2l doesn't know how to handle flags on your system yet"
+upd:"Far2l doesn't know how to handle flags on your system yet"
+upd:"Far2l doesn't know how to handle flags on your system yet"
+upd:"Far2l doesn't know how to handle flags on your system yet"
+upd:"Far2l doesn't know how to handle flags on your system yet"
+
+ChAttrWarnNoOne
+"Применимо только к одному объекту.\nСейчас на панели выбрано несколько объектов."
+"Chattr/chflags only applicable to one object only.\nMultiple objects are currently selected in the panel."
+upd:"Chattr/chflags only applicable to one object only.\nMultiple objects are currently selected in the panel."
+upd:"Chattr/chflags only applicable to one object only.\nMultiple objects are currently selected in the panel."
+upd:"Chattr/chflags only applicable to one object only.\nMultiple objects are currently selected in the panel."
+upd:"Chattr/chflags only applicable to one object only.\nMultiple objects are currently selected in the panel."
+upd:"Chattr/chflags only applicable to one object only.\nMultiple objects are currently selected in the panel."
+upd:"Chattr/chflags only applicable to one object only.\nMultiple objects are currently selected in the panel."
+upd:"Chattr/chflags only applicable to one object only.\nMultiple objects are currently selected in the panel."
+
+ChAttrWarnNoRealFile
+"Применимо только к реальному объекту доступному локально.\nСейчас на панели плагина не объект реальной файловой системы."
+"Chattr/chflags only applicable to a real object accessible locally.\nCurrently, the plugin panel does not have a real file system object."
+upd:"Chattr/chflags only applicable to a real object accessible locally.\nCurrently, the plugin panel does not have a real file system object."
+upd:"Chattr/chflags only applicable to a real object accessible locally.\nCurrently, the plugin panel does not have a real file system object."
+upd:"Chattr/chflags only applicable to a real object accessible locally.\nCurrently, the plugin panel does not have a real file system object."
+upd:"Chattr/chflags only applicable to a real object accessible locally.\nCurrently, the plugin panel does not have a real file system object."
+upd:"Chattr/chflags only applicable to a real object accessible locally.\nCurrently, the plugin panel does not have a real file system object."
+upd:"Chattr/chflags only applicable to a real object accessible locally.\nCurrently, the plugin panel does not have a real file system object."
+upd:"Chattr/chflags only applicable to a real object accessible locally.\nCurrently, the plugin panel does not have a real file system object."
+
+ChAttrErrorGetFlags
+"Не удается получить флаги для \"%ls\":\n"
+"Cannot get flags of \"%ls\":\n"
+upd:"Cannot get flags of \"%ls\":\n"
+upd:"Cannot get flags of \"%ls\":\n"
+upd:"Cannot get flags of \"%ls\":\n"
+upd:"Cannot get flags of \"%ls\":\n"
+upd:"Cannot get flags of \"%ls\":\n"
+upd:"Cannot get flags of \"%ls\":\n"
+upd:"Cannot get flags of \"%ls\":\n"
+
+ChAttrErrorSetFlags
+"Не удается установить флаги для \"%ls\":\n"
+"Cannot chattr for \"%ls\":\n"
+upd:"Cannot chattr for \"%ls\":\n"
+upd:"Cannot chattr for \"%ls\":\n"
+upd:"Cannot chattr for \"%ls\":\n"
+upd:"Cannot chattr for \"%ls\":\n"
+upd:"Cannot chattr for \"%ls\":\n"
+upd:"Cannot chattr for \"%ls\":\n"
+upd:"Cannot chattr for \"%ls\":\n"
+
 
 SetColorPanel
 l:

--- a/far2l/bootstrap/scripts/farlang.templ.m4
+++ b/far2l/bootstrap/scripts/farlang.templ.m4
@@ -16435,6 +16435,17 @@ upd:"selected %d items"
 upd:"selected %d items"
 upd:"selected %d items"
 
+SetAttrInfoSelDevices
+"%lsустройств: %d"
+"%lsdevices: %d"
+upd:"%lsdevices: %d"
+upd:"%lsdevices: %d"
+upd:"%lsdevices: %d"
+upd:"%lsdevices: %d"
+upd:"%lsdevices: %d"
+upd:"%lsdevices: %d"
+upd:"%lsdevices: %d"
+
 SetAttrInfoSelDirs
 "%lsкаталогов: %d"
 "%lsdirs: %d"

--- a/far2l/src/about.cpp
+++ b/far2l/src/about.cpp
@@ -28,7 +28,7 @@ void FarAbout(PluginManager &Plugins)
 
 	fs.Format(L"          FAR2L Version: %s", FAR_BUILD);
 	ListAbout.AddItem(fs); fs2copy = fs;
-	fs =      L"               Compiler: ";
+	fs =      L"         Build Compiler: ";
 #if defined (__clang__)
 	fs.AppendFormat(L"Clang, version %d.%d.%d", __clang_major__, __clang_minor__, __clang_patchlevel__);
 #elif defined (__INTEL_COMPILER)
@@ -40,8 +40,49 @@ void FarAbout(PluginManager &Plugins)
 #endif
 	ListAbout.AddItem(fs); fs2copy += "\n" + fs;
 
-	fs.Format(L"               Platform: %s", FAR_PLATFORM);
+	fs.Format(L"         Build Platform: %s", FAR_PLATFORM);
+// subset of full OS list from https://sourceforge.net/p/predef/wiki/OperatingSystems/
+#if defined(__ANDROID__)
+	fs += " (Android)";
+#elif defined(__linux__)
+	fs += " (Linux)";
+#elif defined(__APPLE__) || (__MACH__)
+	fs += " (macOS)";
+#elif defined(__FreeBSD__)
+	fs += " (FreeBSD)";
+#elif defined(__NetBSD__)
+	fs += " (NetBSD)";
+#elif defined(__OpenBSD__)
+	fs += " (OpenBSD)";
+#elif defined(__DragonFly__)
+	fs += " (DragonFly)";
+#elif defined(BSD)
+	fs += " (unknown BSD)";
+#elif defined(__HAIKU__)
+	fs += " (Haiku)";
+#elif defined(_WIN64)
+	fs += " (Windows 64)";
+#elif defined(_WIN32)
+	fs += " (Windows 32)";
+#elif defined(__CYGWIN__)
+	fs += " (Cygwin)";
+#elif defined(_AIX)
+	fs += " (AIX)";
+#elif defined(sun) || defined(__sun)
+# if defined(__SVR4) || defined(__svr4__)
+	fs += " (Solaris)";
+# else
+	fs += " (SunOS)";
+# endif
+#elif defined(__EMSCRIPTEN__)
+	fs += " (WEB: Emscripten)";
+#elif defined(__QNX__)
+	fs += " (QNX)";
+#else
+	fs += " (unknown)";
+#endif
 	ListAbout.AddItem(fs); fs2copy += "\n" + fs;
+
 	fs.Format(L"                Backend: %s", WinPortBackendInfo(-1));
 	ListAbout.AddItem(fs); fs2copy += "\n" + fs;
 	fs.Format(L"    ConsoleColorPalette: %u", WINPORT(GetConsoleColorPalette)(NULL) );

--- a/far2l/src/chattr.cpp
+++ b/far2l/src/chattr.cpp
@@ -25,9 +25,9 @@ Copyright (c) 2025- Far2l Group
 #include "FSFileFlags.h"
 
 static struct {
-    unsigned long flag;
-    char name_short;
-    const char *name_long;
+	unsigned long flag;
+	char name_short;
+	const char *name_long;
 } flags_list[] = {
 #ifdef __linux__
 // for linux systems see actual constants in <linux/fs.h>
@@ -117,7 +117,7 @@ static struct {
 #endif
 #endif
 
-#if defined(__APPLE__) || defined(__FreeBSD__)  || defined(__DragonFly__)
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__DragonFly__)
 // see actual constants in <sys/stat.h>
 // Super-user and owner changeable flags
 #ifdef UF_NODUMP	// 0x00000001
@@ -176,7 +176,7 @@ static struct {
 	{ SF_NOUNLINK,		'+', "sunlink: file may not be removed or renamed (super-user only)" },
 #endif
 #ifdef SF_SNAPSHOT	// 0x00200000
-	{ SF_SNAPSHOT,		'+', "snapshot: snapshot inode (filesystems do not	allow changing this flag)" },
+	{ SF_SNAPSHOT,		'+', "snapshot: snapshot inode (filesystems do not allow changing this flag)" },
 #endif
 #endif
 };
@@ -320,8 +320,16 @@ bool ChattrDialog(Panel *SrcPanel)
 	FARString strSelName;
 	DWORD FileAttr, FileMode;
 	SrcPanel->GetSelName(nullptr, FileAttr, FileMode);
-    SrcPanel->GetSelName(&strSelName, FileAttr, FileMode);
+	SrcPanel->GetSelName(&strSelName, FileAttr, FileMode);
 	//SrcPanel->GetCurName(strSelName);
+
+	if (FileAttr & FILE_ATTRIBUTE_REPARSE_POINT) {
+		ExMessager em(Msg::ChAttrTitle);
+		em.AddMultiline(Msg::ChAttrWarnNoSymlinks);
+		em.AddDup(Msg::Ok);
+		em.Show(MSG_WARNING, 1);
+		return false;
+	}
 
 	if (TestParentFolderName(strSelName))
 		return false;

--- a/far2l/src/chattr.cpp
+++ b/far2l/src/chattr.cpp
@@ -1,0 +1,382 @@
+/*
+chattr.cpp
+
+Просмотр и установка атрибутов/флагов файлов аналогично lsattr/ls -lo и chattr/chflags
+*/
+/*
+Copyright (c) 2025- Far2l Group
+*/
+
+#include "headers.hpp"
+
+#include "panel.hpp"
+#include "ctrlobj.hpp"
+#include "message.hpp"
+#include "chattr.hpp"
+#include "pathmix.hpp"
+#include "dialog.hpp"
+#include "interf.hpp"
+#include "vmenu.hpp"
+
+#ifdef __linux__
+#include <linux/fs.h>
+#endif
+
+#include "FSFileFlags.h"
+
+static struct {
+    unsigned long flag;
+    char name_short;
+    const char *name_long;
+} flags_list[] = {
+#ifdef __linux__
+// for linux systems see actual constants in <linux/fs.h>
+#ifdef FS_SECRM_FL			// 0x00000001
+	{ FS_SECRM_FL,			's', "(s) Secure deletion" },
+#endif
+#ifdef FS_UNRM_FL			// 0x00000002
+	{ FS_UNRM_FL,			'u', "(u) Undelete" },
+#endif
+#ifdef FS_COMPR_FL			// 0x00000004
+	{ FS_COMPR_FL,			'c', "(c) Compress" },
+#endif
+#ifdef FS_SYNC_FL			// 0x00000008
+	{ FS_SYNC_FL,			'S', "(S) Synchronous updates" },
+#endif
+#ifdef FS_IMMUTABLE_FL		// 0x00000010
+	{ FS_IMMUTABLE_FL,		'i', "(i) Immutable" },
+#endif
+#ifdef FS_APPEND_FL			// 0x00000020
+	{ FS_APPEND_FL,			'a', "(a) Append only" },
+#endif
+#ifdef FS_NODUMP_FL			// 0x00000040
+	{ FS_NODUMP_FL,			'd', "(d) No dump" },
+#endif
+#ifdef FS_NOATIME_FL		// 0x00000080
+	{ FS_NOATIME_FL,		'A', "(A) No update atime" },
+#endif
+#ifdef FS_DIRTY_FL			// 0x00000100
+	{ FS_DIRTY_FL,			'Z', "(Z) Compressed dirty file" },
+#endif
+#ifdef FS_COMPRBLK_FL		// 0x00000200
+	{ FS_COMPRBLK_FL,		'B', "(B) Compressed clusters" },
+#endif
+#ifdef FS_NOCOMP_FL			// 0x00000400
+	{ FS_NOCOMP_FL,			'X', "(X) Don't compress" },
+#endif
+#ifdef FS_ENCRYPT_FL		// 0x00000800
+	{ FS_ENCRYPT_FL,		'E', "(E) Encrypted file" },
+#endif
+#ifdef FS_INDEX_FL			// 0x00001000
+	{ FS_INDEX_FL,			'I', "(I) Indexed directory" },
+#endif
+#ifdef FS_IMAGIC_FL			// 0x00002000
+	{ FS_IMAGIC_FL,			'+', "    AFS directory" },
+#endif
+#ifdef FS_JOURNAL_DATA_FL	// 0x00004000
+	{ FS_JOURNAL_DATA_FL,	'j', "(j) Journaled data" },
+#endif
+#ifdef FS_NOTAIL_FL			// 0x00008000
+	{ FS_NOTAIL_FL,			't', "(t) No tail merging" },
+#endif
+#ifdef FS_DIRSYNC_FL		// 0x00010000
+	{ FS_DIRSYNC_FL,		'D', "(D) Synchronous directory updates" },
+#endif
+#ifdef FS_TOPDIR_FL			// 0x00020000
+	{ FS_TOPDIR_FL,			'T', "(T) Top of directory hierarchies" },
+#endif
+#ifdef FS_HUGE_FILE_FL		// 0x00040000
+	{ FS_HUGE_FILE_FL,		'h', "(h) Huge_file" },
+#endif
+#ifdef FS_EXTENT_FL			// 0x00080000
+	{ FS_EXTENT_FL,			'e', "(e) Inode uses extents" },
+#endif
+#ifdef FS_VERITY_FL			// 0x00100000
+	{ FS_VERITY_FL,			'V', "(V) Verity protected inode" },
+#endif
+#ifdef FS_EA_INODE_FL		// 0x00200000
+	{ FS_EA_INODE_FL,		'+', "    Inode used for large EA" },
+#endif
+#ifdef FS_EOFBLOCKS_FL		// 0x00400000
+	{ FS_EOFBLOCKS_FL,		'+', "    EOFBLOCKS" },
+#endif
+#ifdef FS_NOCOW_FL			// 0x00800000
+	{ FS_NOCOW_FL,			'C', "(C) No COW" },
+#endif
+#ifdef FS_DAX_FL			// 0x02000000
+	{ FS_DAX_FL,			'x', "(x) Direct access for files" },
+#endif
+#ifdef FS_INLINE_DATA_FL	// 0x10000000
+	{ FS_INLINE_DATA_FL,	'N', "(N) Inode has inline data" },
+#endif
+#ifdef FS_PROJINHERIT_FL	// 0x20000000
+	{ FS_PROJINHERIT_FL,	'P', "(P) Project hierarchy" },
+#endif
+#ifdef FS_CASEFOLD_FL		// 0x40000000
+	{ FS_CASEFOLD_FL,		'F', "(F) Casefolded file" },
+#endif
+#endif
+
+#if defined(__APPLE__) || defined(__FreeBSD__)  || defined(__DragonFly__)
+// see actual constants in <sys/stat.h>
+// Super-user and owner changeable flags
+#ifdef UF_NODUMP	// 0x00000001
+	{ UF_NODUMP,		'+', "nodump: do not dump file (owner or super-user only)" },
+#endif
+#ifdef UF_IMMUTABLE	// 0x00000002
+	{ UF_IMMUTABLE,		'+', "uimmutable: file may not be changed (owner or super-user only)" },
+#endif
+#ifdef UF_APPEND	// 0x00000004
+	{ UF_APPEND,		'+', "uappend: writes to file may only append (owner or super-user only)" },
+#endif
+#ifdef UF_OPAQUE	// 0x00000008
+	{ UF_OPAQUE,		'+', "opaque: directory is opaque wrt. union (owner or super-user only)" },
+#endif
+#ifdef UF_NOUNLINK	// 0x00000010
+	{ UF_NOUNLINK,		'+', "uunlink: file may not be removed or renamed (owner or super-user only)" },
+#endif
+#ifdef UF_COMPRESSED	// 0x00000020
+	{ UF_COMPRESSED,	'+', "ucompressed: file is compressed (macOS only) (owner or super-user only)" },
+#endif
+#ifdef UF_TRACKED	// 0x00000040
+	{ UF_TRACKED,		'+', "utracked: renames and deletes are tracked (macOS only) (owner or super-user only)" },
+#endif
+#ifdef UF_SYSTEM	// 0x00000080
+	{ UF_SYSTEM,		'+', "usystem: Windows system file bit (owner or super-user only)" },
+#endif
+#ifdef UF_SPARSE	// 0x00000100
+	{ UF_SPARSE,		'+', "usparse: sparse file (owner or super-user only)" },
+#endif
+#ifdef UF_OFFLINE	// 0x00000200
+	{ UF_OFFLINE,		'+', "uoffline: file is offline (owner or super-user only)" },
+#endif
+#ifdef UF_REPARSE	// 0x00000400
+	{ UF_REPARSE,		'+', "ureparse: Windows reparse point file bit (owner or super-user only)" },
+#endif
+#ifdef UF_ARCHIVE	// 0x00000800
+	{ UF_ARCHIVE,		'+', "uarchive: file needs to be archived (owner or super-user only)" },
+#endif
+#ifdef UF_READONLY	// 0x00001000
+	{ UF_READONLY,		'+', "ureadonly: Windows readonly file bit (owner or super-user only)" },
+#endif
+#ifdef UF_HIDDEN	// 0x00008000
+	{ UF_HIDDEN,		'+', "uhidden: file is hidden (owner or super-user only)" },
+#endif
+// Super-user changeable flags
+#ifdef SF_ARCHIVED	// 0x00010000
+	{ SF_ARCHIVED,		'+', "sarchive: file is archived (super-user only)" },
+#endif
+#ifdef SF_IMMUTABLE	// 0x00020000
+	{ SF_IMMUTABLE,		'+', "simmutable: file may not be changed (super-user only)" },
+#endif
+#ifdef SF_APPEND	// 0x00040000
+	{ SF_APPEND,		'+', "sappend: writes to file may only append (super-user only)" },
+#endif
+#ifdef SF_NOUNLINK	// 0x00100000
+	{ SF_NOUNLINK,		'+', "sunlink: file may not be removed or renamed (super-user only)" },
+#endif
+#ifdef SF_SNAPSHOT	// 0x00200000
+	{ SF_SNAPSHOT,		'+', "snapshot: snapshot inode (filesystems do not	allow changing this flag)" },
+#endif
+#endif
+};
+
+inline void GetFlagStr2BarList(unsigned i, char &ch, FARString &str, bool on, bool changed)
+{
+	ch = on ? flags_list[i].name_short : '-';
+	str.Format(L"%c[%c] %s", changed ? '*' : ' ', on ? 'x' : ' ', flags_list[i].name_long);
+}
+
+enum CHATTRDLG
+{
+	CA_DOUBLEBOX,
+	CA_TEXT_FILENAME,
+	CA_TEXT_FLAGSBAR,
+	CA_SEPARATOR1,
+	CA_LIST_FLAGS,
+	CA_SEPARATOR2,
+	CA_BUTTON_SET,
+	CA_BUTTON_CANCEL
+};
+
+static void flags_show(HANDLE hDlg, bool toggle)
+{
+	char ch;
+	FARString strFlagsBar, strListBoxLine;
+
+	VMenu *ListBox = reinterpret_cast<Dialog *>(hDlg)->GetAllItem()[CA_LIST_FLAGS]->ListPtr;
+	FSFileFlags *FFFlags =
+			reinterpret_cast<FSFileFlags *>(SendDlgMessage(hDlg, DM_GETDLGDATA, 0, 0));
+
+	int sel_pos = ListBox->GetSelectPos();
+	if (toggle && sel_pos >= 0 && sel_pos < (int)ARRAYSIZE(flags_list))
+		FFFlags->FlagInverse(flags_list[sel_pos].flag);
+	else
+		toggle = false;
+
+	ListBox->DeleteItems();
+	for (unsigned i=0; i<ARRAYSIZE(flags_list); i++) {
+		GetFlagStr2BarList(i, ch, strListBoxLine,
+			FFFlags->FlagIsOn(flags_list[i].flag), !FFFlags->FlagEqActual(flags_list[i].flag) );
+		strFlagsBar += ch;
+		ListBox->AddItem(strListBoxLine);
+		SendDlgMessage(hDlg, DM_SETTEXTPTR, CA_TEXT_FLAGSBAR, (LONG_PTR)strFlagsBar.CPtr());
+	}
+
+	if (toggle) {
+		ListBox->SetSelectPos(sel_pos, 0);
+		ListBox->FastShow();
+	}
+}
+
+static LONG_PTR WINAPI ChattrDlgProc(HANDLE hDlg, int Msg, int Param1, LONG_PTR Param2)
+{
+	switch (Msg) {
+		case DN_INITDIALOG: {
+			VMenu *ListBox = reinterpret_cast<Dialog *>(hDlg)->GetAllItem()[CA_LIST_FLAGS]->ListPtr;
+			ListBox->ClearFlags(VMENU_MOUSEREACTION);
+			flags_show(hDlg, false);
+			return TRUE;
+		}
+		case DN_KEY:
+			if (Param1 == CA_LIST_FLAGS && (Param2 == VK_SPACE || Param2 == KEY_ENTER || Param2 == KEY_NUMENTER)) {
+				flags_show(hDlg, true);
+				return TRUE;
+			}
+			break;
+		case DN_CLOSE:
+			if (Param1 == CA_LIST_FLAGS) { // without DIF_LISTNOCLOSE mouse click in ListBox try close dialog
+				flags_show(hDlg, true);
+				return FALSE; // no close if mouse click in ListBox
+			}
+			break;
+	}
+
+	return DefDlgProc(hDlg, Msg, Param1, Param2);
+}
+
+static void error_append(FARString &str, int err)
+{
+	const char *str_err = strerror(err);
+	if (str_err)
+		str.AppendFormat(L"\"%s\" (%d)", str_err, err);
+	else
+		str.AppendFormat(L"Error %d", err);
+}
+
+bool ChattrDialog(Panel *SrcPanel)
+{
+	if (SrcPanel == nullptr)
+		return false;
+
+	if (SrcPanel->GetSelCount() < 1)
+		return false;
+
+	if (ARRAYSIZE(flags_list) < 1) {
+		ExMessager em(Msg::ChAttrTitle);
+		em.AddMultiline(Msg::ChAttrWarnSystem);
+		em.AddDup(Msg::Ok);
+		em.Show(MSG_WARNING, 1);
+		return false;
+	}
+
+	if (SrcPanel->GetSelCount() > 1) {
+		ExMessager em(Msg::ChAttrTitle);
+		em.AddMultiline(Msg::ChAttrWarnNoOne);
+		em.AddDup(Msg::Ok);
+		em.Show(MSG_WARNING, 1);
+		return false;
+	}
+
+	if (SrcPanel->GetMode() == PLUGIN_PANEL) {
+		OpenPluginInfo Info;
+		HANDLE hPlugin = SrcPanel->GetPluginHandle();
+
+		if (hPlugin == INVALID_HANDLE_VALUE) {
+			return false;
+		}
+
+		CtrlObject->Plugins.GetOpenPluginInfo(hPlugin, &Info);
+
+		if (!(Info.Flags & OPIF_REALNAMES)) {
+			ExMessager em(Msg::ChAttrTitle);
+			em.AddMultiline(Msg::ChAttrWarnNoRealFile);
+			em.AddDup(Msg::Ok);
+			em.Show(MSG_WARNING, 1);
+			return false;
+		}
+	}
+
+	FARString strSelName;
+	DWORD FileAttr, FileMode;
+	SrcPanel->GetSelName(nullptr, FileAttr, FileMode);
+    SrcPanel->GetSelName(&strSelName, FileAttr, FileMode);
+	//SrcPanel->GetCurName(strSelName);
+
+	if (TestParentFolderName(strSelName))
+		return false;
+
+	FSFileFlags FFFlags(strSelName.GetMB());
+	if (FFFlags.Errno() != 0) {
+		FARString str;
+		str.Format(Msg::ChAttrErrorGetFlags.CPtr(), strSelName.CPtr());
+		error_append(str, FFFlags.Errno());
+
+		ExMessager em(Msg::ChAttrTitle);
+		em.AddMultiline(str.CPtr());
+		em.AddDup(Msg::Ok);
+		em.Show(MSG_WARNING, 1);
+		return false;
+	}
+
+	const int flags_list_y = ARRAYSIZE(flags_list);
+	int flags_list_x = strSelName.GetLength(); // width by file name
+	if (flags_list_x < flags_list_y) // width of next line with chars ___
+		flags_list_x = flags_list_y;
+	for (unsigned i=0; i<ARRAYSIZE(flags_list); i++) { // width of flags in list + 7=(" [ ] " + "  ")
+		int tmp = strlen(flags_list[i].name_long) + 7;
+		if (flags_list_x < tmp)
+			flags_list_x = tmp;
+	}
+	int DlgWidth = (ScrX - 14 < flags_list_x) ? ScrX + 1 - 2 : flags_list_x + 10;
+	int DlgHeight = (ScrY - 11 < flags_list_y) ? ScrY + 1 - 2 : flags_list_y + 9;
+	DialogDataEx ChattrDlgData[] = {
+		{DI_DOUBLEBOX, 3, 1, (short)(DlgWidth - 4), (short)(DlgHeight - 2), {}, DIF_SHOWAMPERSAND, Msg::ChAttrTitle},
+		{DI_TEXT,      4, 2, (short)(DlgWidth - 5), 2, {}, DIF_CENTERTEXT | DIF_SHOWAMPERSAND, strSelName},
+		{DI_TEXT,      4, 3, (short)(DlgWidth - 5), 3, {}, DIF_CENTERTEXT | DIF_SHOWAMPERSAND, L""},
+		{DI_TEXT,      0, 4, 0, 4, {}, DIF_SEPARATOR, L""},
+		{DI_LISTBOX,   4, 5, (short)(DlgWidth - 5), (short)(DlgHeight - 5), {}, DIF_FOCUS | DIF_LISTNOBOX /*| DIF_LISTNOCLOSE*/, L""},
+		{DI_TEXT,      0, (short)(DlgHeight - 4), 0, (short)(DlgHeight - 4), {}, DIF_SEPARATOR, L""},
+		{DI_BUTTON,    0, (short)(DlgHeight - 3), 0, (short)(DlgHeight - 3), {}, DIF_DEFAULT | DIF_CENTERGROUP, Msg::SetAttrSet},
+		{DI_BUTTON,    0, (short)(DlgHeight - 3), 0, (short)(DlgHeight - 3), {}, DIF_CENTERGROUP, Msg::Cancel}
+	};
+	MakeDialogItemsEx(ChattrDlgData, ChattrDlg);
+
+	TruncStr(ChattrDlg[CA_TEXT_FILENAME].strData, DlgWidth - 10);
+
+	Dialog Dlg(ChattrDlg, ARRAYSIZE(ChattrDlg), ChattrDlgProc, (LONG_PTR)&FFFlags);
+	//Dlg.SetHelp(L"Chattr");
+	Dlg.SetPosition(-1, -1, DlgWidth, DlgHeight);
+
+	Dlg.Process();
+
+	switch (Dlg.GetExitCode()) {
+		case CA_BUTTON_SET: {
+			FFFlags.Apply(strSelName.GetMB());
+			if (FFFlags.Errno() != 0) {
+				FARString str;
+				str.Format(Msg::ChAttrErrorSetFlags.CPtr(), strSelName.CPtr());
+				error_append(str, FFFlags.Errno());
+
+				ExMessager em(Msg::ChAttrTitle);
+				em.AddMultiline(str.CPtr());
+				em.AddDup(Msg::Ok);
+				em.Show(MSG_WARNING, 1);
+				return false;
+			}
+			return true;
+		} break;
+		default:
+			return false;
+	}
+}

--- a/far2l/src/chattr.cpp
+++ b/far2l/src/chattr.cpp
@@ -120,64 +120,79 @@ static struct {
 #if defined(__APPLE__) || defined(__FreeBSD__) || defined(__DragonFly__)
 // see actual constants in <sys/stat.h>
 // Super-user and owner changeable flags
-#ifdef UF_NODUMP	// 0x00000001
-	{ UF_NODUMP,		'+', "nodump: do not dump file (owner or super-user only)" },
+#ifdef UF_NODUMP		// 0x00000001
+	{ UF_NODUMP,		'+', "nodump:      do not dump file (owner or super-user only)" },
 #endif
-#ifdef UF_IMMUTABLE	// 0x00000002
-	{ UF_IMMUTABLE,		'+', "uimmutable: file may not be changed (owner or super-user only)" },
+#ifdef UF_IMMUTABLE		// 0x00000002
+	{ UF_IMMUTABLE,		'+', "uimmutable:  file may not be changed (owner or super-user only)" },
 #endif
-#ifdef UF_APPEND	// 0x00000004
-	{ UF_APPEND,		'+', "uappend: writes to file may only append (owner or super-user only)" },
+#ifdef UF_APPEND		// 0x00000004
+	{ UF_APPEND,		'+', "uappend:     writes to file may only append (owner or super-user only)" },
 #endif
-#ifdef UF_OPAQUE	// 0x00000008
-	{ UF_OPAQUE,		'+', "opaque: directory is opaque wrt. union (owner or super-user only)" },
+#ifdef UF_OPAQUE		// 0x00000008
+	{ UF_OPAQUE,		'+', "opaque:      directory is opaque wrt. union (owner or super-user only)" },
 #endif
-#ifdef UF_NOUNLINK	// 0x00000010
-	{ UF_NOUNLINK,		'+', "uunlink: file may not be removed or renamed (owner or super-user only)" },
+#ifdef UF_NOUNLINK		// 0x00000010
+	{ UF_NOUNLINK,		'+', "uunlink:     file may not be removed or renamed (owner or super-user only)" },
 #endif
-#ifdef UF_COMPRESSED	// 0x00000020
-	{ UF_COMPRESSED,	'+', "ucompressed: file is compressed (macOS only) (owner or super-user only)" },
+#ifdef UF_COMPRESSED	// 0x00000020 (in macOS)
+	{ UF_COMPRESSED,	'+', "ucompressed: file is compressed (macOS only) (read-only some file-systems)" },
 #endif
-#ifdef UF_TRACKED	// 0x00000040
-	{ UF_TRACKED,		'+', "utracked: renames and deletes are tracked (macOS only) (owner or super-user only)" },
+#ifdef UF_TRACKED		// 0x00000040 (in macOS)
+	{ UF_TRACKED,		'+', "utracked:    renames and deletes are tracked (macOS only) (owner or super-user only)" },
 #endif
-#ifdef UF_SYSTEM	// 0x00000080
-	{ UF_SYSTEM,		'+', "usystem: Windows system file bit (owner or super-user only)" },
+#ifdef UF_SYSTEM		// 0x00000080
+	{ UF_SYSTEM,		'+', "usystem:     Windows system file bit (owner or super-user only)" },
+#elif defined(UF_DATAVAULT)	// 0x00000080 (in macOS)
+	{ UF_DATAVAULT,		'+', "udatavault:  entitlement required for reading and writing (read-only)" },
 #endif
-#ifdef UF_SPARSE	// 0x00000100
-	{ UF_SPARSE,		'+', "usparse: sparse file (owner or super-user only)" },
+#ifdef UF_SPARSE		// 0x00000100
+	{ UF_SPARSE,		'+', "usparse:     sparse file (owner or super-user only)" },
 #endif
-#ifdef UF_OFFLINE	// 0x00000200
-	{ UF_OFFLINE,		'+', "uoffline: file is offline (owner or super-user only)" },
+#ifdef UF_OFFLINE		// 0x00000200
+	{ UF_OFFLINE,		'+', "uoffline:    file is offline (owner or super-user only)" },
 #endif
-#ifdef UF_REPARSE	// 0x00000400
-	{ UF_REPARSE,		'+', "ureparse: Windows reparse point file bit (owner or super-user only)" },
+#ifdef UF_REPARSE		// 0x00000400
+	{ UF_REPARSE,		'+', "ureparse:    Windows reparse point file bit (owner or super-user only)" },
 #endif
-#ifdef UF_ARCHIVE	// 0x00000800
-	{ UF_ARCHIVE,		'+', "uarchive: file needs to be archived (owner or super-user only)" },
+#ifdef UF_ARCHIVE		// 0x00000800
+	{ UF_ARCHIVE,		'+', "uarchive:    file needs to be archived (owner or super-user only)" },
 #endif
-#ifdef UF_READONLY	// 0x00001000
-	{ UF_READONLY,		'+', "ureadonly: Windows readonly file bit (owner or super-user only)" },
+#ifdef UF_READONLY		// 0x00001000
+	{ UF_READONLY,		'+', "ureadonly:   Windows readonly file bit (owner or super-user only)" },
 #endif
-#ifdef UF_HIDDEN	// 0x00008000
-	{ UF_HIDDEN,		'+', "uhidden: file is hidden (owner or super-user only)" },
+#ifdef UF_HIDDEN		// 0x00008000
+	{ UF_HIDDEN,		'+', "uhidden:     file is hidden (owner or super-user only)" },
 #endif
 // Super-user changeable flags
-#ifdef SF_ARCHIVED	// 0x00010000
-	{ SF_ARCHIVED,		'+', "sarchive: file is archived (super-user only)" },
+#ifdef SF_ARCHIVED		// 0x00010000
+	{ SF_ARCHIVED,		'+', "sarchive:    file is archived (super-user only)" },
 #endif
-#ifdef SF_IMMUTABLE	// 0x00020000
-	{ SF_IMMUTABLE,		'+', "simmutable: file may not be changed (super-user only)" },
+#ifdef SF_IMMUTABLE		// 0x00020000
+	{ SF_IMMUTABLE,		'+', "simmutable:  file may not be changed (super-user only)" },
 #endif
-#ifdef SF_APPEND	// 0x00040000
-	{ SF_APPEND,		'+', "sappend: writes to file may only append (super-user only)" },
+#ifdef SF_APPEND		// 0x00040000
+	{ SF_APPEND,		'+', "sappend:     writes to file may only append (super-user only)" },
 #endif
-#ifdef SF_NOUNLINK	// 0x00100000
-	{ SF_NOUNLINK,		'+', "sunlink: file may not be removed or renamed (super-user only)" },
+#ifdef SF_RESTRICTED	// 0x00080000 (in macOS)
+	{ SF_RESTRICTED,	'+', "srestricted: entitlement required for writing (super-user only)" },
 #endif
-#ifdef SF_SNAPSHOT	// 0x00200000
-	{ SF_SNAPSHOT,		'+', "snapshot: snapshot inode (filesystems do not allow changing this flag)" },
+#ifdef SF_NOUNLINK		// 0x00100000
+	{ SF_NOUNLINK,		'+', "sunlink:     file may not be removed or renamed (super-user only)" },
 #endif
+#ifdef SF_SNAPSHOT		// 0x00200000
+	{ SF_SNAPSHOT,		'+', "snapshot:    snapshot inode (filesystems do not allow changing this flag)" },
+#endif
+#ifdef SF_FIRMLINK		// 0x00800000 (in macOS)
+	{ SF_FIRMLINK,		'+', "sfirmlink:   file is a firmlink (super-user only)" },
+#endif
+#ifdef SF_DATALESS		// 0x40000000 (in macOS)
+	{ SF_DATALESS,		'+', "sdataless:   file is dataless object (read-only)" },
+#endif
+#endif
+
+#if defined(__HAIKU__)
+// TODO ?
 #endif
 };
 

--- a/far2l/src/chattr.hpp
+++ b/far2l/src/chattr.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+/*
+chattr.hpp
+
+Просмотр и установка атрибутов/флагов файлов аналогично lsattr/ls -lo и chattr/chflags
+*/
+/*
+Copyright (c) 2025- Far2l Group
+*/
+
+bool ChattrDialog(Panel *SrcPanel);

--- a/far2l/src/main.cpp
+++ b/far2l/src/main.cpp
@@ -312,22 +312,18 @@ static int MainProcess(FARString strEditViewArg, FARString strDestName1, FARStri
 				if (tweaks & TWEAK_STATUS_SUPPORT_OSC52CLIP_SET) {
 					SetMessageHelp(L"Far2lGettingStarted");
 
-					std::wstring source_str = Msg::OSC52Confirm.CPtr();
-					std::vector<std::wstring> lines;
 					ExMessager em;
-					StrExplode(lines, source_str, L"\n", false);
-					for (const auto &current_line : lines) {
-						em.AddDup(current_line.c_str());
-					}
+					em.AddMultiline(Msg::OSC52Confirm);
 					em.AddDup(L"Yes");
 					em.AddDup(L"No");
 
 					if (em.Show(0, 2)) {
-						Opt.OSC52ClipSet = 0;
+						if (Opt.OSC52ClipSet != 0)
+						{ Opt.OSC52ClipSet = 0; cfgNeedSave = true; }
 					} else {
-						Opt.OSC52ClipSet = 1;
+						if (Opt.OSC52ClipSet != 1)
+						{ Opt.OSC52ClipSet = 1; cfgNeedSave = true; }
 					}
-					cfgNeedSave = true;
 				}
 			}
 

--- a/far2l/src/message.cpp
+++ b/far2l/src/message.cpp
@@ -566,6 +566,16 @@ Messager &FN_NOINLINE ExMessager::AddDup(const wchar_t *v)
 	return *this;
 }
 
+Messager &FN_NOINLINE ExMessager::AddMultiline(const wchar_t *v, const wchar_t *divs)
+{
+	std::wstring source_str = v;
+	std::vector<std::wstring> lines;
+	StrExplode(lines, source_str, divs, false);
+	for (const auto &current_line : lines)
+		AddDup(current_line.c_str());
+	return *this;
+}
+
 ///////////////////////////////////
 
 void GetMessagePosition(int &X1, int &Y1, int &X2, int &Y2)

--- a/far2l/src/message.hpp
+++ b/far2l/src/message.hpp
@@ -89,6 +89,9 @@ struct ExMessager : Messager
 	Messager &AddFormat(FarLangMsg fmt, ...);
 	Messager &AddFormat(const wchar_t *fmt, ...);
 	Messager &AddDup(const wchar_t *v);
+	Messager &AddMultiline(const wchar_t *v, const wchar_t *divs = L"\n");
+	inline Messager &AddMultiline(FarLangMsg v, const wchar_t *divs = L"\n")
+	{ return AddMultiline(v.CPtr(), divs); };
 
 private:
 	std::vector<FARString> _owneds;

--- a/far2l/src/mix/FSFileFlags.cpp
+++ b/far2l/src/mix/FSFileFlags.cpp
@@ -18,8 +18,9 @@ FSFileFlags::FSFileFlags(const std::string &path)
 	if (sdc_fs_flags_get(path.c_str(), &_flags) == 0) {
 		_valid = true;
 		_actual_flags = _flags;
-
+		_errno = 0;
 	} else {
+		_errno = errno;
 		fprintf(stderr, "FSFileFlags: error %d; path='%s'\n", errno, path.c_str());
 	}
 }
@@ -27,14 +28,17 @@ FSFileFlags::FSFileFlags(const std::string &path)
 void FSFileFlags::Apply(const std::string &path, bool force)
 {
 	if (!_valid) {
+		_errno = -1;
 		fprintf(stderr, "FSFileFlags::Apply: not valid; path='%s'\n", path.c_str());
 
 	} else if (_flags != _actual_flags || force) {
 		if (sdc_fs_flags_set(path.c_str(), _flags) == 0) {
 			_actual_flags = _flags;
+			_errno = 0;
 			fprintf(stderr, "FSFileFlags::Apply: OK; path='%s'\n", path.c_str());
 
 		} else {
+			_errno = errno;
 			fprintf(stderr, "FSFileFlags::Apply: error %d; path='%s'\n", errno, path.c_str());
 		}
 	}

--- a/far2l/src/mix/FSFileFlags.cpp
+++ b/far2l/src/mix/FSFileFlags.cpp
@@ -41,7 +41,8 @@ void FSFileFlags::Apply(const std::string &path, bool force)
 			_errno = errno;
 			fprintf(stderr, "FSFileFlags::Apply: error %d; path='%s'\n", errno, path.c_str());
 		}
-	}
+	} else
+		_errno = 0;
 }
 
 ////////

--- a/far2l/src/mix/FSFileFlags.h
+++ b/far2l/src/mix/FSFileFlags.h
@@ -12,6 +12,7 @@ class FSFileFlags
 public:
 	FSFileFlags(const std::string &path);
 	void Apply(const std::string &path, bool force = false);
+	inline void Reset() { _flags = _actual_flags; }
 
 	inline bool Valid() const { return _valid; }
 

--- a/far2l/src/mix/FSFileFlags.h
+++ b/far2l/src/mix/FSFileFlags.h
@@ -7,12 +7,15 @@ class FSFileFlags
 {
 	unsigned long _flags = 0, _actual_flags = 0;
 	bool _valid = false;
+	int _errno = 0;
 
 public:
 	FSFileFlags(const std::string &path);
 	void Apply(const std::string &path, bool force = false);
 
 	inline bool Valid() const { return _valid; }
+
+	inline int Errno() const { return _errno; }
 
 
 	bool Immutable() const;

--- a/far2l/src/mix/FSFileFlags.h
+++ b/far2l/src/mix/FSFileFlags.h
@@ -17,6 +17,12 @@ public:
 
 	inline int Errno() const { return _errno; }
 
+	inline unsigned long GetFlags() const { return _flags; }
+	inline unsigned long GetActualFlags() const { return _actual_flags; }
+
+	inline bool FlagIsOn(unsigned long flag) const { return _flags & flag; }
+	inline bool FlagEqActual(unsigned long flag) const { return (_flags & flag) == (_actual_flags & flag); }
+	inline void FlagInverse(unsigned long flag) { _flags = _flags ^ flag; }
 
 	bool Immutable() const;
 	void SetImmutable(bool v);

--- a/far2l/src/options.cpp
+++ b/far2l/src/options.cpp
@@ -111,6 +111,7 @@ enum enumFilesMenu
 	MENU_FILES_ARCHIVECOMMANDS,
 	MENU_FILES_SEPARATOR2,
 	MENU_FILES_ATTRIBUTES,
+	MENU_FILES_CHATTR,
 	MENU_FILES_APPLYCOMMAND,
 	MENU_FILES_DESCRIBE,
 	MENU_FILES_SEPARATOR3,
@@ -242,6 +243,7 @@ void ShellOptions(int LastCommand, MOUSE_EVENT_RECORD *MouseEvent)
 		{Msg::MenuArchiveCommands,  0,             KEY_SHIFTF3 },
 		{L"",                       LIF_SEPARATOR, 0           },
 		{Msg::MenuAttributes,       0,             KEY_CTRLA   },
+		{Msg::MenuChattr,           0,             KEY_CTRLALTA},
 		{Msg::MenuApplyCommand,     0,             KEY_CTRLG   },
 		{Msg::MenuDescribe,         0,             KEY_CTRLZ   },
 		{L"",                       LIF_SEPARATOR, 0           },
@@ -467,6 +469,9 @@ void ShellOptions(int LastCommand, MOUSE_EVENT_RECORD *MouseEvent)
 					break;
 				case MENU_FILES_ATTRIBUTES:		// File attributes
 					CtrlObject->Cp()->ActivePanel->ProcessKey(KEY_CTRLA);
+					break;
+				case MENU_FILES_CHATTR:		// chattr
+					CtrlObject->Cp()->ActivePanel->ProcessKey(KEY_CTRLALTA);
 					break;
 				case MENU_FILES_APPLYCOMMAND:	// Apply command
 					CtrlObject->Cp()->ActivePanel->ProcessKey(KEY_CTRLG);

--- a/far2l/src/panels/filelist.cpp
+++ b/far2l/src/panels/filelist.cpp
@@ -66,6 +66,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "stddlg.hpp"
 #include "mkdir.hpp"
 #include "setattr.hpp"
+#include "chattr.hpp"
 #include "filetype.hpp"
 #include "execute.hpp"
 #include "Bookmarks.hpp"
@@ -1189,6 +1190,16 @@ int FileList::ProcessKey(FarKey Key)
 
 			if (!ListData.IsEmpty() && SetCurPath()) {
 				ShellSetFileAttributes(this);
+				Show();
+			}
+
+			return TRUE;
+		}
+		case KEY_CTRLALTA: {
+			_ALGO(CleverSysLog clv(L"Ctrl-Alt-A"));
+
+			if (!ListData.IsEmpty() && SetCurPath()) {
+				ChattrDialog(this);
 				Show();
 			}
 

--- a/far2l/src/setattr.cpp
+++ b/far2l/src/setattr.cpp
@@ -1139,11 +1139,12 @@ bool ShellSetFileAttributes(Panel *SrcPanel, LPCWSTR Object)
 		AttrDlg[SA_FIXEDIT_LAST_ACCESS_TIME].strMask = AttrDlg[SA_FIXEDIT_LAST_MODIFICATION_TIME].strMask =
 				AttrDlg[SA_FIXEDIT_LAST_CHANGE_TIME].strMask = strTMask;
 		bool FolderPresent = false;//, LinkPresent = false;
-		int  FolderCount = 0, Link2FileCount = 0, Link2DirCount = 0;
+		int  FolderCount = 0, Link2FileCount = 0, Link2DirCount = 0, DeviceCount = 0, FSFileFlagsErrno = 0;
 		FARString strLinkName;
 
 		if (SelCount == 1) {
 			FSFileFlagsSafe FFFlags(strSelName.GetMB(), FileAttr);
+			FSFileFlagsErrno = FFFlags.Errno();
 			if (FileAttr & FILE_ATTRIBUTE_REPARSE_POINT) {
 				DlgParam.SymlinkButtonTitles[0] = Msg::SetAttrSymlinkObject;
 				DlgParam.SymlinkButtonTitles[1] = Msg::SetAttrSymlinkObjectInfo;
@@ -1165,9 +1166,8 @@ bool ShellSetFileAttributes(Panel *SrcPanel, LPCWSTR Object)
 				AttrDlg[SA_EDIT_INFO].strData = Msg::FileFilterAttrDevFIFO;
 			else if (FileAttr & FILE_ATTRIBUTE_DEVICE_SOCK)
 				AttrDlg[SA_EDIT_INFO].strData = Msg::FileFilterAttrDevSock;
-			else {
+			else
 				AttrDlg[SA_EDIT_INFO].strData = BriefInfo(strSelName);
-			}
 
 
 			if (FileAttr & FILE_ATTRIBUTE_DIRECTORY) {
@@ -1272,7 +1272,7 @@ bool ShellSetFileAttributes(Panel *SrcPanel, LPCWSTR Object)
 				SrcPanel->GetSelName(nullptr, FileAttr, FileMode);
 			}
 			FolderPresent = false;
-			FolderCount = 0; Link2FileCount = 0; Link2DirCount = 0;
+			FolderCount = 0; Link2FileCount = 0; Link2DirCount = 0; DeviceCount = 0;
 
 			if (SrcPanel) {
 				FARString strComputerName;
@@ -1299,6 +1299,8 @@ bool ShellSetFileAttributes(Panel *SrcPanel, LPCWSTR Object)
 					}
 					else if (FileAttr & FILE_ATTRIBUTE_REPARSE_POINT)
 						Link2FileCount++;
+					else if (FileAttr & FILE_ATTRIBUTE_DEVICE)
+						DeviceCount++;
 
 					for (size_t i = 0; i < ARRAYSIZE(AP); i++) {
 						if (FileMode & AP[i].Mode) {
@@ -1309,6 +1311,8 @@ bool ShellSetFileAttributes(Panel *SrcPanel, LPCWSTR Object)
 					CheckFileOwnerGroup(AttrDlg[SA_COMBO_GROUP], GetFileGroup, strComputerName, strSelName);
 
 					FSFileFlagsSafe FFFlags(strSelName.GetMB(), FileAttr);
+					if( FFFlags.Errno() != 0 ) // last errno if was error
+						FSFileFlagsErrno = FFFlags.Errno();
 					if (FFFlags.Immutable())
 						AttrDlg[SA_CHECKBOX_IMMUTABLE].Selected++;
 					if (FFFlags.Append())
@@ -1357,8 +1361,10 @@ bool ShellSetFileAttributes(Panel *SrcPanel, LPCWSTR Object)
 
 			{
 				FARString strTmp, strSep=L" (";
-				int FilesCount = SelCount-FolderCount-Link2FileCount-Link2DirCount;
+				int FilesCount = SelCount-DeviceCount-FolderCount-Link2FileCount-Link2DirCount;
 				strTmp.Format(Msg::SetAttrInfoSelAll, SelCount);
+				if (DeviceCount>0)
+				{ strTmp.AppendFormat(Msg::SetAttrInfoSelDevices, strSep.CPtr(), DeviceCount); strSep=L", "; }
 				if (FolderCount>0)
 				{ strTmp.AppendFormat(Msg::SetAttrInfoSelDirs, strSep.CPtr(), FolderCount); strSep=L", "; }
 				if (FilesCount>0)
@@ -1410,7 +1416,20 @@ bool ShellSetFileAttributes(Panel *SrcPanel, LPCWSTR Object)
 
 		DlgParam.strOwner = AttrDlg[SA_COMBO_OWNER].strData;
 		DlgParam.strGroup = AttrDlg[SA_COMBO_GROUP].strData;
-		DlgParam.strInitOwner = DlgParam.strOwner; DlgParam.strInitGroup = DlgParam.strGroup;
+		DlgParam.strInitOwner = DlgParam.strOwner;
+		DlgParam.strInitGroup = DlgParam.strGroup;
+
+		// if was error during obtain attributes / flags make it disabled
+		if (FSFileFlagsErrno != 0) {
+			AttrDlg[SA_TEXT_IMMUTABLE_CHMARK].Flags|= DIF_DISABLE;
+			AttrDlg[SA_CHECKBOX_IMMUTABLE].Flags|= DIF_DISABLE;
+			AttrDlg[SA_TEXT_APPEND_CHMARK].Flags|= DIF_DISABLE;
+			AttrDlg[SA_CHECKBOX_APPEND].Flags|= DIF_DISABLE;
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__DragonFly__)
+			AttrDlg[SA_TEXT_HIDDEN_CHMARK].Flags|= DIF_DISABLE;
+			AttrDlg[SA_CHECKBOX_HIDDEN].Flags|= DIF_DISABLE;
+#endif
+		}
 
 		DlgParam.DialogMode = ((SelCount == 1 && !(FileAttr & FILE_ATTRIBUTE_DIRECTORY))
 						? MODE_FILE


### PR DESCRIPTION
* new function `ExMessager::AddMultiline()` & tuning after #2576
* save errno after flags operations
* setattr (Ctrl-A) count devices + disable attributes/flags if was error

Возможно странно ловятся ошибки работы с атрибутами: для устройств или любых файлах на разделах, не поддерживающих атрибуты, - ловятся, а для симлинков на обычных разделах нет ошибки, хотя и **lsattr** и **mc->File->chattr** на них также ругаются кодом 95 "Operation not supported". ~Но по всей навороченной касакдности вызовов внутри far2l (`sdc_fs_flags_get` обернутое вокруг `bugaware_ioctl_pint`) я запутался теряются ли там errno или просто lsattr не умеет, то что умеет ext4.~

_Разобрался_ - см. ниже **UPD3**.

* **UPD:** Новый диалог для выставления известных мне из `<linux/fs.h>` и `<sys/stat.h>` атрибутов/флагов.

(!) Протестировано только на linux - возможно на *BSD или macOS будут сюрпризы, хотя вроде бы не должно - в коде все системно зависимые места максимально обложены `#ifdef`. 

![image](https://github.com/user-attachments/assets/a256ca45-206d-49e3-8985-a96fbb1f2d62)

![image](https://github.com/user-attachments/assets/40214d5d-8ea2-474e-8b47-ece6d97bf363)

![image](https://github.com/user-attachments/assets/463b938b-c210-4432-92e7-c3adb5b77991)

![image](https://github.com/user-attachments/assets/39d1cecd-31a1-46e6-9580-e4c1b2477213)

![image](https://github.com/user-attachments/assets/d9f09885-c8ec-4104-9e80-0d6c29b0c689)

![image](https://github.com/user-attachments/assets/f58101fa-1689-4e80-8190-0f7db49580c7)

* **UPD2:** в тг-чате обратили внимание, что
    > если кликать мышкой в область открывающих квадратных скобок флажков атрибутов, то выставляется/снимается не тот флажок, куда тыкнул, а тот, на котором курсорная рамка сейчас стоит

    Проверил - действительно иногда есть такое - очень странное поведение при том, что никаких выделенных '[' там нет - это просто второй символ в строке списка (первый либо ' ', либо '*'). 

    Это общее для всех VMenu и связано с реализацией горизонтальной прокрутки: https://github.com/elfmz/far2l/blob/9fb213347946d753d55f9c95ac7f9cb171230894/far2l/src/vmenu.cpp#L1215-L1222 - т.е. при нажатии **в области на 2 символа отстоящие от края** происходит попытка прокручивания без смены активной строки. _Без правки `VMenu::ProcessMouse()` такое поведение не поменять - наверное когда-то в будущем_ 🤯

* **UPD3:**
    > а для симлинков на обычных разделах нет ошибки

    Разобрался, взглянув внимательнее в потроха: в [WinPort/src/sudo/sudo_client_api.cpp](https://github.com/elfmz/far2l/blob/master/WinPort/src/sudo/sudo_client_api.cpp) в `sdc_fs_flags_get()` и `sdc_fs_flags_set()` для именно Linux используется `open(path, O_RDONLY);` к которому затем применяется `bugaware_ioctl_pint(fd, FS_IOC_GETFLAGS, flags);`. Так вот `open()` без маски `O_NOFOLLOW` **переходит по symlink  и работает с целевым файлом**. Для *BSD/macOS используется `sdc_stat`, который такое вроде вытворять не должен.

    ~Как про такое поведение предупреждать пользователей? Добавить строку как и в Ctrl+A, например, "For symlinks flags are displayed and will be modified for the original object"? Или сразу, если работаем с симлинк, то делать { Set } disabled и не позволять менять галочки?~

    Сделал всегда жесткое предупреждение и отвал без показа флагов:
![image](https://github.com/user-attachments/assets/68d0cbce-9192-4051-b88a-401b12557bac)
