### PR TITLE
Bring back symlink resolving via hotkeys, as in FAR2/3

### DIFF
--- a/far2l/bootstrap/scripts/farlang.templ.m4
+++ b/far2l/bootstrap/scripts/farlang.templ.m4
@@ -2199,6 +2199,17 @@ ConfigAutoUpdateLimit2
 "якщо об'ектів більше"
 "калі аб'ектаў больш"
 
+ConfigClassicHotkeyLinkResolving
+"&Классическое разрешение ссылок по хоткеям"
+"Classic hotkey &link resolving"
+upd:"Classic hotkey link resolving"
+upd:"Classic hotkey link resolving"
+upd:"Classic hotkey link resolving"
+upd:"Classic hotkey link resolving"
+upd:"Classic hotkey link resolving"
+"&Класичне розширення посилань гарячими клавішами"
+upd:"Classic hotkey link resolving"
+
 ConfigAutoUpdateRemoteDrive
 "Автообновление с&етевых дисков"
 "Network drives autor&efresh"

--- a/far2l/src/cfg/ConfigOpt.cpp
+++ b/far2l/src/cfg/ConfigOpt.cpp
@@ -397,6 +397,7 @@ const ConfigOpt g_cfg_opts[] {
 	{true,  NSecPanel, "DirNameStyle", &Opt.DirNameStyle, 0 },
 	{true,  NSecPanel, "DirNameStyleColumnWidthAlways", &Opt.DirNameStyleColumnWidthAlways, 0 },
 	{true,  NSecPanel, "ShowSymlinkSize", &Opt.ShowSymlinkSize, 0},
+	{true,  NSecPanel, "ClassicHotkeyLinkResolving", &Opt.ClassicHotkeyLinkResolving, 1},
 
 	{true,  NSecPanelLeft, "Type", &Opt.LeftPanel.Type, 0},
 	{true,  NSecPanelLeft, "Visible", &Opt.LeftPanel.Visible, 1},

--- a/far2l/src/cfg/config.cpp
+++ b/far2l/src/cfg/config.cpp
@@ -277,6 +277,7 @@ void PanelSettings()
 		AutoUpdateLimit->Indent(4);
 		AutoUpdateText->Indent(4);
 		Builder.AddCheckbox(Msg::ConfigAutoUpdateRemoteDrive, &Opt.AutoUpdateRemoteDrive);
+		Builder.AddCheckbox(Msg::ConfigClassicHotkeyLinkResolving, &Opt.ClassicHotkeyLinkResolving);
 
 		Builder.AddSeparator();
 		Builder.AddCheckbox(Msg::ConfigShowColumns, &Opt.ShowColumnTitles);

--- a/far2l/src/cfg/config.hpp
+++ b/far2l/src/cfg/config.hpp
@@ -522,6 +522,7 @@ struct Options
 	FARString strLanguage;
 	int SmallIcon;
 	FARString strRegRoot;
+	int ClassicHotkeyLinkResolving;
 	int PanelRightClickRule;	// задает поведение правой клавиши мыши
 	int PanelCtrlAltShiftRule;	// задает поведение Ctrl-Alt-Shift для панелей.
 	// Panel/CtrlFRule в реестре - задает поведение Ctrl-F. Если = 0, то штампуется файл как есть, иначе - с учетом отображения на панели

--- a/far2l/src/editor.cpp
+++ b/far2l/src/editor.cpp
@@ -2329,10 +2329,10 @@ int Editor::ProcessKey(FarKey Key)
 			Show();
 			return TRUE;
 		}
-		case KEY_CTRLALTBRACKET:		// Вставить сетевое (UNC) путь из левой панели
-		case KEY_CTRLALTBACKBRACKET:	// Вставить сетевое (UNC) путь из правой панели
-		case KEY_ALTSHIFTBRACKET:		// Вставить сетевое (UNC) путь из активной панели
-		case KEY_ALTSHIFTBACKBRACKET:	// Вставить сетевое (UNC) путь из пассивной панели
+		case KEY_CTRLALTBRACKET:		// Вставить реальный (разрешенный) путь из левой панели
+		case KEY_CTRLALTBACKBRACKET:	// Вставить реальный (разрешенный) путь из правой панели
+		case KEY_ALTSHIFTBRACKET:		// Вставить реальный (разрешенный) путь из активной панели
+		case KEY_ALTSHIFTBACKBRACKET:	// Вставить реальный (разрешенный) путь из пассивной панели
 		case KEY_CTRLBRACKET:			// Вставить путь из левой панели
 		case KEY_CTRLBACKBRACKET:		// Вставить путь из правой панели
 		case KEY_CTRLSHIFTBRACKET:		// Вставить путь из активной панели

--- a/far2l/src/mix/panelmix.cpp
+++ b/far2l/src/mix/panelmix.cpp
@@ -171,10 +171,10 @@ int _MakePath1(DWORD Key, FARString &strPathName, const wchar_t *Param2, int esc
 	strPathName.Clear();
 
 	switch (Key) {
-		case KEY_CTRLALTBRACKET:		// Вставить сетевое (UNC) путь из левой панели
-		case KEY_CTRLALTBACKBRACKET:	// Вставить сетевое (UNC) путь из правой панели
-		case KEY_ALTSHIFTBRACKET:		// Вставить сетевое (UNC) путь из активной панели
-		case KEY_ALTSHIFTBACKBRACKET:	// Вставить сетевое (UNC) путь из пассивной панели
+		case KEY_CTRLALTBRACKET:		// Вставить реальный (разрешенный) путь из левой панели
+		case KEY_CTRLALTBACKBRACKET:	// Вставить реальный (разрешенный) путь из правой панели
+		case KEY_ALTSHIFTBRACKET:		// Вставить реальный (разрешенный) путь из активной панели
+		case KEY_ALTSHIFTBACKBRACKET:	// Вставить реальный (разрешенный) путь из пассивной панели
 			NeedRealName = TRUE;
 		case KEY_CTRLBRACKET:			// Вставить путь из левой панели
 		case KEY_CTRLBACKBRACKET:		// Вставить путь из правой панели
@@ -225,7 +225,7 @@ int _MakePath1(DWORD Key, FARString &strPathName, const wchar_t *Param2, int esc
 							&& SrcPanel->GetMode() != PLUGIN_PANEL) {
 						FileList *SrcFilePanel = (FileList *)SrcPanel;
 						SrcFilePanel->CreateFullPathName(strPathName, FILE_ATTRIBUTE_DIRECTORY, strPathName,
-								TRUE);
+								true);
 					}
 
 					AddEndSlash(strPathName);

--- a/far2l/src/panels/filelist.cpp
+++ b/far2l/src/panels/filelist.cpp
@@ -1037,7 +1037,7 @@ int FileList::ProcessKey(FarKey Key)
 		case KEY_CTRLSHIFTNUMPAD0:
 		case KEY_CTRLC:				// копировать имена
 		case KEY_CTRLALTINS:
-		case KEY_CTRLALTNUMPAD0:	// копировать UNC-имена
+		case KEY_CTRLALTNUMPAD0:	// копировать реальные (разрешенные) имена
 		case KEY_ALTSHIFTINS:
 		case KEY_ALTSHIFTNUMPAD0:
 		case KEY_ALTSHIFTC:		// копировать полные имена
@@ -1049,8 +1049,8 @@ int FileList::ProcessKey(FarKey Key)
 			{
 				bool FullPath = Key == KEY_CTRLALTINS || Key == KEY_ALTSHIFTINS || Key == KEY_CTRLALTNUMPAD0
 						|| Key == KEY_ALTSHIFTNUMPAD0 || Key == KEY_ALTSHIFTC;
-				bool unc = (Key & (KEY_CTRL | KEY_ALT)) == (KEY_CTRL | KEY_ALT);
-				CopyNames(FullPath, unc);
+				bool RealName = (Key & (KEY_CTRL | KEY_ALT)) == (KEY_CTRL | KEY_ALT);
+				CopyNames(FullPath, RealName);
 			}
 			return TRUE;
 
@@ -1063,7 +1063,7 @@ int FileList::ProcessKey(FarKey Key)
 			/*
 				$ 14.02.2001 VVM
 				+ Ctrl: вставляет имя файла с пассивной панели.
-				+ CtrlAlt: вставляет UNC-имя файла с пассивной панели
+				+ CtrlAlt: вставляет реальное (разрешенное) имя файла с пассивной панели
 			*/
 		case KEY_CTRL | KEY_SEMICOLON:
 		case KEY_CTRL | KEY_ALT | KEY_SEMICOLON: {
@@ -1168,10 +1168,10 @@ int FileList::ProcessKey(FarKey Key)
 
 			return TRUE;
 		}
-		case KEY_CTRLALTBRACKET:			// Вставить сетевое (UNC) путь из левой панели
-		case KEY_CTRLALTBACKBRACKET:		// Вставить сетевое (UNC) путь из правой панели
-		case KEY_ALTSHIFTBRACKET:			// Вставить сетевое (UNC) путь из активной панели
-		case KEY_ALTSHIFTBACKBRACKET:		// Вставить сетевое (UNC) путь из пассивной панели
+		case KEY_CTRLALTBRACKET:			// Вставить реальный (разрешенный) путь из левой панели
+		case KEY_CTRLALTBACKBRACKET:		// Вставить реальный (разрешенный) путь из правой панели
+		case KEY_ALTSHIFTBRACKET:			// Вставить реальный (разрешенный) путь из активной панели
+		case KEY_ALTSHIFTBACKBRACKET:		// Вставить реальный (разрешенный) путь из пассивной панели
 		case KEY_CTRLBRACKET:				// Вставить путь из левой панели
 		case KEY_CTRLBACKBRACKET:			// Вставить путь из правой панели
 		case KEY_CTRLSHIFTBRACKET:			// Вставить путь из активной панели
@@ -3674,7 +3674,7 @@ void FileList::CopyFiles()
 			if (TestParentFolderName(strSelName)) {
 				strSelName.Truncate(1);
 			}
-			if (!CreateFullPathName(strSelName, FileAttr, strSelName, FALSE)) {
+			if (!CreateFullPathName(strSelName, FileAttr, strSelName, false)) {
 				if (CopyData) {
 					free(CopyData);
 					CopyData = nullptr;
@@ -3704,7 +3704,7 @@ void FileList::CopyFiles()
 	}
 }
 
-void FileList::CopyNames(bool FullPathName, bool UNC)
+void FileList::CopyNames(bool FullPathName, bool RealName)
 {
 	OpenPluginInfo Info{};
 	wchar_t *CopyData = nullptr;
@@ -3736,7 +3736,7 @@ void FileList::CopyNames(bool FullPathName, bool UNC)
 					strQuotedName.Truncate(1);
 				}
 
-				if (!CreateFullPathName(strQuotedName, FileAttr, strQuotedName, UNC)) {
+				if (!CreateFullPathName(strQuotedName, FileAttr, strQuotedName, RealName)) {
 					if (CopyData) {
 						free(CopyData);
 						CopyData = nullptr;
@@ -3803,7 +3803,7 @@ void FileList::CopyNames(bool FullPathName, bool UNC)
 	free(CopyData);
 }
 
-FARString &FileList::CreateFullPathName(const wchar_t *Name, DWORD FileAttr, FARString &strDest, int UNC)
+FARString &FileList::CreateFullPathName(const wchar_t *Name, DWORD FileAttr, FARString &strDest, bool RealName)
 {
 	FARString strFileName = strDest;
 	const wchar_t *NameLastSlash = LastSlash(Name);
@@ -3812,12 +3812,9 @@ FARString &FileList::CreateFullPathName(const wchar_t *Name, DWORD FileAttr, FAR
 		ConvertNameToFull(strFileName, strFileName);
 	}
 
-	/*
-		$ 29.01.2001 VVM
-		+ По CTRL+ALT+F в командную строку сбрасывается UNC-имя текущего файла.
-	*/
-	/*if (UNC)
-		ConvertNameToUNC(strFileName);*/
+	if (Opt.ClassicHotkeyLinkResolving && RealName) {
+		ConvertNameToReal(strFileName, strFileName);
+	}
 
 	// $ 20.10.2000 SVS Сделаем фичу Ctrl-F опциональной!
 	if (Opt.PanelCtrlFRule) {

--- a/far2l/src/panels/filelist.hpp
+++ b/far2l/src/panels/filelist.hpp
@@ -267,7 +267,7 @@ private:
 	void PushPlugin(HANDLE hPlugin, const wchar_t *HostFile);
 	int PopPlugin(int EnableRestoreViewMode);
 	void CopyFiles();
-	void CopyNames(bool FullPathName, bool UNC);
+	void CopyNames(bool FullPathName, bool RealName);
 	void SelectSortMode();
 	bool ApplyCommand();
 	void DescribeFiles();
@@ -399,7 +399,7 @@ public:
 	int PluginPanelHelp(HANDLE hPlugin);
 	virtual long GetFileCount() { return ListData.Count(); }
 
-	FARString &CreateFullPathName(const wchar_t *Name, DWORD FileAttr, FARString &strDest, int UNC);
+	FARString &CreateFullPathName(const wchar_t *Name, DWORD FileAttr, FARString &strDest, bool RealName);
 
 	virtual const void *GetItem(int Index);
 	virtual BOOL UpdateKeyBar();


### PR DESCRIPTION
Вместе с унаследованным UNC-кодом из far2l был также удалён функционал разрешения символических ссылок и получения реальных путей при процессинге хоткеев в панелях:


```
  Вставить сетевое (UNC) имя файла из активной панели     Ctrl-Alt-F
  Вставить сетевое (UNC) имя файла из пассивной панели    Ctrl-Alt-;
  Вставить сетевой (UNC) путь из левой панели             Ctrl-Alt-[
  Вставить сетевой (UNC) путь из правой панели            Ctrl-Alt-]
  Вставить сетевой (UNC) путь из активной панели         Alt-Shift-[
  Вставить сетевой (UNC) путь из пассивной панели        Alt-Shift-]
  Поместить сетевые (UNC) имена помеченных файлов       Ctrl-Alt-Ins
   в Буфер Обмена (без учёта состояния командной
   строки)


  5. Комбинации клавиш, позволяющие получить сетевое (UNC) имя файлового
объекта, работают по следующим правилам:
      * для сетевых дисков - сетевое (UNC) имя файлового объекта;
      * для локальных дисков - полное имя с учётом символических ссылок.

```
Сейчас эти комбинации дублируют поведение `Ctrl-F`, `Ctrl-;` , ... , `Alt-Shift-Ins`, работая с неразрешенными путями.

Мнения в чате разделились, но большинство проголосовавших за приведение текущего поведения far2l в соответствии с помощью и поведением виндового прародителя.

PR возвращает функционал, но опционально, чтобы не ломать пользовательский опыт тех, кто уже привык к текущему поведению far2l:

```
╔════════════════ Настройки панели ════════════════╗
║ [ ] Показывать скрытые и системные файлы         ║
║ [ ] Раскраска файлов                             ║
║   [ Раскраска файлов - Маркировка ]              ║
║  [ Каталоги и симлинки в колонке Размер ]        ║
║ [ ] Автосмена папки                              ║
║ [ ] Пометка папок                                ║
║ [ ] Учитывать регистр при сравнении или пометке  ║
║ [ ] Сортировать имена папок по расширению        ║
║ [ ] Разрешить обратную сортировку                ║
║ [ ] Отключать автообновление панелей,            ║
║     если объектов больше 0                       ║
║ [ ] Автообновление сетевых дисков                ║
║ [x] Классическое разрешение ссылок по хоткеям    ║
╟──────────────────────────────────────────────────╢
║ [ ] Показывать заголовки колонок                 ║
║ [ ] Показывать строку статуса                    ║
║ [ ] Показывать суммарную информацию              ║
║ [ ] Показывать свободное место                   ║
║ [ ] Показывать полосу прокрутки                  ║
║ [ ] Показывать количество фоновых экранов        ║
║ [ ] Показывать букву режима сортировки           ║
╟──────────────────────────────────────────────────╢
║                { OK } [ Отмена ]                 ║
╚══════════════════════════════════════════════════╝
```

