### PR TITLE
FIX: ClipboardAllocate for non (unicode)text elements

### DIFF
--- a/WinPort/src/Backend/WX/wxClipboardBackend.cpp
+++ b/WinPort/src/Backend/WX/wxClipboardBackend.cpp
@@ -317,7 +317,7 @@ void *wxClipboardBackend::OnClipboardGetData(UINT format)
 		}
 				
 		const size_t data_size = data.GetDataSize();
-		p = WINPORT(ClipboardAlloc)(data_size + 1); 
+		p = WINPORT(ClipboardAlloc)(data_size); 
 		if (!p) {
 			fprintf(stderr, "GetClipboardData(%s) - cant alloc %u + 1\n", 
 				(const char *)data_format->GetId().char_str(), (unsigned int)data_size);

--- a/WinPort/src/Backend/WX/wxClipboardBackend.cpp
+++ b/WinPort/src/Backend/WX/wxClipboardBackend.cpp
@@ -319,7 +319,7 @@ void *wxClipboardBackend::OnClipboardGetData(UINT format)
 		const size_t data_size = data.GetDataSize();
 		p = WINPORT(ClipboardAlloc)(data_size); 
 		if (!p) {
-			fprintf(stderr, "GetClipboardData(%s) - cant alloc %u + 1\n", 
+			fprintf(stderr, "GetClipboardData(%s) - cant alloc %u\n", 
 				(const char *)data_format->GetId().char_str(), (unsigned int)data_size);
 			return nullptr;
 		}

--- a/python/configs/plug/plugins/uclipget.py
+++ b/python/configs/plug/plugins/uclipget.py
@@ -15,7 +15,7 @@ class Plugin(PluginBase):
         data = data.decode('utf8')
         log.debug(f'copyfiles: {data}')
         prefix = 'file://'
-        for uri in data.split('\r\n'):
+        for uri in data.split('\n'):
             if uri[:len(prefix)] != prefix:
                 continue
             fqname = uri[len(prefix):]
@@ -47,13 +47,13 @@ class Plugin(PluginBase):
             data = winport.GetClipboardData(clipurifmt)
             if data is not None:
                 nb = winport.ClipboardSize(data)
-                result = self.ffi.buffer(self.ffi.cast("PSTR", data), nb-1)
+                result = self.ffi.buffer(self.ffi.cast("PSTR", data), nb)
                 self.CopyFiles(bytes(result))
             else:
                 data = winport.GetClipboardData(clipgnofmt)
                 if data is not None:
                     nb = winport.ClipboardSize(data)
-                    result = self.ffi.buffer(self.ffi.cast("PSTR", data), nb-1)
+                    result = self.ffi.buffer(self.ffi.cast("PSTR", data), nb)
                     self.CopyFiles(bytes(result))
         except:
             log.exception('uclipset.GetClipboardData')


### PR DESCRIPTION
ClipboardAllocate should allocate as many bytes as the clipboard size, not one byte more.
Then ClipboardSize used to allocate the destination buffer adds one byte to the buffer size.

python plugins uclipget.py and uclipset.py also work in --tty session