### PR TITLE
Fix issue #2668: Multiarc ignores some archives 

### DIFF
--- a/multiarc/src/arcread.cpp
+++ b/multiarc/src/arcread.cpp
@@ -30,10 +30,6 @@ int PluginClass::PreReadArchive(const char *Name)
 
 	ArcName = Name;
 
-	if (FindExt(ArcName) == std::string::npos) {
-		ArcName+= '.';
-	}
-
 	return TRUE;
 }
 


### PR DESCRIPTION

Fix issue #2668:  Multiarc ignores archives if the archive file name does not have an extension - update arcread.cpp

Remove appending dot to archive filename