### PR TITLE
Remaining issues on a line starting with zwsp

### DIFF
--- a/far2l/src/edit.cpp
+++ b/far2l/src/edit.cpp
@@ -425,7 +425,7 @@ void Edit::FastShow()
 					break;
 				}
 				OutStrCells+= 2;
-			} else if (i == RealLeftPos || !cc.Xxxfix())
+			} else if (!cc.Xxxfix())
 				OutStrCells++;
 
 			OutStr.emplace_back(wc ? wc : L' ');

--- a/far2l/src/editor.cpp
+++ b/far2l/src/editor.cpp
@@ -391,8 +391,10 @@ void Editor::ShowEditor(int CurLineOnly)
 				// CurPtr->SetTables(UseDecodeTable ? &TableSet:nullptr);
 				//_D(SysLog(L"Setleftpos 3 to %i",LeftPos));
 				CurPtr->SetLeftPos(LeftPos);
-				CurPtr->SetCellCurPos(CurPos);
-				CurPtr->FastShow();
+				if (CurPtr != CurLine) {
+					CurPtr->SetCellCurPos(CurPos);
+					CurPtr->FastShow();
+				}
 				CurPtr->SetEditBeyondEnd(EdOpt.CursorBeyondEOL);
 				CurPtr = CurPtr->m_next;
 			} else {

--- a/far2l/src/mix/StrCells.cpp
+++ b/far2l/src/mix/StrCells.cpp
@@ -11,7 +11,7 @@ size_t StrCellsCount(const wchar_t *pwz, size_t nw)
 		CharClasses cc(pwz[i]);
 		if (cc.FullWidth()) {
 			out+= 2;
-		} else if ((i == nw - 1 || !cc.Prefix()) && (i == 0 || !cc.Suffix())) {
+		} else if ((i == nw - 1 || !cc.Prefix()) && !cc.Suffix() ) {
 			++out;
 		}
 	}
@@ -25,7 +25,7 @@ size_t StrZCellsCount(const wchar_t *pwz)
 		CharClasses cc(pwz[i]);
 		if (cc.FullWidth()) {
 			out+= 2;
-		} else if ((pwz[i + 1] == 0 || !cc.Prefix()) && (i == 0 || !cc.Suffix())) {
+		} else if ((pwz[i + 1] == 0 || !cc.Prefix()) && !cc.Suffix() ) {
 			++out;
 		}
 	}


### PR DESCRIPTION
* Avoid resetting the current line cursor position when redrawing from plugins.
* Don't increase the number of cells for a non-printable character in the first position.

Fix #2554