### PR TITLE
macOS WX: junk control chars on Ctrl-Q

### DIFF
--- a/WinPort/src/Backend/WX/Mac/init.mm
+++ b/WinPort/src/Backend/WX/Mac/init.mm
@@ -21,5 +21,10 @@ void MacInit()
 	} else {
 		fprintf(stderr, "MacInit: no lang\n");
 	}
+	//avoid Ctrl-Q handling by cocoa
+	CFPreferencesSetAppValue(CFSTR("NSQuotedKeystrokeBinding"),
+							 CFSTR(""),
+							 kCFPreferencesCurrentApplication);
+	CFPreferencesAppSynchronize(kCFPreferencesCurrentApplication);
 }
 


### PR DESCRIPTION
Junk control characters appear in command line on arrows, backspace etc press after invoking quick view because native Ctrl-Q handling is enabled by default, see NSQuotedKeystrokeBinding  on  https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/EventOverview/TextDefaultsBindings/TextDefaultsBindings.html