### PR TITLE
Always prepend filename with ./ when pasting to cmd line

### DIFF
--- a/far2l/src/panels/filelist.cpp
+++ b/far2l/src/panels/filelist.cpp
@@ -1158,9 +1158,7 @@ int FileList::ProcessKey(FarKey Key)
 						EscapeSpace(strFileName);
 
 					strFileName+= L" ";
-					if (PanelMode != PLUGIN_PANEL) {
-						EnsurePathHasParentPrefix(strFileName);
-					}
+					EnsurePathHasParentPrefix(strFileName);
 				}
 
 				CtrlObject->CmdLine->InsertString(strFileName);


### PR DESCRIPTION
even for plugins
fix #2313