### PR TITLE
Setattr: ability to show "uname"/"gname" or "uid: uname"/"gid: gname"

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@ Only significant user-side changes are listed here (for all changes see history 
 * _New:_ Customize Size column in panels (all by dialog or **Ctrl+Alt+D**, symlinks by **Ctrl+Alt+L**)
 * More customize dirs/files markers in panels (by dialog or **Ctrl+Alt+M** and **Ctrl+Alt+N**)
 * _New:_ Link item in File menu (in addition to the usual **Alt+F6**)
+* File attributes dialog (by **Ctrl+A**): ability to show "uname"/"gname" or "uid: uname"/"gid: gname"
 * _New:_ Chattr / chflags with all flags for single file (in File menu or by **Ctrl+Alt+A**)
 * _New:_ Python-subplugin: copy/paste files via clipboard - wx ONLY version - with support for gnome clipboard types, works with gnome files/nautilus
 * _New:_ At 1st run detect Russian locale

--- a/far2l/bootstrap/scripts/farlang.templ.m4
+++ b/far2l/bootstrap/scripts/farlang.templ.m4
@@ -16809,6 +16809,28 @@ upd:"(multiple values)"
 "(кілька значень)"
 "(некалькі значэнняў)"
 
+SetAttrOwnerGroupShowId
+"Показывать U&id / Gid"
+"Show Ui&d / Gid"
+"&Zobrazit Uid / Gid"
+"Ui&d / Gid anzeigen"
+"Megjelenítése Ui&d / Gid"
+"Pokaż &Uid / Gid"
+"Mostrar Uid / Gid"
+"Показувати U&id / Gid"
+"Паказваць U&id / Gid"
+
+SetAttrOwnerOriginal
+"Исходное"
+"Original"
+"Originál"
+"Original"
+"Eredeti"
+"Oryginalny"
+"Original"
+"Вихідне"
+"Першасны"
+
 SetAttrModification
 "Время последней &записи:"
 "Last &write time:"

--- a/far2l/src/cfg/ConfigOpt.cpp
+++ b/far2l/src/cfg/ConfigOpt.cpp
@@ -335,6 +335,8 @@ const ConfigOpt g_cfg_opts[] {
 
 	{true,  NSecSystem, "FolderInfo", &Opt.InfoPanel.strFolderInfoFiles, L"DirInfo,File_Id.diz,Descript.ion,ReadMe.*,Read.Me"},
 
+	{true,  NSecSystem, "OwnerGroupShowId", &Opt.OwnerGroupShowId, 0},
+
 	{false, NSecSystemNowell, "MoveRO", &Opt.Nowell.MoveRO, 1},
 
 	{false, NSecSystemExecutor, "RestoreCP", &Opt.RestoreCPAfterExecute, 1},

--- a/far2l/src/cfg/config.hpp
+++ b/far2l/src/cfg/config.hpp
@@ -639,6 +639,8 @@ struct Options
 	FARString strTimeSeparator;
 	FARString strDecimalSeparator;
 
+	DWORD OwnerGroupShowId;
+
 	bool IsFirstStart;
 
 	std::vector<std::wstring> CmdLineStrings;

--- a/far2l/src/fileowner.cpp
+++ b/far2l/src/fileowner.cpp
@@ -88,6 +88,50 @@ bool WINAPI GetFileGroup(const wchar_t *Computer, const wchar_t *Name, FARString
 	return false;
 }
 
+// make "id: name"
+void MakeFileOwnerGroupIDShowStr(unsigned long id, const char *sname, FARString &snameid, unsigned int id_minchars)
+{
+	snameid.Format(L"%*lu: %s", id_minchars, id, sname);
+}
+
+// from "id: name" try return only name
+const wchar_t *FileOwnerGroupIDShowNameSanitize(const wchar_t *str)
+{
+	const wchar_t *str_name_only;
+	str_name_only = wcschr(str, ':');
+	if (!str_name_only || *(str_name_only+1)!=' ')
+		return str;
+	return str_name_only+2;
+}
+
+// in strOwner return "uname", in strOwnerIDShow return "uid: uname"
+bool WINAPI GetFileOwnerIDShow(const wchar_t *Computer, const wchar_t *Name,
+		FARString &strOwner, FARString &strOwnerIDShow, unsigned int id_minchars)
+{
+	struct stat s{};
+	if (sdc_stat(Wide2MB(Name).c_str(), &s) == 0) {
+		const char *sz = OwnerNameByID(s.st_uid);
+		strOwner = sz;
+		MakeFileOwnerGroupIDShowStr(s.st_uid, sz, strOwnerIDShow, id_minchars);
+		return true;
+	}
+	return false;
+}
+
+// in strGroup return "gname", in strGroupIDShow return "gid: gname"
+bool WINAPI GetFileGroupIDShow(const wchar_t *Computer, const wchar_t *Name,
+		FARString &strGroup, FARString &strGroupIDShow, unsigned int id_minchars)
+{
+	struct stat s{};
+	if (sdc_stat(Wide2MB(Name).c_str(), &s) == 0) {
+		const char *sz = GroupNameByID(s.st_gid);
+		strGroup = sz;
+		MakeFileOwnerGroupIDShowStr(s.st_gid, sz, strGroupIDShow, id_minchars);
+		return true;
+	}
+	return false;
+}
+
 bool SetOwner(LPCWSTR Object, LPCWSTR Owner)
 {
 	struct passwd *p = getpwnam(Wide2MB(Owner).c_str());

--- a/far2l/src/fileowner.hpp
+++ b/far2l/src/fileowner.hpp
@@ -67,5 +67,16 @@ typedef CachedFileLookupT<gid_t, &GroupNameByID> CachedFileGroupLookup;
 bool WINAPI GetFileOwner(const wchar_t *Computer, const wchar_t *Name, FARString &strOwner);
 bool WINAPI GetFileGroup(const wchar_t *Computer, const wchar_t *Name, FARString &strGroup);
 
+// make "id: name"
+void MakeFileOwnerGroupIDShowStr(unsigned long id, const char *sname, FARString &snameid, unsigned int id_minchars = 0);
+// from "id: name" try return only name
+const wchar_t *FileOwnerGroupIDShowNameSanitize(const wchar_t *str);
+// in strOwnerIDShow return "uid: uname"
+bool WINAPI GetFileOwnerIDShow(const wchar_t *Computer, const wchar_t *Name,
+		FARString &strOwner, FARString &strOwnerIDShow, unsigned int id_minchars = 0);
+// in strGroupIDShow return "gid: gname"
+bool WINAPI GetFileGroupIDShow(const wchar_t *Computer, const wchar_t *Name,
+		FARString &strGroup, FARString &strGroupIDShow, unsigned int id_minchars = 0);
+
 bool SetOwner(LPCWSTR Object, LPCWSTR Owner);
 bool SetGroup(LPCWSTR Object, LPCWSTR Group);


### PR DESCRIPTION
Now any changing also reset owners/groups to original and not fully compatible with changing due to Process subfolders.

Also prohibition processing info and ownership for objects inside plugins which not in real local file system.

![image](https://github.com/user-attachments/assets/76a96bc7-fba7-4699-8229-ccd85c6a4596)

---

Повторяю просьбу по возможности выпустить релиз - вроде уже совсем край ещё протащить в Ubuntu 25.04 (подробности см. в https://github.com/elfmz/far2l/issues/2646 ).

Ну и в любом случае лучше заранее на большем числе архитектур и пользователей обкатать все нововедения пока в апреле не настанет заморозка Debian 13.