### PR TITLE
Added debug message

### DIFF
--- a/far2l/src/vt/vtshell.cpp
+++ b/far2l/src/vt/vtshell.cpp
@@ -820,13 +820,18 @@ class VTShell : VTOutputReader::IProcessor, VTInputReader::IProcessor, IVTShell
 			}
 
 			if (_win32_input_mode_expected) {
-				return StrPrintf("\x1B[%i;%i;%i;%i;%i;%i_",
-						 KeyEvent.wVirtualKeyCode,
-						 KeyEvent.wVirtualScanCode,
-						 KeyEvent.uChar.UnicodeChar,
-						 KeyEvent.bKeyDown,
-						 KeyEvent.dwControlKeyState,
-						 KeyEvent.wRepeatCount);
+
+				std::string result = StrPrintf("\x1B[%i;%i;%i;%i;%i;%i_",
+				                KeyEvent.wVirtualKeyCode,
+				                KeyEvent.wVirtualScanCode,
+				                KeyEvent.uChar.UnicodeChar,
+				                KeyEvent.bKeyDown,
+				                KeyEvent.dwControlKeyState,
+				                KeyEvent.wRepeatCount);
+
+				fprintf(stderr, "win32-input-mode: generated ESC%s\n", result.c_str() + 1); // пропускаем \x1B
+
+				return result;
 			}
 
 			if (!KeyEvent.bKeyDown)


### PR DESCRIPTION
Output messages to the log not only when generating kitty sequences, but also win32-input-mode ones. Now it will be clear exactly which protocol the application running in the far uses. Debugging will be easier