### PR TITLE
Fix cmake warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules)
+include(${CMAKE_SOURCE_DIR}/cmake/FuncCopyResources.cmake)
 
 cmake_minimum_required (VERSION 3.5.0)
 

--- a/NetRocks/CMakeLists.txt
+++ b/NetRocks/CMakeLists.txt
@@ -102,10 +102,18 @@ set_target_properties(NetRocks-SHELL
     SUFFIX ".broker")
 target_compile_options(NetRocks-SHELL PUBLIC -DNETROCKS_PROTOCOL)
 
-add_custom_command(TARGET NetRocks-SHELL POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/src/Protocol/SHELL/Helpers "${INSTALL_DIR}/Plugins/NetRocks/plug/SHELL"
+# copy resource files
+set(CURRENT_TARGET "NetRocks-SHELL")
+file(GLOB_RECURSE RESOURCE_FILES
+        RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/src/Protocol/SHELL/Helpers
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/Protocol/SHELL/Helpers/*"
 )
-
+setup_target_auxiliary_files(${CURRENT_TARGET}
+        RESOURCE_FILES
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/Protocol/SHELL/Helpers
+        "${INSTALL_DIR}/Plugins/NetRocks/plug/SHELL/"
+)
+add_dependencies(${CURRENT_TARGET} copy_aux_files_for_${CURRENT_TARGET})
 
 if (LIBSSH_FOUND AND ((NOT DEFINED NR_SFTP) OR NR_SFTP))
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DHAVE_SFTP")
@@ -237,5 +245,15 @@ set_target_properties(NetRocks
         PREFIX ""
         SUFFIX ".far-plug-wide")
 
-add_custom_command(TARGET NetRocks POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/configs "${INSTALL_DIR}/Plugins/NetRocks")
+# copy resource files
+set(CURRENT_TARGET "NetRocks")
+file(GLOB_RECURSE RESOURCE_FILES
+        RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/configs
+        "${CMAKE_CURRENT_SOURCE_DIR}/configs/*"
+)
+setup_target_auxiliary_files(${CURRENT_TARGET}
+        RESOURCE_FILES
+        ${CMAKE_CURRENT_SOURCE_DIR}/configs
+        "${INSTALL_DIR}/Plugins/${CURRENT_TARGET}/"
+)
+add_dependencies(${CURRENT_TARGET} copy_aux_files_for_${CURRENT_TARGET})

--- a/NetRocks/CMakeLists.txt
+++ b/NetRocks/CMakeLists.txt
@@ -103,7 +103,6 @@ set_target_properties(NetRocks-SHELL
 target_compile_options(NetRocks-SHELL PUBLIC -DNETROCKS_PROTOCOL)
 
 add_custom_command(TARGET NetRocks-SHELL POST_BUILD
-    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/src/Protocol/SHELL/Helpers
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/src/Protocol/SHELL/Helpers "${INSTALL_DIR}/Plugins/NetRocks/plug/SHELL"
 )
 
@@ -239,5 +238,4 @@ set_target_properties(NetRocks
         SUFFIX ".far-plug-wide")
 
 add_custom_command(TARGET NetRocks POST_BUILD
-    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/configs
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/configs "${INSTALL_DIR}/Plugins/NetRocks")

--- a/align/CMakeLists.txt
+++ b/align/CMakeLists.txt
@@ -21,7 +21,15 @@ set_target_properties(align
         PREFIX ""
         SUFFIX ".far-plug-wide")
 
-
-add_custom_command(TARGET align POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/configs "${INSTALL_DIR}/Plugins/align"
+# copy resource files
+set(CURRENT_TARGET "align")
+file(GLOB_RECURSE RESOURCE_FILES
+        RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/configs
+        "${CMAKE_CURRENT_SOURCE_DIR}/configs/*"
 )
+setup_target_auxiliary_files(${CURRENT_TARGET}
+        RESOURCE_FILES
+        ${CMAKE_CURRENT_SOURCE_DIR}/configs
+        "${INSTALL_DIR}/Plugins/${CURRENT_TARGET}/"
+)
+add_dependencies(${CURRENT_TARGET} copy_aux_files_for_${CURRENT_TARGET})

--- a/align/CMakeLists.txt
+++ b/align/CMakeLists.txt
@@ -23,6 +23,5 @@ set_target_properties(align
 
 
 add_custom_command(TARGET align POST_BUILD
-    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/configs
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/configs "${INSTALL_DIR}/Plugins/align"
 )

--- a/autowrap/CMakeLists.txt
+++ b/autowrap/CMakeLists.txt
@@ -21,7 +21,15 @@ set_target_properties(autowrap
         PREFIX ""
         SUFFIX ".far-plug-wide")
 
-
-add_custom_command(TARGET autowrap POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/configs "${INSTALL_DIR}/Plugins/autowrap"
+# copy resource files
+set(CURRENT_TARGET "autowrap")
+file(GLOB_RECURSE RESOURCE_FILES
+        RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/configs
+        "${CMAKE_CURRENT_SOURCE_DIR}/configs/*"
 )
+setup_target_auxiliary_files(${CURRENT_TARGET}
+        RESOURCE_FILES
+        ${CMAKE_CURRENT_SOURCE_DIR}/configs
+        "${INSTALL_DIR}/Plugins/${CURRENT_TARGET}/"
+)
+add_dependencies(${CURRENT_TARGET} copy_aux_files_for_${CURRENT_TARGET})

--- a/autowrap/CMakeLists.txt
+++ b/autowrap/CMakeLists.txt
@@ -23,6 +23,5 @@ set_target_properties(autowrap
 
 
 add_custom_command(TARGET autowrap POST_BUILD
-    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/configs
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/configs "${INSTALL_DIR}/Plugins/autowrap"
 )

--- a/calc/CMakeLists.txt
+++ b/calc/CMakeLists.txt
@@ -54,6 +54,5 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
     SUFFIX ".far-plug-wide")
 
 add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/configs
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/configs "${INSTALL_DIR}/Plugins/${PROJECT_NAME}/plug")
 

--- a/calc/CMakeLists.txt
+++ b/calc/CMakeLists.txt
@@ -53,6 +53,15 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
     PREFIX ""
     SUFFIX ".far-plug-wide")
 
-add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/configs "${INSTALL_DIR}/Plugins/${PROJECT_NAME}/plug")
-
+# copy resource files
+set(CURRENT_TARGET "calc")
+file(GLOB_RECURSE RESOURCE_FILES
+        RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/configs
+        "${CMAKE_CURRENT_SOURCE_DIR}/configs/*"
+)
+setup_target_auxiliary_files(${CURRENT_TARGET}
+        RESOURCE_FILES
+        ${CMAKE_CURRENT_SOURCE_DIR}/configs
+        "${INSTALL_DIR}/Plugins/${CURRENT_TARGET}/plug"
+)
+add_dependencies(${CURRENT_TARGET} copy_aux_files_for_${CURRENT_TARGET})

--- a/cmake/FuncCopyResources.cmake
+++ b/cmake/FuncCopyResources.cmake
@@ -1,0 +1,83 @@
+# Function to copy auxiliary files next to a target and track their changes.
+#
+# ARGN:
+#   TARGET_NAME                 - The name of the CMake target (e.g., my_app).
+#   AUX_FILES_VAR               - The NAME of the CMake list variable containing relative paths to auxiliary files.
+#   AUX_FILES_BASE_SOURCE_DIR   - The base directory in your source tree from which the paths in AUX_FILES_VAR are relative.
+#   AUX_FILES_DESTINATION_SUBDIR- A subdirectory within the target's output directory where files will be copied.
+#
+function(setup_target_auxiliary_files TARGET_NAME AUX_FILES_VAR AUX_FILES_BASE_SOURCE_DIR AUX_FILES_DESTINATION_SUBDIR)
+
+    if(NOT TARGET_NAME)
+        message(FATAL_ERROR "setup_target_auxiliary_files: TARGET_NAME is required.")
+    endif()
+    if(NOT AUX_FILES_VAR)
+        message(FATAL_ERROR "setup_target_auxiliary_files: AUX_FILES_VAR (name of the list variable) is required.")
+    endif()
+    if(NOT AUX_FILES_BASE_SOURCE_DIR)
+        message(FATAL_ERROR "setup_target_auxiliary_files: AUX_FILES_BASE_SOURCE_DIR is required.")
+    endif()
+    if(NOT EXISTS "${AUX_FILES_BASE_SOURCE_DIR}")
+        message(FATAL_ERROR "setup_target_auxiliary_files: AUX_FILES_BASE_SOURCE_DIR '${AUX_FILES_BASE_SOURCE_DIR}' does not exist.")
+    endif()
+    if(NOT AUX_FILES_DESTINATION_SUBDIR)
+        message(FATAL_ERROR "setup_target_auxiliary_files: AUX_FILES_DESTINATION_SUBDIR is required.")
+    endif()
+
+    if(NOT TARGET ${TARGET_NAME})
+        message(FATAL_ERROR "setup_target_auxiliary_files: Target '${TARGET_NAME}' does not exist. Please define it before calling this function.")
+    endif()
+
+    set(AUX_SOURCE_FILES_RELATIVE_PATHS ${${AUX_FILES_VAR}})
+
+    if(NOT AUX_SOURCE_FILES_RELATIVE_PATHS)
+        message(STATUS "setup_target_auxiliary_files: No auxiliary files provided for target '${TARGET_NAME}' via variable '${AUX_FILES_VAR}'.")
+        return()
+    endif()
+
+    set(COPIED_AUX_FILES_OUTPUTS "")
+
+    foreach(AUX_FILE_RELATIVE_PATH ${AUX_SOURCE_FILES_RELATIVE_PATHS})
+        set(SOURCE_FULL_PATH "${AUX_FILES_BASE_SOURCE_DIR}/${AUX_FILE_RELATIVE_PATH}")
+
+        if(NOT EXISTS "${SOURCE_FULL_PATH}")
+            message(WARNING "setup_target_auxiliary_files: Source auxiliary file '${SOURCE_FULL_PATH}' does not exist for target '${TARGET_NAME}'. Skipping.")
+            continue()
+        endif()
+
+
+        set(FINAL_DESTINATION_PATH "${AUX_FILES_DESTINATION_SUBDIR}/${AUX_FILE_RELATIVE_PATH}")
+        set(MKDIR_BASE_PATH "${AUX_FILES_DESTINATION_SUBDIR}")
+
+        get_filename_component(AUX_FILE_SUBDIR ${AUX_FILE_RELATIVE_PATH} DIRECTORY)
+        if(AUX_FILE_SUBDIR AND NOT AUX_FILE_SUBDIR STREQUAL ".")
+            set(FULL_DIR_TO_CREATE "${MKDIR_BASE_PATH}/${AUX_FILE_SUBDIR}")
+        else()
+            set(FULL_DIR_TO_CREATE "${MKDIR_BASE_PATH}")
+        endif()
+
+        add_custom_command(
+                OUTPUT "${FINAL_DESTINATION_PATH}"
+                COMMAND ${CMAKE_COMMAND} -E make_directory "${FULL_DIR_TO_CREATE}"
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                "${SOURCE_FULL_PATH}"
+                "${FINAL_DESTINATION_PATH}"
+                DEPENDS "${SOURCE_FULL_PATH}"
+                COMMENT "Copying aux file for ${TARGET_NAME}: ${AUX_FILE_RELATIVE_PATH}"
+                VERBATIM
+        )
+        list(APPEND COPIED_AUX_FILES_OUTPUTS "${FINAL_DESTINATION_PATH}")
+    endforeach()
+
+    if(COPIED_AUX_FILES_OUTPUTS)
+        set(AUX_FILES_CUSTOM_TARGET_NAME "copy_aux_files_for_${TARGET_NAME}")
+        add_custom_target(${AUX_FILES_CUSTOM_TARGET_NAME} ALL
+                DEPENDS ${COPIED_AUX_FILES_OUTPUTS}
+                COMMENT "Ensuring auxiliary files for ${TARGET_NAME} are copied"
+        )
+        # cycle dependecy
+        # add_dependencies(${TARGET_NAME} ${AUX_FILES_CUSTOM_TARGET_NAME})
+    endif()
+
+    message(STATUS "Setup auxiliary files copying for target '${TARGET_NAME}'.")
+endfunction()

--- a/colorer/CMakeLists.txt
+++ b/colorer/CMakeLists.txt
@@ -65,7 +65,6 @@ set_target_properties(colorer
         SUFFIX ".far-plug-wide")
 
 add_custom_command(TARGET colorer POST_BUILD
-    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/configs
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/configs "${INSTALL_DIR}/Plugins/colorer"
 )
 

--- a/colorer/CMakeLists.txt
+++ b/colorer/CMakeLists.txt
@@ -64,10 +64,6 @@ set_target_properties(colorer
         PREFIX ""
         SUFFIX ".far-plug-wide")
 
-add_custom_command(TARGET colorer POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/configs "${INSTALL_DIR}/Plugins/colorer"
-)
-
 add_subdirectory("${LIBCOLORER_TREE}" "${CMAKE_BINARY_DIR}/Colorer-library/src")
 
 set_target_properties(colorer PROPERTIES
@@ -75,3 +71,16 @@ set_target_properties(colorer PROPERTIES
     CXX_STANDARD_REQUIRED YES
     CXX_EXTENSIONS YES
 )
+
+# copy resource files
+set(CURRENT_TARGET "colorer")
+file(GLOB_RECURSE RESOURCE_FILES
+        RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/configs
+        "${CMAKE_CURRENT_SOURCE_DIR}/configs/*"
+)
+setup_target_auxiliary_files(${CURRENT_TARGET}
+        RESOURCE_FILES
+        ${CMAKE_CURRENT_SOURCE_DIR}/configs
+        "${INSTALL_DIR}/Plugins/${CURRENT_TARGET}/"
+)
+add_dependencies(${CURRENT_TARGET} copy_aux_files_for_${CURRENT_TARGET})

--- a/compare/CMakeLists.txt
+++ b/compare/CMakeLists.txt
@@ -23,6 +23,5 @@ set_target_properties(compare
 
 
 add_custom_command(TARGET compare POST_BUILD
-    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/configs
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/configs "${INSTALL_DIR}/Plugins/compare"
 )

--- a/compare/CMakeLists.txt
+++ b/compare/CMakeLists.txt
@@ -21,7 +21,15 @@ set_target_properties(compare
         PREFIX ""
         SUFFIX ".far-plug-wide")
 
-
-add_custom_command(TARGET compare POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/configs "${INSTALL_DIR}/Plugins/compare"
+# copy resource files
+set(CURRENT_TARGET "compare")
+file(GLOB_RECURSE RESOURCE_FILES
+        RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/configs
+        "${CMAKE_CURRENT_SOURCE_DIR}/configs/*"
 )
+setup_target_auxiliary_files(${CURRENT_TARGET}
+        RESOURCE_FILES
+        ${CMAKE_CURRENT_SOURCE_DIR}/configs
+        "${INSTALL_DIR}/Plugins/${CURRENT_TARGET}/"
+)
+add_dependencies(${CURRENT_TARGET} copy_aux_files_for_${CURRENT_TARGET})

--- a/drawline/CMakeLists.txt
+++ b/drawline/CMakeLists.txt
@@ -21,7 +21,15 @@ set_target_properties(drawline
         PREFIX ""
         SUFFIX ".far-plug-wide")
 
-
-add_custom_command(TARGET drawline POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/configs "${INSTALL_DIR}/Plugins/drawline"
+# copy resource files
+set(CURRENT_TARGET "drawline")
+file(GLOB_RECURSE RESOURCE_FILES
+        RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/configs
+        "${CMAKE_CURRENT_SOURCE_DIR}/configs/*"
 )
+setup_target_auxiliary_files(${CURRENT_TARGET}
+        RESOURCE_FILES
+        ${CMAKE_CURRENT_SOURCE_DIR}/configs
+        "${INSTALL_DIR}/Plugins/${CURRENT_TARGET}/"
+)
+add_dependencies(${CURRENT_TARGET} copy_aux_files_for_${CURRENT_TARGET})

--- a/drawline/CMakeLists.txt
+++ b/drawline/CMakeLists.txt
@@ -23,6 +23,5 @@ set_target_properties(drawline
 
 
 add_custom_command(TARGET drawline POST_BUILD
-    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/configs
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/configs "${INSTALL_DIR}/Plugins/drawline"
 )

--- a/editcase/CMakeLists.txt
+++ b/editcase/CMakeLists.txt
@@ -23,6 +23,5 @@ set_target_properties(editcase
 
 
 add_custom_command(TARGET editcase POST_BUILD
-    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/configs
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/configs "${INSTALL_DIR}/Plugins/editcase"
 )

--- a/editcase/CMakeLists.txt
+++ b/editcase/CMakeLists.txt
@@ -21,7 +21,15 @@ set_target_properties(editcase
         PREFIX ""
         SUFFIX ".far-plug-wide")
 
-
-add_custom_command(TARGET editcase POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/configs "${INSTALL_DIR}/Plugins/editcase"
+# copy resource files
+set(CURRENT_TARGET "editcase")
+file(GLOB_RECURSE RESOURCE_FILES
+        RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/configs
+        "${CMAKE_CURRENT_SOURCE_DIR}/configs/*"
 )
+setup_target_auxiliary_files(${CURRENT_TARGET}
+        RESOURCE_FILES
+        ${CMAKE_CURRENT_SOURCE_DIR}/configs
+        "${INSTALL_DIR}/Plugins/${CURRENT_TARGET}/"
+)
+add_dependencies(${CURRENT_TARGET} copy_aux_files_for_${CURRENT_TARGET})

--- a/editorcomp/CMakeLists.txt
+++ b/editorcomp/CMakeLists.txt
@@ -24,6 +24,15 @@ set_target_properties(editorcomp
         PREFIX ""
         SUFFIX ".far-plug-wide")
 
-add_custom_command(TARGET editorcomp POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/configs "${INSTALL_DIR}/Plugins/editorcomp"
+# copy resource files
+set(CURRENT_TARGET "editorcomp")
+file(GLOB_RECURSE RESOURCE_FILES
+        RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/configs
+        "${CMAKE_CURRENT_SOURCE_DIR}/configs/*"
 )
+setup_target_auxiliary_files(${CURRENT_TARGET}
+        RESOURCE_FILES
+        ${CMAKE_CURRENT_SOURCE_DIR}/configs
+        "${INSTALL_DIR}/Plugins/${CURRENT_TARGET}/"
+)
+add_dependencies(${CURRENT_TARGET} copy_aux_files_for_${CURRENT_TARGET})

--- a/editorcomp/CMakeLists.txt
+++ b/editorcomp/CMakeLists.txt
@@ -25,6 +25,5 @@ set_target_properties(editorcomp
         SUFFIX ".far-plug-wide")
 
 add_custom_command(TARGET editorcomp POST_BUILD
-    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/configs
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/configs "${INSTALL_DIR}/Plugins/editorcomp"
 )

--- a/far2l/CMakeLists.txt
+++ b/far2l/CMakeLists.txt
@@ -310,11 +310,14 @@ else()
                         ERROR_QUIET)
 
         if(PYTHON_MARKDOWN_STATUS EQUAL 0)
-            add_custom_command(TARGET far2l POST_BUILD
+            add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/DE/io.github.elfmz.far2l.metainfo.xml"
                                COMMAND ${Python3_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/DE/generate_metainfo.py"
                                        "${CMAKE_SOURCE_DIR}/changelog.md"
                                        "${CMAKE_CURRENT_SOURCE_DIR}/DE/io.github.elfmz.far2l.metainfo.xml.in"
                                        "${CMAKE_CURRENT_BINARY_DIR}/DE/io.github.elfmz.far2l.metainfo.xml"
+                               DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/DE/generate_metainfo.py"
+                                       "${CMAKE_SOURCE_DIR}/changelog.md"
+                                       "${CMAKE_CURRENT_SOURCE_DIR}/DE/io.github.elfmz.far2l.metainfo.xml.in"
                                COMMENT "Generating DE/io.github.elfmz.far2l.metainfo.xml"
                                VERBATIM)
             install(FILES "${CMAKE_CURRENT_BINARY_DIR}/DE/io.github.elfmz.far2l.metainfo.xml"

--- a/far2l/CMakeLists.txt
+++ b/far2l/CMakeLists.txt
@@ -315,9 +315,6 @@ else()
                                        "${CMAKE_SOURCE_DIR}/changelog.md"
                                        "${CMAKE_CURRENT_SOURCE_DIR}/DE/io.github.elfmz.far2l.metainfo.xml.in"
                                        "${CMAKE_CURRENT_BINARY_DIR}/DE/io.github.elfmz.far2l.metainfo.xml"
-                               DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/DE/generate_metainfo.py"
-                                       "${CMAKE_SOURCE_DIR}/changelog.md"
-                                       "${CMAKE_CURRENT_SOURCE_DIR}/DE/io.github.elfmz.far2l.metainfo.xml.in"
                                COMMENT "Generating DE/io.github.elfmz.far2l.metainfo.xml"
                                VERBATIM)
             install(FILES "${CMAKE_CURRENT_BINARY_DIR}/DE/io.github.elfmz.far2l.metainfo.xml"

--- a/far2l/CMakeLists.txt
+++ b/far2l/CMakeLists.txt
@@ -320,6 +320,8 @@ else()
                                        "${CMAKE_CURRENT_SOURCE_DIR}/DE/io.github.elfmz.far2l.metainfo.xml.in"
                                COMMENT "Generating DE/io.github.elfmz.far2l.metainfo.xml"
                                VERBATIM)
+            add_custom_target(Far2lMetainfo DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/DE/io.github.elfmz.far2l.metainfo.xml")
+            add_dependencies(far2l Far2lMetainfo)
             install(FILES "${CMAKE_CURRENT_BINARY_DIR}/DE/io.github.elfmz.far2l.metainfo.xml"
                     DESTINATION "share/metainfo"
                     COMPONENT desktop)

--- a/far2l/bootstrap/CMakeLists.txt
+++ b/far2l/bootstrap/CMakeLists.txt
@@ -1,6 +1,4 @@
-cmake_minimum_required (VERSION 3.5.0)
-
-add_custom_target(bootstrap 
+add_custom_target(bootstrap
     DEPENDS farlang.templ lang.inc
 )
 

--- a/far2l/bootstrap/CMakeLists.txt
+++ b/far2l/bootstrap/CMakeLists.txt
@@ -1,7 +1,3 @@
-add_custom_target(bootstrap
-    DEPENDS farlang.templ lang.inc
-)
-
 message(STATUS "generating headers and languages")
 
 if (CMAKE_SIZEOF_VOID_P EQUAL 8)
@@ -23,11 +19,9 @@ set(HLFFILES
     "${BOOTSTRAP}/FarHun.hlf"
     "${BOOTSTRAP}/FarUkr.hlf"
 )
-set(LNGFILES
-    "${BOOTSTRAP}/FarEng.lng"
-    "${BOOTSTRAP}/FarRus.lng"
-    "${BOOTSTRAP}/FarHun.lng"
-    "${BOOTSTRAP}/FarUkr.lng"
+
+add_custom_target(bootstrap
+        DEPENDS farlang.templ lang.inc ${HLFFILES}
 )
 
 add_custom_command(OUTPUT "${BOOTSTRAP}/farlang.templ"
@@ -50,38 +44,28 @@ add_custom_command(TARGET bootstrap PRE_BUILD
     COMMENT "generating version information"
 )
 
-add_custom_command(OUTPUT "${BOOTSTRAP}/FarEng.hlf"
-    COMMAND perl -I. "${SCRIPTS}/mkhlf.pl" "${SCRIPTS}/FarEng.hlf.m4" | perl ${M4PL} > "${BOOTSTRAP}/FarEng.hlf"
-    WORKING_DIRECTORY "${SCRIPTS}"
-    COMMENT "generating help eng"
-)
-add_custom_command(OUTPUT "${BOOTSTRAP}/FarRus.hlf"
-    COMMAND perl -I. "${SCRIPTS}/mkhlf.pl" "${SCRIPTS}/FarRus.hlf.m4" | perl ${M4PL} > "${BOOTSTRAP}/FarRus.hlf"
-    WORKING_DIRECTORY "${SCRIPTS}"
-    COMMENT "generating help rus"
-)
-add_custom_command(OUTPUT "${BOOTSTRAP}/FarHun.hlf"
-    COMMAND perl -I. "${SCRIPTS}/mkhlf.pl" "${SCRIPTS}/FarHun.hlf.m4" | perl ${M4PL} > "${BOOTSTRAP}/FarHun.hlf"
-    WORKING_DIRECTORY "${SCRIPTS}"
-    COMMENT "generating help hun"
-)
-add_custom_command(OUTPUT "${BOOTSTRAP}/FarUkr.hlf"
-    COMMAND perl -I. "${SCRIPTS}/mkhlf.pl" "${SCRIPTS}/FarUkr.hlf.m4" | perl ${M4PL} > "${BOOTSTRAP}/FarUkr.hlf"
-    WORKING_DIRECTORY "${SCRIPTS}"
-    COMMENT "generating help ukr"
-)
+# List of langs for help files
+set(LANGS "Eng" "Rus" "Hun" "Ukr")
+foreach(LANG ${LANGS})
+    add_custom_command(OUTPUT "${BOOTSTRAP}/Far${LANG}.hlf"
+            COMMAND perl -I. "${SCRIPTS}/mkhlf.pl" "${SCRIPTS}/Far${LANG}.hlf.m4" | perl ${M4PL} > "${BOOTSTRAP}/Far${LANG}.hlf"
+            WORKING_DIRECTORY "${SCRIPTS}"
+            DEPENDS "${SCRIPTS}/Far${LANG}.hlf.m4"
+            COMMENT "generating help ${LANG}"
+    )
+endforeach()
 
 # older cmake versions does not support copying of multiple files,
 # so we use simple stupid /bin/cp and wildcards
 
-add_custom_command(OUTPUT "${INSTALL_DIR}/*.lng"
-    DEPENDS "${LNGFILES}"
-    COMMAND "cp" "${BOOTSTRAP}/*.lng" "${INSTALL_DIR}"
+add_custom_command(TARGET bootstrap
+        POST_BUILD
+        COMMAND "cp" "${BOOTSTRAP}/*.lng" "${INSTALL_DIR}"
 )
 
-add_custom_command(OUTPUT "${INSTALL_DIR}/*.hlf"
-    DEPENDS "${HLFFILES}"
-    COMMAND "cp" "${BOOTSTRAP}/*.hlf" "${INSTALL_DIR}"
+add_custom_command(TARGET bootstrap
+        POST_BUILD
+        COMMAND "cp" "${BOOTSTRAP}/*.hlf" "${INSTALL_DIR}"
 )
 
 add_custom_command(TARGET bootstrap

--- a/far2l/bootstrap/CMakeLists.txt
+++ b/far2l/bootstrap/CMakeLists.txt
@@ -35,60 +35,53 @@ set(LNGFILES
 add_custom_command(OUTPUT "${BOOTSTRAP}/farlang.templ"
     COMMAND cat "${SCRIPTS}/farlang.templ.m4" | perl -I. ${M4PL} > "${BOOTSTRAP}/farlang.templ"
     WORKING_DIRECTORY "${SCRIPTS}"
-    DEPENDS ${DEPENDENCIES} "${SCRIPTS}/farlang.templ.m4" "${SCRIPTS}/far2l_m4.pl"
-    COMMENT generating language template
+    DEPENDS "${SCRIPTS}/farlang.templ.m4" "${SCRIPTS}/far2l_m4.pl"
+    COMMENT "generating language template"
 )
 
 add_custom_command(OUTPUT "${BOOTSTRAP}/lang.inc"
     COMMAND perl -I. "${SCRIPTS}/farlng.pl" "${BOOTSTRAP}/farlang.templ" "${BOOTSTRAP}"
     WORKING_DIRECTORY "${SCRIPTS}"
     DEPENDS "${BOOTSTRAP}/farlang.templ"
-    COMMENT generating languages
+    COMMENT "generating languages"
 )
 
 add_custom_command(TARGET bootstrap PRE_BUILD
     COMMAND perl -I. "${SCRIPTS}/farver.pl" "${BOOTSTRAP}/farversion.inc" "${CMAKE_SYSTEM_NAME} ${CMAKE_SYSTEM_PROCESSOR}" "${VERSION_MAJOR}" "${VERSION_MINOR}" "${VERSION_PATCH}"
     WORKING_DIRECTORY "${SCRIPTS}"
-    COMMENT generating version information
+    COMMENT "generating version information"
 )
 
-add_custom_command(TARGET bootstrap
+add_custom_command(OUTPUT "${BOOTSTRAP}/FarEng.hlf"
     COMMAND perl -I. "${SCRIPTS}/mkhlf.pl" "${SCRIPTS}/FarEng.hlf.m4" | perl ${M4PL} > "${BOOTSTRAP}/FarEng.hlf"
-
     WORKING_DIRECTORY "${SCRIPTS}"
-    DEPENDS ${DEPENDENCIES}
-    COMMENT generating help eng
+    COMMENT "generating help eng"
 )
-add_custom_command(TARGET bootstrap
+add_custom_command(OUTPUT "${BOOTSTRAP}/FarRus.hlf"
     COMMAND perl -I. "${SCRIPTS}/mkhlf.pl" "${SCRIPTS}/FarRus.hlf.m4" | perl ${M4PL} > "${BOOTSTRAP}/FarRus.hlf"
     WORKING_DIRECTORY "${SCRIPTS}"
-    DEPENDS ${DEPENDENCIES}
-    COMMENT generating help rus
+    COMMENT "generating help rus"
 )
-add_custom_command(TARGET bootstrap
+add_custom_command(OUTPUT "${BOOTSTRAP}/FarHun.hlf"
     COMMAND perl -I. "${SCRIPTS}/mkhlf.pl" "${SCRIPTS}/FarHun.hlf.m4" | perl ${M4PL} > "${BOOTSTRAP}/FarHun.hlf"
     WORKING_DIRECTORY "${SCRIPTS}"
-    DEPENDS ${DEPENDENCIES}
-    COMMENT generating help hun
+    COMMENT "generating help hun"
 )
-add_custom_command(TARGET bootstrap
+add_custom_command(OUTPUT "${BOOTSTRAP}/FarUkr.hlf"
     COMMAND perl -I. "${SCRIPTS}/mkhlf.pl" "${SCRIPTS}/FarUkr.hlf.m4" | perl ${M4PL} > "${BOOTSTRAP}/FarUkr.hlf"
     WORKING_DIRECTORY "${SCRIPTS}"
-    DEPENDS ${DEPENDENCIES}
-    COMMENT generating help ukr
+    COMMENT "generating help ukr"
 )
 
 # older cmake versions does not support copying of multiple files,
 # so we use simple stupid /bin/cp and wildcards
 
-add_custom_command(TARGET bootstrap
-    POST_BUILD
+add_custom_command(OUTPUT "${INSTALL_DIR}/*.lng"
     DEPENDS "${LNGFILES}"
     COMMAND "cp" "${BOOTSTRAP}/*.lng" "${INSTALL_DIR}"
 )
 
-add_custom_command(TARGET bootstrap
-    POST_BUILD
+add_custom_command(OUTPUT "${INSTALL_DIR}/*.hlf"
     DEPENDS "${HLFFILES}"
     COMMAND "cp" "${BOOTSTRAP}/*.hlf" "${INSTALL_DIR}"
 )

--- a/filecase/CMakeLists.txt
+++ b/filecase/CMakeLists.txt
@@ -23,6 +23,5 @@ set_target_properties(filecase
 
 
 add_custom_command(TARGET filecase POST_BUILD
-    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/configs
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/configs "${INSTALL_DIR}/Plugins/filecase"
 )

--- a/filecase/CMakeLists.txt
+++ b/filecase/CMakeLists.txt
@@ -21,7 +21,15 @@ set_target_properties(filecase
         PREFIX ""
         SUFFIX ".far-plug-wide")
 
-
-add_custom_command(TARGET filecase POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/configs "${INSTALL_DIR}/Plugins/filecase"
+# copy resource files
+set(CURRENT_TARGET "filecase")
+file(GLOB_RECURSE RESOURCE_FILES
+        RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/configs
+        "${CMAKE_CURRENT_SOURCE_DIR}/configs/*"
 )
+setup_target_auxiliary_files(${CURRENT_TARGET}
+        RESOURCE_FILES
+        ${CMAKE_CURRENT_SOURCE_DIR}/configs
+        "${INSTALL_DIR}/Plugins/${CURRENT_TARGET}/"
+)
+add_dependencies(${CURRENT_TARGET} copy_aux_files_for_${CURRENT_TARGET})

--- a/inside/CMakeLists.txt
+++ b/inside/CMakeLists.txt
@@ -41,5 +41,15 @@ set_target_properties(inside
         PREFIX ""
         SUFFIX ".far-plug-mb")
 
-add_custom_command(TARGET inside POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/configs "${INSTALL_DIR}/Plugins/inside")
+# copy resource files
+set(CURRENT_TARGET "inside")
+file(GLOB_RECURSE RESOURCE_FILES
+        RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/configs
+        "${CMAKE_CURRENT_SOURCE_DIR}/configs/*"
+)
+setup_target_auxiliary_files(${CURRENT_TARGET}
+        RESOURCE_FILES
+        ${CMAKE_CURRENT_SOURCE_DIR}/configs
+        "${INSTALL_DIR}/Plugins/${CURRENT_TARGET}/"
+)
+add_dependencies(${CURRENT_TARGET} copy_aux_files_for_${CURRENT_TARGET})

--- a/inside/CMakeLists.txt
+++ b/inside/CMakeLists.txt
@@ -42,5 +42,4 @@ set_target_properties(inside
         SUFFIX ".far-plug-mb")
 
 add_custom_command(TARGET inside POST_BUILD
-    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/configs
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/configs "${INSTALL_DIR}/Plugins/inside")

--- a/multiarc/CMakeLists.txt
+++ b/multiarc/CMakeLists.txt
@@ -222,5 +222,4 @@ set_target_properties(multiarc
         SUFFIX ".far-plug-mb")
 
 add_custom_command(TARGET multiarc POST_BUILD
-    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/configs
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/configs "${INSTALL_DIR}/Plugins/multiarc")

--- a/multiarc/CMakeLists.txt
+++ b/multiarc/CMakeLists.txt
@@ -221,5 +221,15 @@ set_target_properties(multiarc
         PREFIX ""
         SUFFIX ".far-plug-mb")
 
-add_custom_command(TARGET multiarc POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/configs "${INSTALL_DIR}/Plugins/multiarc")
+# copy resource files
+set(CURRENT_TARGET "multiarc")
+file(GLOB_RECURSE RESOURCE_FILES
+        RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/configs
+        "${CMAKE_CURRENT_SOURCE_DIR}/configs/*"
+)
+setup_target_auxiliary_files(${CURRENT_TARGET}
+        RESOURCE_FILES
+        ${CMAKE_CURRENT_SOURCE_DIR}/configs
+        "${INSTALL_DIR}/Plugins/${CURRENT_TARGET}/"
+)
+add_dependencies(${CURRENT_TARGET} copy_aux_files_for_${CURRENT_TARGET})

--- a/packaging/debian/CMakeLists.txt
+++ b/packaging/debian/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required (VERSION 3.5.0)
-
 find_package(Git QUIET)
 execute_process(COMMAND "${GIT_EXECUTABLE}" status
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"

--- a/tmppanel/CMakeLists.txt
+++ b/tmppanel/CMakeLists.txt
@@ -25,6 +25,5 @@ set_target_properties(tmppanel
         SUFFIX ".far-plug-wide")
 
 add_custom_command(TARGET tmppanel POST_BUILD
-    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/configs
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/configs "${INSTALL_DIR}/Plugins/tmppanel"
 )

--- a/tmppanel/CMakeLists.txt
+++ b/tmppanel/CMakeLists.txt
@@ -24,6 +24,15 @@ set_target_properties(tmppanel
         PREFIX ""
         SUFFIX ".far-plug-wide")
 
-add_custom_command(TARGET tmppanel POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/configs "${INSTALL_DIR}/Plugins/tmppanel"
+# copy resource files
+set(CURRENT_TARGET "tmppanel")
+file(GLOB_RECURSE RESOURCE_FILES
+        RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/configs
+        "${CMAKE_CURRENT_SOURCE_DIR}/configs/*"
 )
+setup_target_auxiliary_files(${CURRENT_TARGET}
+        RESOURCE_FILES
+        ${CMAKE_CURRENT_SOURCE_DIR}/configs
+        "${INSTALL_DIR}/Plugins/${CURRENT_TARGET}/"
+)
+add_dependencies(${CURRENT_TARGET} copy_aux_files_for_${CURRENT_TARGET})


### PR DESCRIPTION
errors appear on the latest version of cmake, such as:
```
CMake Warning (dev) at far2l/bootstrap/CMakeLists.txt:35 (add_custom_command):
  COMMENT requires exactly one argument, but multiple values or COMMENT
  keywords have been given.

  Policy CMP0175 is not set: add_custom_command() rejects invalid arguments.
  Run "cmake --help-policy CMP0175" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
```

```
CMake Warning (dev) at far2l/bootstrap/CMakeLists.txt:55 (add_custom_command):
  The following keywords are not supported when using
  add_custom_command(TARGET): DEPENDS.

  Policy CMP0175 is not set: add_custom_command() rejects invalid arguments.
  Run "cmake --help-policy CMP0175" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
```
Using 'DEPENDS', you need to specify the dependencies that should be generated by other steps.


