### PR TITLE
fix black.hrd for non-higlighted files

### DIFF
--- a/colorer/configs/base/hrd/rgb/black.hrd
+++ b/colorer/configs/base/hrd/rgb/black.hrd
@@ -4,8 +4,8 @@
 <hrd xmlns="http://colorer.sf.net/2003/hrd">
 
   <assign name="def:Text" fore="#d1d1d1" back="#000000"/>
-  <assign name="def:HorzCross" fore="#000000" back="#313b30"/>
-  <assign name="def:VertCross" fore="#000000" back="#313b30"/>
+  <assign name="def:HorzCross" fore="#fbc9ff" back="#313b30"/>
+  <assign name="def:VertCross" fore="#fbc9ff" back="#313b30"/>
 
   <assign name="def:Number" fore="#00a800" />
   <assign name="def:NumberDec" fore="#008c00" />


### PR DESCRIPTION
When 'CrossDraw=1' in non highlighted files, text color was #000000 in front of #313b30. It is unreadable.  Changed text color from  #000000 to #fbc9ff to make it readble