### PR TITLE
Improvements of kitty protocol implementation

### DIFF
--- a/WinPort/src/Backend/WX/wxMain.cpp
+++ b/WinPort/src/Backend/WX/wxMain.cpp
@@ -1607,7 +1607,9 @@ void WinPortPanel::OnChar( wxKeyEvent& event )
 		INPUT_RECORD ir = {0};
 		ir.EventType = KEY_EVENT;
 		ir.Event.KeyEvent.wRepeatCount = 1;
-		ir.Event.KeyEvent.wVirtualKeyCode = VK_OEM_PERIOD;
+		// we can not determine correct VirtualKeyCode value here because of
+		// https://github.com/wxWidgets/wxWidgets/issues/25379
+		ir.Event.KeyEvent.wVirtualKeyCode = VK_NONAME;
 		if (event.GetUnicodeKey() <= 0x7f) { 
 			if (_key_tracker.LastKeydown().GetTimestamp() == event.GetTimestamp()) {
 				wx2INPUT_RECORD irx(TRUE, _key_tracker.LastKeydown(), _key_tracker);

--- a/far2l/src/vt/vtshell_translation_kitty.cpp
+++ b/far2l/src/vt/vtshell_translation_kitty.cpp
@@ -250,7 +250,7 @@ std::string VT_TranslateKeyToKitty(const KEY_EVENT_RECORD &KeyEvent, int flags, 
 		case VK_OEM_3:      base = '`'; break;
 		// ...digits...
 		case VK_OEM_MINUS:  base = '-'; break;
-		case VK_OEM_PLUS:   base = '-'; break;
+		case VK_OEM_PLUS:   base = '+'; break;
 
 		// second row
 		// ...letters...

--- a/far2l/src/vt/vtshell_translation_kitty.cpp
+++ b/far2l/src/vt/vtshell_translation_kitty.cpp
@@ -400,9 +400,12 @@ std::string VT_TranslateKeyToKitty(const KEY_EVENT_RECORD &KeyEvent, int flags, 
 	// automatically determined, we use that. If it's not a symbol key, we simply use 0,
 	// as it's unclear why the "unshifted" value would be needed in real-world applications:
 	// for consistently working shortcuts, it's more reasonable to use the "base-layout-key" field instead.
+	// See also: https://github.com/elfmz/far2l/issues/2743
 	if (shifted && (keycode != tolower(shifted))) { keycode = 0; }
-	// UPD: base-layout-key also can not be trusted in our implementation for now because of
+	// UPD: base-layout-key also can not be trusted in our implementation
+	// for non-latin keypresses w/o modifiers (except Shift) because of IM usage, see
 	// https://github.com/wxWidgets/wxWidgets/issues/25379
+	// But hot keys w/o modifiers is nonsence, so not a problem actually
 
 	// avoid sending base char if it is equal to keycode
 	if (base == keycode) { base = 0; }

--- a/far2l/src/vt/vtshell_translation_kitty.cpp
+++ b/far2l/src/vt/vtshell_translation_kitty.cpp
@@ -356,6 +356,15 @@ std::string VT_TranslateKeyToKitty(const KEY_EVENT_RECORD &KeyEvent, int flags, 
 
 	out = "\x1B[";
 
+	// According to the spec, the keycode should always be "unshifted", meaning it should contain the value
+	// that this key would generate if Shift were not pressed. However, we have no knowledge of the user's
+	// keyboard layout here, so the unshifted value for an arbitrary key cannot be reliably determined.
+	// Therefore, if a symbol key is pressed together with Shift, and its lowercase variant can be
+	// automatically determined, we use that. If it's not a symbol key, we simply use 0,
+	// as it's unclear why the "unshifted" value would be needed in real-world applications:
+	// for consistently working shortcuts, it's more reasonable to use the "base-layout-key" field instead.
+	if (shifted && (keycode != tolower(shifted))) { keycode = 0; }
+
 	// adding keycode
 	out += std::to_string(keycode);
 


### PR DESCRIPTION
Our implementation of the Kitty protocol is still not fully compliant with the specification. One of the discrepancies was that when the Shift key was pressed, the `unicode-key-code` field contained values that didn't conform to the spec for all keys except alphabetic ones. After this commit, that field will contain 0 in such cases — which is not ideal, but still better than providing incorrect values. In any case, for character codes, applications should rely on the `shifted key` or `text-as-codepoints` fields that provide chars taking in mind Shift state, so this change should not affect real-world application behavior (tested it in the kitty mode of far2l and also in turbo).