### PR TITLE
ci: change gcc7 build test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,61 +35,22 @@ env:
 jobs:
   ubuntu-low-compiler:
     if: ${{ !(github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository != 'elfmz/far2l') }}
-    runs-on: ubuntu-20.04
-
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        compiler: [ gcc, clang ]
-        include:
-          - compiler: gcc
-            version: 7
-            c: /usr/bin/gcc-7
-            cxx: /usr/bin/g++-7
-          - compiler: clang
-            version: 7
-            c: /usr/bin/clang-7
-            cxx: /usr/bin/clang++-7
+        compiler: [ gcc7, clang7 ]
 
-    name: ubuntu-${{ matrix.compiler }}-${{ matrix.version }}
+    name: ubuntu-${{ matrix.compiler }}
 
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
 
-      - name: Install compilers
-        run: >
-          sudo apt-get update;
-          sudo apt-get -y install gcc-7 g++-7 clang-7
-
-      - name: Install far2l dependencies
-        run: >
-         sudo apt-get -y install
-         libuchardet-dev libxml2-dev libwxgtk3.0-gtk3-dev
-         libx11-dev libxi-dev
-         libssl-dev libsmbclient-dev libnfs-dev libneon27-dev libssh-dev
-         libarchive-dev
-         python3-dev python3-cffi
- 
-      - name: Create Build Environment
-        # Create a separate build directory as working directory for all subsequent commands
-        run: mkdir -p _build
-
-      - name: Configure CMake
-        # Use a bash shell so we can use the same syntax for environment variable
-        # access regardless of the host operating system
-        shell: bash
-        # -S and -B options specify source and build directories
-        run: > 
-         cmake -S . -B _build -Wno-dev -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DPYTHON=yes
-         -DCMAKE_C_COMPILER=${{ matrix.c }} -DCMAKE_CXX_COMPILER=${{ matrix.cxx }}
-  
-      - name: Build
-        shell: bash
-        # Execute the build.  You can specify a specific target with "--target <NAME>"
+      - name: 'Build in docker'
         run: |
-          cmake --build _build --config $BUILD_TYPE -j$(nproc --all)
-  
+          docker build -f _ci/Dockerfile.${{ matrix.compiler }} -t tempx:latest .
+
   ubuntu-medium-compiler:
     if: ${{ !(github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository != 'elfmz/far2l') }}
     runs-on: ubuntu-22.04

--- a/_ci/Dockerfile.clang7
+++ b/_ci/Dockerfile.clang7
@@ -1,0 +1,19 @@
+# Image for the test build far2l with clang 7
+# run build from root of project
+
+FROM ghcr.io/colorer/devimage:clang7
+
+SHELL ["/bin/bash", "-xeuo", "pipefail", "-c"]
+
+WORKDIR /code
+
+RUN --mount=type=bind,source=.,target=/code/far2l \
+<<EOT
+    apt-get update
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends libuchardet-dev libxml2-dev libwxgtk3.0-gtk3-dev \
+     libx11-dev libxi-dev libssl-dev libsmbclient-dev libnfs-dev libneon27-dev libssh-dev libarchive-dev \
+     python3-dev python3-cffi
+    mkdir build
+    cmake -S far2l -B build -Wno-dev -DCMAKE_BUILD_TYPE=Release -DPYTHON=yes -DCMAKE_C_COMPILER=/usr/bin/clang-7 -DCMAKE_CXX_COMPILER=/usr/bin/clang++-7
+    cmake --build build -j$(nproc --all)
+EOT

--- a/_ci/Dockerfile.gcc7
+++ b/_ci/Dockerfile.gcc7
@@ -1,0 +1,19 @@
+# Image for the test build far2l with gcc/g++ 7.5
+# run build from root of project
+
+FROM ghcr.io/colorer/devimage:gcc7
+
+SHELL ["/bin/bash", "-xeuo", "pipefail", "-c"]
+
+WORKDIR /code
+
+RUN --mount=type=bind,source=.,target=/code/far2l \
+<<EOT
+    apt-get update
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends libuchardet-dev libxml2-dev libwxgtk3.0-gtk3-dev \
+     libx11-dev libxi-dev libssl-dev libsmbclient-dev libnfs-dev libneon27-dev libssh-dev libarchive-dev \
+     python3-dev python3-cffi
+    mkdir build
+    cmake -S far2l -B build -Wno-dev -DCMAKE_BUILD_TYPE=Release -DPYTHON=yes
+    cmake --build build -j$(nproc --all)
+EOT


### PR DESCRIPTION
The Ubuntu 20.04 Actions runner image will begin deprecation on 2025-02-01 and will be fully unsupported by 2025-04-01  https://github.com/actions/runner-images/issues/11101

переделал сборку на использование doсker образа с нужными компиляторами.

как можно развить эту тему
- отказаться от сборки на старых версиях компиляторов, этот PR не нужен
- не зависить от базового образа в репе colorer (но я сам использую его), расширить образ включив туда нужные зависимости для far2l. Но это потребует больших настроек в текущем проекте - включить packages, настроить секреты, настроить сборку образа

