### PR TITLE
From far2m

### DIFF
--- a/far2l/src/dialog.cpp
+++ b/far2l/src/dialog.cpp
@@ -1052,7 +1052,7 @@ const wchar_t *Dialog::GetDialogTitle()
 			const wchar_t *Ptr = CurItem->strData;
 
 			for (; *Ptr; Ptr++)
-				if (IsAlpha(*Ptr) || iswdigit(*Ptr))
+				if (!IsSpace(*Ptr) && !IsEol(*Ptr))
 					return (Ptr);
 		} else if (CurItem->Type == DI_LISTBOX && !I)
 			CurItemList = CurItem;

--- a/far2l/src/plug/plugapi.cpp
+++ b/far2l/src/plug/plugapi.cpp
@@ -1003,9 +1003,10 @@ static HANDLE FarDialogInitSynched(INT_PTR PluginNumber, int X1, int Y1, int X2,
 		return hDlg;
 
 	// ФИЧА! нельзя указывать отрицательные X2 и Y2
-	const auto fixCoord = [](int first, int second) { return (first < 0 && second == 0) ? 1 : second; };
-	X2 = fixCoord(X1, X2);
-	Y2 = fixCoord(Y1, Y2);
+	if (X1 < 0 && X2 == 0)
+		X2 = 1;
+	if (Y1 < 0 && Y2 == 0)
+		Y2 = 1;
 	const auto checkCoord = [](int first, int second) { return second >= 0 && ((first < 0) ? (second > 0) : (first <= second)); };
 	if (!checkCoord(X1, X2) || !checkCoord(Y1, Y2))
 		return hDlg;

--- a/far2l/src/plug/plugapi.cpp
+++ b/far2l/src/plug/plugapi.cpp
@@ -1003,7 +1003,11 @@ static HANDLE FarDialogInitSynched(INT_PTR PluginNumber, int X1, int Y1, int X2,
 		return hDlg;
 
 	// ФИЧА! нельзя указывать отрицательные X2 и Y2
-	if (X2 < 0 || Y2 < 0)
+	const auto fixCoord = [](int first, int second) { return (first < 0 && second == 0) ? 1 : second; };
+	X2 = fixCoord(X1, X2);
+	Y2 = fixCoord(Y1, Y2);
+	const auto checkCoord = [](int first, int second) { return second >= 0 && ((first < 0) ? (second > 0) : (first <= second)); };
+	if (!checkCoord(X1, X2) || !checkCoord(Y1, Y2))
 		return hDlg;
 
 	{


### PR DESCRIPTION
FAR API: fix crashing on invalid dialog coordinates (from far2m & Far3)
 from: https://github.com/shmuz/far2m/commit/9868000e6a96ddee05fa0623240484865369ae76
 & https://github.com/FarGroup/FarManager/blob/5f71f81412163821955049811aba544be5cbdcae/far/plugapi.cpp#L947-L951