### PR TITLE
SetAttr: fix recursive file owner changing + wrong group mark indicating + recursive file attributes/flags changing

### DIFF
--- a/far2l/src/setattr.cpp
+++ b/far2l/src/setattr.cpp
@@ -644,7 +644,7 @@ LONG_PTR WINAPI SetAttrDlgProc(HANDLE hDlg, int Msg, int Param1, LONG_PTR Param2
 					break;
 				case SA_COMBO_GROUP:
 					SetAttrDefaultMark(hDlg, SA_COMBO_GROUP-1, // mark (un)changed
-						IsEditChanged(hDlg, SA_COMBO_GROUP, DlgParam->strInitOwner) );
+						IsEditChanged(hDlg, SA_COMBO_GROUP, DlgParam->strInitGroup) );
 					break;
 				case SA_FIXEDIT_LAST_ACCESS_DATE:
 					SetAttrDefaultMark(hDlg, SA_FIXEDIT_LAST_ACCESS_DATE-1, // mark (un)changed
@@ -1651,7 +1651,7 @@ bool ShellSetFileAttributes(Panel *SrcPanel, LPCWSTR Object)
 										}
 									}
 
-									if (!ApplyFileOwnerGroupIfChanged(AttrDlg[SA_COMBO_GROUP], ESetFileOwner,
+									if (!ApplyFileOwnerGroupIfChanged(AttrDlg[SA_COMBO_OWNER], ESetFileOwner,
 												SkipMode, strFullName, DlgParam.strInitOwner,
 												DlgParam.OSubfoldersState))
 										break;

--- a/far2l/src/setattr.cpp
+++ b/far2l/src/setattr.cpp
@@ -1700,8 +1700,8 @@ bool ShellSetFileAttributes(Panel *SrcPanel, LPCWSTR Object)
 											SkipMode = SETATTR_RET_SKIP;
 											continue;
 										}
-										ApplyFSFileFlags(AttrDlg, strFullName, FileAttr);
 									}
+									ApplyFSFileFlags(AttrDlg, strFullName, FileAttr);
 								}
 							}
 						}


### PR DESCRIPTION
Диалог Ctrl-A:
1. Неправильно устанавливался владелец при рекурсивной обработке вложенных папок  (вместо имени владельца использовалось имя группы).
2. Некорректная индикация звёздочкой при изменении группы (вместо сравнения с именем исходной группы происходило сравнение с именем исходного владельца).
3. Рекурсивное выставление атрибутов _(Immutable / Append / Hidden)_ для вложенных папок должно было происходить, но не отрабатывало потому, что было размещено не под той веткой if, и выполнялось только в том случае, если одновременно менялись права доступа.