### PR TITLE
version_bump_patch.sh: Also update changelog

### DIFF
--- a/packaging/version_bump_patch.sh
+++ b/packaging/version_bump_patch.sh
@@ -11,6 +11,11 @@ echo $NEW_VERSION > ./version
 
 sed -i "s|FAR2L_VERSION = .*|FAR2L_VERSION = $NEW_TAG|" buildroot/far2l/far2l.mk
 
-git add ./version ./buildroot/far2l/far2l.mk
+sed -i "s|Master (current development)|${NEW_VERSION} beta ($(date -I))|" ../changelog.md
+
+git add ./version ./buildroot/far2l/far2l.mk ../changelog.md
 git commit -m "Bump version to $NEW_VERSION"
 git tag $NEW_TAG
+
+sed -i "/${NEW_VERSION} beta/i ## Master (current development)\n" ../changelog.md
+git commit ../changelog.md -m "Start a new changelog entry"


### PR DESCRIPTION
For the release commit/tag, `Master (current development)` is replaced with the new version number in the changelog.

After the tag, a separate commit is created to start a new changelog entry, so other developers can add their rows to it.

Proper formatting of changelog file is important because we generate a `metainfo` file from it, and `metainfo` file is used by software center applications and other services like Flathub.