### PR TITLE
Update NetRocks libnfs 6.0.x compatibility

### DIFF
--- a/NetRocks/CMakeLists.txt
+++ b/NetRocks/CMakeLists.txt
@@ -151,7 +151,7 @@ if (LIBNFS_FOUND AND ((NOT DEFINED NR_NFS) OR NR_NFS))
     target_link_libraries(NetRocks-NFS utils ${LIBNFS_LIBRARIES})
     find_package(GnuTLS)
     if (GNUTLS_FOUND)
-        target_link_libraries(NetRocks-NFS gnutls)
+        target_link_libraries(NetRocks-NFS ${GNUTLS_LIBRARIES})
     endif ()
     target_include_directories(NetRocks-NFS PRIVATE src ${LIBNFS_INCLUDE_DIRS})
     set_target_properties(NetRocks-NFS

--- a/NetRocks/CMakeLists.txt
+++ b/NetRocks/CMakeLists.txt
@@ -149,6 +149,10 @@ if (LIBNFS_FOUND AND ((NOT DEFINED NR_NFS) OR NR_NFS))
         src/Protocol/NFS/ProtocolNFS.cpp
     )
     target_link_libraries(NetRocks-NFS utils ${LIBNFS_LIBRARIES})
+    find_package(GnuTLS)
+    if (GNUTLS_FOUND)
+        target_link_libraries(NetRocks-NFS gnutls)
+    endif ()
     target_include_directories(NetRocks-NFS PRIVATE src ${LIBNFS_INCLUDE_DIRS})
     set_target_properties(NetRocks-NFS
         PROPERTIES


### PR DESCRIPTION
Updating libnfs from version 5.x.x to 6.0.x in Arch Linux leads to errors when building the application.
New libnfs 6.0.x requires gnutls library.

Update NetRocks' CMakeLists.txt file to ensure compatibility with libnfs version 6.0.x and above by adding the libgnutls library to the list of linked libraries.
