### PR TITLE
Bump required CMake version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules)
 
-cmake_minimum_required (VERSION 3.0.2)
+cmake_minimum_required (VERSION 3.5.0)
 
 project (far2l)
 

--- a/far2l/bootstrap/CMakeLists.txt
+++ b/far2l/bootstrap/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0.2)
+cmake_minimum_required (VERSION 3.5.0)
 
 add_custom_target(bootstrap 
     DEPENDS farlang.templ lang.inc

--- a/packaging/debian/CMakeLists.txt
+++ b/packaging/debian/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0.2)
+cmake_minimum_required (VERSION 3.5.0)
 
 find_package(Git QUIET)
 execute_process(COMMAND "${GIT_EXECUTABLE}" status


### PR DESCRIPTION
This fixes build with CMake 4.0.

See:
- https://cmake.org/cmake/help/latest/release/4.0.html#deprecated-and-removed-features
- https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html#policy-version