### PR TITLE
Add missing <cstdint> include for uint16_t, to fix build with GCC 15

### DIFF
--- a/colorer/src/Colorer-library/src/colorer/strings/legacy/UnicodeString.h
+++ b/colorer/src/Colorer-library/src/colorer/strings/legacy/UnicodeString.h
@@ -3,6 +3,7 @@
 
 #include <colorer/strings/legacy/CommonString.h>
 #include <memory>
+#include <cstdint>
 
 class CString;
 


### PR DESCRIPTION
Fixes https://bugs.debian.org/1096605.