### PR TITLE
debug dumper: add stacktrace support

### DIFF
--- a/DUMPER.md
+++ b/DUMPER.md
@@ -371,7 +371,7 @@ Here is the full list:
 	- PreferSymtab: Try .symtab first; if lookup fails or .symtab is absent, fall back to .dynsym.
 
 
-* `SHOW_SYMBOL_SOURCE`
+* `STACKTRACE_SHOW_SYMBOL_SOURCE`
 
 	When true, append a source tag indicating whether symbols were resolved via the dynamic symbol table (dynsym) or the full symbol table (symtab); when false, omit the tag.
 

--- a/utils/include/debug.h
+++ b/utils/include/debug.h
@@ -114,7 +114,7 @@ namespace Dumper {
 		static constexpr bool STACKTRACE_DEMANGLE_NAMES = true;
 		static constexpr AdjustmentStrategy STACKTRACE_RETADDR_ADJUSTMENT = AdjustmentStrategy::Off;
 		static constexpr ResolutionStrategy STACKTRACE_SYMBOL_RESOLUTION = ResolutionStrategy::PreferDynsym;
-		static constexpr bool SHOW_SYMBOL_SOURCE = true;
+		static constexpr bool STACKTRACE_SHOW_SYMBOL_SOURCE = true;
 		static constexpr bool STACKTRACE_SHOW_CMDLINE_TOOL_COMMANDS = true;
 		static constexpr size_t STACKTRACE_MAX_FRAMES = 64;
 		static constexpr size_t STACKTRACE_SKIP_FRAMES = 2;
@@ -503,7 +503,7 @@ namespace Dumper {
 			result << (frameinfo.func_name.empty() ? "[unknown-function]" : frameinfo.func_name.c_str());
 			result << "  ";
 
-			if constexpr (DumperConfig::SHOW_SYMBOL_SOURCE) {
+			if constexpr (DumperConfig::STACKTRACE_SHOW_SYMBOL_SOURCE) {
 				if (frameinfo.found_in_symtab) {
 					result << " [symtab]";
 				} else if (!frameinfo.func_name.empty()) {

--- a/utils/include/debug.h
+++ b/utils/include/debug.h
@@ -28,7 +28,48 @@
 #include <iterator>
 #include <algorithm>
 #include <array>
+#include <map>
+#include <dlfcn.h>
 #include "WideMB.h"
+#include <fcntl.h>
+
+#if defined(__linux__)
+#  include <elf.h>
+#  define HAS_ELF_ENHANCEMENT
+#endif
+
+#if defined(HAS_ELF_ENHANCEMENT) && !defined(ELF_PSEUDO_TYPES_DEFINED)
+#  if defined(__LP64__) || defined(_LP64)
+typedef Elf64_Ehdr Elf_Ehdr;
+typedef Elf64_Phdr Elf_Phdr;
+typedef Elf64_Shdr Elf_Shdr;
+typedef Elf64_Sym  Elf_Sym;
+#  else
+typedef Elf32_Ehdr Elf_Ehdr;
+typedef Elf32_Phdr Elf_Phdr;
+typedef Elf32_Shdr Elf_Shdr;
+typedef Elf32_Sym  Elf_Sym;
+#  endif
+#  define ELF_PSEUDO_TYPES_DEFINED
+#endif
+
+// Platform-specific includes for stack trace functionality
+#if !defined(__FreeBSD__) && !defined(__DragonFly__) && !defined(__MUSL__) && !defined(__UCLIBC__) && !defined(__HAIKU__) && !defined(__ANDROID__) // todo: pass to linker -lexecinfo under BSD and then may remove this ifndef
+# include <execinfo.h>
+# define HAS_BACKTRACE
+#endif
+
+#if defined(__has_include)
+# if __has_include(<cxxabi.h>)
+#   include <cxxabi.h>
+#   define HAS_CXX_DEMANGLE
+# endif
+#else
+# if defined(__GLIBCXX__) || defined(__GLIBCPP__) || ((defined(__GNUC__) || defined(__clang__)) && !defined(__APPLE__))
+#   include <cxxabi.h>
+#   define HAS_CXX_DEMANGLE
+# endif
+#endif
 
 
 /** This ABORT_* / ASSERT_* have following distinctions comparing to abort/assert:
@@ -66,6 +107,17 @@ namespace Dumper {
 		static constexpr size_t HEXDUMP_MAX_LENGTH = 1024 * 1024;
 
 		static constexpr std::size_t CONTAINERS_MAX_INDENT_LEVEL = 32;
+		enum class AdjustmentStrategy { Off, PreferAdjusted, PreferOriginal };
+		enum class ResolutionStrategy { OnlyDynsym, PreferDynsym, PreferSymtab, OnlySymtab };
+
+		static constexpr bool STACKTRACE_SHOW_ADDRESSES = true;
+		static constexpr bool STACKTRACE_DEMANGLE_NAMES = true;
+		static constexpr AdjustmentStrategy STACKTRACE_RETADDR_ADJUSTMENT = AdjustmentStrategy::Off;
+		static constexpr ResolutionStrategy STACKTRACE_SYMBOL_RESOLUTION = ResolutionStrategy::PreferDynsym;
+		static constexpr bool SHOW_SYMBOL_SOURCE = true;
+		static constexpr bool STACKTRACE_SHOW_CMDLINE_TOOL_COMMANDS = true;
+		static constexpr size_t STACKTRACE_MAX_FRAMES = 64;
+		static constexpr size_t STACKTRACE_SKIP_FRAMES = 2;
 	};
 
 
@@ -164,6 +216,366 @@ namespace Dumper {
 
 	template <typename T>
 	inline constexpr bool is_container_v = is_container<T>::value;
+
+
+	// ****************************************************************************************************
+	// Stack trace support functionality
+	// ****************************************************************************************************
+
+	struct StackTrace
+	{
+		std::vector<std::string> frames;
+		std::vector<std::string> cmdline_tool_invocations;
+
+		StackTrace()
+		{
+			CaptureStackTrace();
+		}
+
+	private:
+
+		struct DlAddrResult
+		{
+			int dladdr_success = false;
+			Dl_info info = {};
+			const void* used_address = nullptr;
+			bool used_adjusted = false;
+		};
+
+
+		struct FrameInfo
+		{
+			std::string module_shortname {};
+			std::string module_fullname {};
+			std::string func_name {};
+
+			uintptr_t original_address = 0;
+			uintptr_t used_address = 0;
+			uintptr_t module_base = 0;
+			uintptr_t offset_from_module = 0;
+			uintptr_t symbol_addr = 0;
+
+			bool used_adjusted = false;
+			bool found_in_symtab = false;
+
+			// uintptr_t symbol_size = 0;
+			// uintptr_t offset_from_symbol = 0;
+		};
+
+
+		static std::string DemangleName(const char* mangled_name)
+		{
+			if (!mangled_name || !*mangled_name) return "";
+#ifdef HAS_CXX_DEMANGLE
+			int status = 0;
+			char* raw = abi::__cxa_demangle(mangled_name, nullptr, nullptr, &status);
+			std::unique_ptr<char, decltype(&std::free)> demangled(raw, &std::free);
+			if (status == 0 && demangled) {
+				return std::string(demangled.get());
+			}
+#endif
+			return std::string(mangled_name);
+		}
+
+
+		static std::string HexAddr(uintptr_t v)
+		{
+			std::ostringstream os;
+			os << "0x" << std::hex << v;
+			return os.str();
+		}
+
+
+		static bool TryAdjustReturnAddress(const void* in, const void*& out)
+		{
+			out = in;
+			if (in == nullptr) return false;
+
+			auto original = reinterpret_cast<uintptr_t>(in);
+			uintptr_t adjusted = original;
+
+#if defined(__arm__) && !defined(__aarch64__)
+			if (original & 1u) {
+				adjusted = original & ~uintptr_t(1);
+			}
+#elif defined(__aarch64__)
+			if (original > 4) {
+				adjusted = original - 4;
+			}
+#elif defined(__x86_64__) || defined(__i386__) || defined(_M_X64) || defined(_M_IX86)
+			if (original > 1) {
+				adjusted = original - 1;
+			}
+#endif
+
+			if (adjusted != original && adjusted != 0) {
+				out = reinterpret_cast<const void*>(adjusted);
+				return true;
+			}
+			return false;
+		}
+
+
+		static DlAddrResult DlAddrWithAdjust(const void* original)
+		{
+			auto adjust_strategy = DumperConfig::STACKTRACE_RETADDR_ADJUSTMENT;
+
+			DlAddrResult result;
+			result.used_address = original;
+
+			auto TryDlAddr = [&](const void* addr) -> bool {
+				Dl_info info_local;
+				if (dladdr(addr, &info_local)) {
+					result.dladdr_success = true;
+					result.info = info_local;
+					result.used_address = addr;
+					return true;
+				}
+				return false;
+			};
+
+			if (adjust_strategy == DumperConfig::AdjustmentStrategy::Off) {
+				TryDlAddr(original);
+				return result;
+			}
+
+			const void* adjusted = nullptr;
+			bool has_adjusted = TryAdjustReturnAddress(original, adjusted);
+
+			if (adjust_strategy == DumperConfig::AdjustmentStrategy::PreferAdjusted) {
+				if (has_adjusted) {
+					if (TryDlAddr(adjusted)) { result.used_adjusted = true; return result; }
+				}
+				TryDlAddr(original);
+				return result;
+			}
+
+			if (TryDlAddr(original)) { return result; }
+			if (has_adjusted) {
+				if (TryDlAddr(adjusted)) { result.used_adjusted = true; return result; }
+			}
+			return result;
+		}
+
+
+#ifdef HAS_ELF_ENHANCEMENT
+		struct FileData : std::vector<char>
+		{
+			FileData(const char *file, size_t offset, size_t size) : std::vector<char>(size)
+			{
+				int fd = open(file, O_RDONLY);
+				if (fd != -1) {
+					pread(fd, data(), size, offset);
+					close(fd);
+				}
+			}
+		};
+
+
+		static bool TrySymtabResolve(DlAddrResult dladdr_result, FrameInfo &frameinfo_out)
+		{
+			if (!dladdr_result.dladdr_success || !dladdr_result.info.dli_fname) {
+				return false;
+			}
+
+			const char *fname = dladdr_result.info.dli_fname;
+			const void *raw_addr = dladdr_result.used_address;
+			void *module_base = dladdr_result.info.dli_fbase;
+
+			unsigned long offset = (const char *)raw_addr - (const char *)module_base;
+			unsigned long base_addr = 0;
+			const Elf_Ehdr *eh = (const Elf_Ehdr *)module_base;
+			for (int i = 0; i < (int)eh->e_phnum; ++i) {
+				const Elf_Phdr *ph = (const Elf_Phdr *)
+				((const char *)module_base + eh->e_phoff + i * eh->e_phentsize);
+				if (ph->p_type == PT_LOAD) {
+					base_addr = ph->p_vaddr;
+					break;
+				}
+			}
+
+
+			FileData shtab(fname, eh->e_shoff, eh->e_shnum * eh->e_shentsize);
+			for (int i = 0; i < (int)eh->e_shnum; ++i) {
+				const Elf_Shdr *sh = (const Elf_Shdr *)&shtab[i * eh->e_shentsize];
+				if (sh->sh_type == SHT_SYMTAB && sh->sh_link < eh->e_shnum) {
+					FileData syms(fname, sh->sh_offset, sh->sh_size);
+					size_t syms_count = sh->sh_size / sh->sh_entsize;
+					for (size_t s = 0; s < syms_count; ++s) {
+						const Elf_Sym *sym = (const Elf_Sym *)&syms[s * sh->sh_entsize];
+						if (offset >= sym->st_value - base_addr && offset < sym->st_value + sym->st_size - base_addr
+							&& (sym->st_info == STT_FUNC || sym->st_info == STT_OBJECT || sym->st_info == STT_TLS) ) {
+							const Elf_Shdr *strtab_sh = (const Elf_Shdr *)&shtab[sh->sh_link * eh->e_shentsize];
+							FileData strtab(fname, strtab_sh->sh_offset, strtab_sh->sh_size);
+							strtab.emplace_back(0); //ensure 0-terminated
+							if (sym->st_name < strtab.size() && strtab[sym->st_name] != '$') {
+								frameinfo_out.found_in_symtab = true;
+								frameinfo_out.func_name = &strtab[sym->st_name];
+								return true;
+							}
+						}
+					}
+				}
+			}
+
+			return false;
+		}
+#endif
+
+
+		static bool TryDynsymResolve(DlAddrResult dladdr_result, FrameInfo &frameinfo_out)
+		{
+			const char* sname = dladdr_result.info.dli_sname;
+			const void *saddr = dladdr_result.info.dli_saddr;
+
+			if (sname && *sname && saddr) {
+				frameinfo_out.func_name = sname;
+				frameinfo_out.symbol_addr = reinterpret_cast<uintptr_t>(saddr);
+				return true;
+			}
+			return false;
+		}
+
+
+		static FrameInfo GetFrameInfo(const void* raw_addr)
+		{
+			FrameInfo frameinfo;
+			frameinfo.original_address = reinterpret_cast<uintptr_t>(raw_addr);
+			auto dladdr_result = DlAddrWithAdjust(raw_addr);
+			frameinfo.used_address = reinterpret_cast<uintptr_t>(dladdr_result.used_address);
+			frameinfo.used_adjusted = dladdr_result.used_adjusted;
+
+			if (dladdr_result.dladdr_success) {
+
+				frameinfo.module_base = reinterpret_cast<uintptr_t>(dladdr_result.info.dli_fbase);
+				frameinfo.offset_from_module = CalculateOffset(frameinfo.used_address, frameinfo.module_base);
+
+				const char* fname = dladdr_result.info.dli_fname;
+
+				if (fname && *fname) {
+					frameinfo.module_fullname = fname;
+					const char* last_slash = strrchr(fname, '/');
+					frameinfo.module_shortname = last_slash ? last_slash + 1 : fname;
+				}
+
+				auto resolve_strategy = DumperConfig::STACKTRACE_SYMBOL_RESOLUTION;
+
+#ifdef HAS_ELF_ENHANCEMENT
+				if (resolve_strategy == DumperConfig::ResolutionStrategy::PreferSymtab) {
+					if (!TrySymtabResolve(dladdr_result, frameinfo)) {
+						TryDynsymResolve(dladdr_result, frameinfo);
+					}
+				} else if (resolve_strategy == DumperConfig::ResolutionStrategy::PreferDynsym) {
+					if (!TryDynsymResolve(dladdr_result, frameinfo)) {
+						TrySymtabResolve(dladdr_result, frameinfo);
+					}
+				} else if (resolve_strategy == DumperConfig::ResolutionStrategy::OnlyDynsym) {
+					TryDynsymResolve(dladdr_result, frameinfo);
+				} else {
+					TrySymtabResolve(dladdr_result, frameinfo);
+				}
+#else
+				TryDynsymResolve(dladdr_result, frameinfo);
+#endif
+			}
+
+			if constexpr (DumperConfig::STACKTRACE_DEMANGLE_NAMES) {
+				frameinfo.func_name = DemangleName(frameinfo.func_name.c_str());
+			}
+
+			return frameinfo;
+		}
+
+
+
+		static uintptr_t CalculateOffset(uintptr_t address, uintptr_t base)
+		{
+			return (address >= base) ? (address - base) : 0;
+		}
+
+
+		static std::string FormatFrame(const FrameInfo& frameinfo)
+		{
+			std::ostringstream result;
+
+			result << (frameinfo.module_shortname.empty() ? "[unknown-module]" : frameinfo.module_shortname.c_str());
+			result << " :: ";
+			result << (frameinfo.func_name.empty() ? "[unknown-function]" : frameinfo.func_name.c_str());
+			result << "  ";
+
+			if constexpr (DumperConfig::SHOW_SYMBOL_SOURCE) {
+				if (frameinfo.found_in_symtab) {
+					result << " [symtab]";
+				} else if (!frameinfo.func_name.empty()) {
+					result << " [dynsym]";
+				}
+			}
+
+			if constexpr (DumperConfig::STACKTRACE_SHOW_ADDRESSES) {
+				result << " :: abs=" << HexAddr(frameinfo.used_address);
+
+				if (frameinfo.used_adjusted) {
+					result << " (*original: " << HexAddr(frameinfo.original_address) << ")";
+				}
+
+				if (frameinfo.module_base) {
+					result << ", mod_base=" << HexAddr(frameinfo.module_base)
+					<< ", +off_mod=" << HexAddr(frameinfo.offset_from_module);
+				}
+
+				if (frameinfo.symbol_addr) {
+					result << ", sym_addr=" << HexAddr(frameinfo.symbol_addr);
+				}
+			}
+			return result.str();
+		}
+
+
+		void CaptureStackTrace()
+		{
+#ifdef HAS_BACKTRACE
+			static_assert(DumperConfig::STACKTRACE_MAX_FRAMES <= 0x7fffffff, "STACKTRACE_MAX_FRAMES too large for backtrace()");
+
+			void* raw_frames[DumperConfig::STACKTRACE_MAX_FRAMES];
+			auto frame_count = static_cast<size_t>(backtrace(raw_frames, DumperConfig::STACKTRACE_MAX_FRAMES));
+
+			if (frame_count <= DumperConfig::STACKTRACE_SKIP_FRAMES) {
+				frames.emplace_back("[no stack frames available]");
+				return;
+			}
+
+			frames.reserve(frame_count - DumperConfig::STACKTRACE_SKIP_FRAMES);
+
+
+			std::map<std::string, std::vector<uintptr_t>> module_addresses;
+
+			for (size_t i = DumperConfig::STACKTRACE_SKIP_FRAMES; i < frame_count; ++i) {
+				auto frameinfo = GetFrameInfo(raw_frames[i]);
+				frames.emplace_back(FormatFrame(frameinfo));
+
+				if constexpr (DumperConfig::STACKTRACE_SHOW_CMDLINE_TOOL_COMMANDS) {
+					if (!frameinfo.module_fullname.empty()) {
+						module_addresses[frameinfo.module_fullname].push_back(frameinfo.offset_from_module);
+					}
+				}
+			}
+
+			if constexpr (DumperConfig::STACKTRACE_SHOW_CMDLINE_TOOL_COMMANDS) {
+				cmdline_tool_invocations.reserve(module_addresses.size());
+				for (const auto& [module_path, addresses] : module_addresses) {
+					std::ostringstream cmdline_stream;
+					cmdline_stream << "addr2line -e '" << module_path << "' -f -p -C -i";
+					for (const auto& addr : addresses) {
+						cmdline_stream << " " << HexAddr(addr);
+					}
+					cmdline_tool_invocations.emplace_back(cmdline_stream.str());
+				}
+			}
+#else
+			frames.emplace_back("[stack trace not available on this platform]");
+#endif
+		}
+	};
 
 	// ****************************************************************************************************
 	// Formatting variable names/values according to their nesting level when displaying containers
@@ -448,9 +860,8 @@ namespace Dumper {
 						   << " bytes (full length: " << bin_buf_wrapper.length << " bytes)\n";
 			}
 		}
-
-
 	}
+
 
 	// ****************************************************************************************************
 	// Support for iterable STL containers and static arrays via DCONT + DUMP macros
@@ -493,6 +904,7 @@ namespace Dumper {
 					   << " elements (total elements: " << container_size << ")\n";
 		}
 	}
+
 
 	// ****************************************************************************************************
 	// Support for flags (bitmasks, etc.) via DFLAGS + DUMP; use Dumper::FlagsAs::... as the second argument
@@ -598,6 +1010,26 @@ namespace Dumper {
 		log_stream << "|=> " << var_name << " = " << decoded << '\n';
 	}
 
+
+	// ****************************************************************************************************
+	// Support for [STACKTRACE]
+	// ****************************************************************************************************
+
+
+	inline void DumpValue(
+		std::ostringstream& log_stream,
+		std::string_view var_name,
+		const StackTrace& stack_trace,
+		const IndentInfo& indent_info = IndentInfo())
+	{
+		LogVarWithIndentation(log_stream, "[STACKTRACE]", nullptr, indent_info, false);
+		DumpValue(log_stream, "[FRAMES]", stack_trace.frames, indent_info.CreateChild(DumperConfig::STACKTRACE_SHOW_CMDLINE_TOOL_COMMANDS));
+		if constexpr (DumperConfig::STACKTRACE_SHOW_CMDLINE_TOOL_COMMANDS) {
+			DumpValue(log_stream, "[CMDLINE TOOL]", stack_trace.cmdline_tool_invocations, indent_info.CreateChild(false));
+		}
+	}
+
+
 	// ****************************************************************************************************
 	// Helper code for logging
 	// ****************************************************************************************************
@@ -655,6 +1087,7 @@ namespace Dumper {
 		}
 	}
 
+
 	// ****************************************************************************************************
 	// Backend for the DUMP macro: arguments must be wrapped in helper macros (DVV, DBINBUF, DCONT, DMSG...)
 	// ****************************************************************************************************
@@ -680,6 +1113,7 @@ namespace Dumper {
 		ProcessPairs(args_tuple, log_stream, std::make_index_sequence<pair_count>{});
 		FlushLog(log_stream);
 	}
+
 
 	// ****************************************************************************************************
 	// Backend for the DUMPV macro: only simple variables support (no function calls, macros, or complex expressions)
@@ -763,3 +1197,4 @@ namespace Dumper {
 #define DSTRBUF(ptr,length) #ptr, Dumper::StrBufWrapper(ptr,length)
 #define DCONT(container,max_elements) #container, Dumper::ContainerWrapper(container,max_elements)
 #define DFLAGS(var, treat_as) #var, Dumper::FlagsWrapper(var, treat_as)
+#define DSTACKTRACE() "[STACKTRACE]", Dumper::StackTrace()


### PR DESCRIPTION
Добавляет в отладочный дампер возможность получать стек вызовов:
```cpp
DUMP(DSTACKTRACE());
```
На данный момент использует `backtrace()`, `dladdr()` и `abi::__cxa_demangle()`. Код максимально обложен #ifdef-ами.
~~Поскольку для полезного и красивого стека нужны опции -fno-omit-frame-pointer, -fvisibility=default и -rdynamic, был также обновлён файл CMakeLists.txt. Пока что данные настройки применяются только к цели far2l, в Debug-сборке и при явном задании CMake опции -DDUMPER_STACKTRACE_SUPPORT=ON.~~

В качестве метода резолвинга символов добавлен прямой парсинг .symtab/.strtab. На выбор доступно 4 стратегии: юзать только .dynsym, либо только .symtab, либо одну из них с фолбэком к другой.



<img width="836" height="482" alt="изображение" src="https://github.com/user-attachments/assets/a181f68a-281c-47ac-8bc5-c27bfd26617c" />
