### PR TITLE
fix mouse selection beyond left border of an edit

### DIFF
--- a/far2l/src/edit.cpp
+++ b/far2l/src/edit.cpp
@@ -2137,6 +2137,7 @@ int Edit::RealPosToCell(int PrevLength, int PrevPos, int Pos, int *CorrectPos)
 
 int Edit::CellPosToReal(int Pos)
 {
+	if (Pos < 0) return 0;
 	if (!HasSpecialWidthChars) return Pos;
 	int Index = 0;
 	for (int CellPos = 0; CellPos < Pos; Index++) {


### PR DESCRIPTION
Issue:

> Вызываем какой-нибудь диалог с полем редактирования, например Make Folder. Мышью выделяем текст справа налево вплоть до начального символа текста (если там есть текст) и продолжаем удерживать левую кнопку мыши. Начинается скроллинг вправо, и в поле ввода появляется мусор.