### PR TITLE
changelog.md: Set release date for v2.6.5

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,8 @@
 Only significant user-side changes are listed here (for all changes see history of [Commits](https://github.com/elfmz/far2l/commits/master/) and [Pull requests](https://github.com/elfmz/far2l/pulls?q=is%3Apr+is%3Aclosed)).
 
 ## Master (current development)
+
+## 2.6.5 beta (2025-03-30)
 * _New:_ Different desktop files for launch WX (GUI) `--notty` and TTY `--tty`
 * _New:_ Horizontal panels layout (toggle horizontal-vertical by **Ctrl+,**)
 * _New:_ Groups of file masks


### PR DESCRIPTION
Next time, please do it before the release. This way the generated `.metainfo` file in the release tarball will have an entry for the release.