### PR TITLE
debug dumper updates

### DIFF
--- a/DUMPER.md
+++ b/DUMPER.md
@@ -41,6 +41,7 @@ Output example:
 /-----[PID:38000, TID:1]-----[2025-05-08 00:46:28,450]-----
 |[/home/testuser/far2l/far2l/src/copy.cpp:2803] in ShellCopyFile()
 |=> SrcName = .editorconfig
+|=> SrcData.dwUnixMode = 100644 (rw-r--r--)
 |=> strDestName = /home/testuser/foobar/.editorconfig
 
 
@@ -211,7 +212,7 @@ DUMP(true,
 
 Wraps containers or static arrays.
 
-Use to log the contents of static arrays and iterable containers (i.e. containers that provide both `begin()` and `end()` methods) in a detailed and structured way.
+Use to log the contents of static arrays and iterable containers (i.e. containers that provide both `begin()` and `end()` methods) when you need to limit the number of displayed elements; for a complete container dump, prefer the simpler DVV macro.
 
 **Syntax:**
 

--- a/utils/include/debug.h
+++ b/utils/include/debug.h
@@ -622,7 +622,7 @@ namespace Dumper {
 		static_assert(sizeof...(args) % 2 == 0, "Dump() expects arguments in pairs: name and value.");
 
 		std::ostringstream log_stream;
-		log_stream << CreateLogHeader(func_name, location);
+		log_stream << CreateLogHeader(func_name, location) << std::boolalpha;
 
 		auto args_tuple = std::forward_as_tuple(args...);
 		constexpr std::size_t pair_count = sizeof...(args) / 2;
@@ -683,7 +683,7 @@ namespace Dumper {
 		const Ts&... var_values)
 	{
 		std::ostringstream log_stream;
-		log_stream << CreateLogHeader(func_name, location);
+		log_stream << CreateLogHeader(func_name, location) << std::boolalpha;
 
 		constexpr auto var_values_count = sizeof...(var_values);
 		std::vector<std::string> var_names;

--- a/utils/include/debug.h
+++ b/utils/include/debug.h
@@ -55,7 +55,7 @@ void FN_NORETURN FN_PRINTF_ARGS(1) Panic(const char *format, ...) noexcept;
 namespace Dumper {
 
 	// ****************************************************************************************************
-	// Вспомогательные переменные, функции и структуры
+	// Helper variables, functions, and structures
 	// ****************************************************************************************************
 
 	inline std::mutex g_log_output_mutex;
@@ -135,7 +135,7 @@ namespace Dumper {
 	}
 
 
-	// Метафункция для проверки на этапе компиляции: является ли тип T контейнером?
+	// Compile-time metafunction that determines if T is a container
 
 	template <typename T, typename = void>
 	struct is_container : std::false_type { };
@@ -150,7 +150,7 @@ namespace Dumper {
 	inline constexpr bool is_container_v = is_container<T>::value;
 
 	// ****************************************************************************************************
-	// Форматирование имён/значений переменных с учётом уровня их возможной вложенности при отображении контейнеров
+	// Formatting variable names/values according to their nesting level when displaying containers
 	// ****************************************************************************************************
 
 	constexpr std::size_t MAX_INDENT_LEVEL = 32;
@@ -209,7 +209,7 @@ namespace Dumper {
 
 
 	// ****************************************************************************************************
-	// DumpValue() - главная реализация-"диспетчер", обрабатывающая основные типы
+	// DumpValue() – the main dispatcher implementation handling the basic types
 	// ****************************************************************************************************
 
 	template <typename T>
@@ -288,7 +288,7 @@ namespace Dumper {
 
 
 	// ****************************************************************************************************
-	// Поддержка статических массивов char[], unsigned char[] и wchar_t[]
+	// Support for char[], unsigned char[], and wchar_t[] static arrays
 	// ****************************************************************************************************
 
 	template <typename CharT, std::size_t N>
@@ -314,7 +314,7 @@ namespace Dumper {
 
 
 	// ****************************************************************************************************
-	// Поддержка строковых буферов, доступных по паре (указатель, размер): через макросы DSTRBUF + DUMP
+	// Support for string buffers specified as (pointer, length) via DSTRBUF + DUMP macros
 	// ****************************************************************************************************
 
 	template <typename T>
@@ -350,7 +350,7 @@ namespace Dumper {
 	}
 
 	// ****************************************************************************************************
-	// Поддержка бинарных буферов, доступных по паре (указатель, размер в байтах): через макросы DBINBUF + DUMP
+	// Support for binary buffers specified as (pointer, byte count) via DBINBUF + DUMP macros
 	// ****************************************************************************************************
 
 	inline std::string CreateHexDump(const std::uint8_t* data, size_t length,
@@ -432,7 +432,7 @@ namespace Dumper {
 	}
 
 	// ****************************************************************************************************
-	// Поддержка итерируемых STL контейнеров и статических массивов: через макросы DCONT + DUMP
+	// Support for iterable STL containers and static arrays via DCONT + DUMP macros
 	// ****************************************************************************************************
 
 	template <typename ContainerT, typename = std::enable_if_t<is_container_v<ContainerT>>>
@@ -474,7 +474,7 @@ namespace Dumper {
 	}
 
 	// ****************************************************************************************************
-	// Поддержка флагов (битовые маски, etc): через макросы DFLAGS + DUMP; второй аргумент - Dumper::FlagsAs::...
+	// Support for flags (bitmasks, etc.) via DFLAGS + DUMP; use Dumper::FlagsAs::... as the second argument
 	// ****************************************************************************************************
 
 	enum class FlagsAs
@@ -569,7 +569,7 @@ namespace Dumper {
 	}
 
 	// ****************************************************************************************************
-	// Вспомогательный код для работы с логом
+	// Helper code for logging
 	// ****************************************************************************************************
 
 
@@ -605,7 +605,7 @@ namespace Dumper {
 	}
 
 	// ****************************************************************************************************
-	// Бэкенд для макроса DUMP: аргументы заключаются в дополнительные макросы DVV, DBUF, DCONT, DMSG...
+	// Backend for the DUMP macro: arguments must be wrapped in helper macros (DVV, DBUF, DCONT, DMSG...)
 	// ****************************************************************************************************
 
 	template<std::size_t... I, typename NameValueTupleT>
@@ -631,7 +631,7 @@ namespace Dumper {
 	}
 
 	// ****************************************************************************************************
-	// Бэкенд для макроса DUMPV: поддержка дампинга только переменных (без вызовов функций, макросов и сложных выражений)
+	// Backend for the DUMPV macro: only simple variables support (no function calls, macros, or complex expressions)
 	// ****************************************************************************************************
 
 	template <std::size_t... I, typename ValuesTupleT>


### PR DESCRIPTION
1. `std::codecvt_utf8`  has been replaced with calls to `Wide2MB()` and `StrWide2MB()` (no more **'codecvt_utf8<wchar_t>' is deprecated** warnings).
2. Boolean values are now logged in alphanumeric format (`true` and `false` instead of `1` and `0`).
3. All Russian comments have been replaced with their English translations.
4. Minor changes to DUMPER.md.