### PR TITLE
A few build fixes for macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,7 +232,10 @@ else()
         endif()
 
     elseif (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-        if (EXISTS "/opt/local/Library/Frameworks/wxWidgets.framework/Versions/wxWidgets/3.2/bin/wx-config")
+        if (DEFINED wxWidgets_CONFIG_EXECUTABLE)
+            message(STATUS "Using pre-defined wx config: ${wxWidgets_CONFIG_EXECUTABLE}")
+
+        elseif (EXISTS "/opt/local/Library/Frameworks/wxWidgets.framework/Versions/wxWidgets/3.2/bin/wx-config")
             # MacPorts
             set(wxWidgets_CONFIG_EXECUTABLE "/opt/local/Library/Frameworks/wxWidgets.framework/Versions/wxWidgets/3.2/bin/wx-config")
             set(wxWidgets_wxrc_EXECUTABLE "/opt/local/Library/Frameworks/wxWidgets.framework/Versions/wxWidgets/3.2/bin/wxrc")

--- a/WinPort/src/Backend/WX/CMakeLists.txt
+++ b/WinPort/src/Backend/WX/CMakeLists.txt
@@ -69,7 +69,7 @@ if(CMAKE_THREAD_LIBS_INIT)
     target_link_libraries(far2l_gui "${CMAKE_THREAD_LIBS_INIT}")
 endif()
 
-if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND ${CMAKE_CXX_COMPILER} MATCHES "Clang")
     set_property (TARGET far2l_gui APPEND_STRING PROPERTY COMPILE_FLAGS "-fobjc-arc")
 endif()
 

--- a/WinPort/src/Backend/WX/Mac/displaynotify.mm
+++ b/WinPort/src/Backend/WX/Mac/displaynotify.mm
@@ -1,12 +1,24 @@
 #import <Foundation/Foundation.h>
 #import <Cocoa/Cocoa.h>
+#include <AvailabilityMacros.h>
 
 bool MacDisplayNotify(const char *title, const char *text)
 {
+	NSString *nsTitle = [NSString stringWithUTF8String:title];
+	NSString *nsText  = [NSString stringWithUTF8String:text];
+
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1080
 	NSUserNotification *userNotification = [[NSUserNotification alloc] init];
-	userNotification.title = [NSString stringWithUTF8String:title];
-	userNotification.informativeText = [NSString stringWithUTF8String:text];
+	userNotification.title = nsTitle;
+	userNotification.informativeText = nsText;
 
 	[[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification:userNotification]; //deliverNotification
+#else
+	NSAlert *alert = [[NSAlert alloc] init];
+	[alert setMessageText:nsTitle];
+	[alert setInformativeText:nsText];
+	[alert addButtonWithTitle:@"OK"];
+	[alert runModal];
+#endif
 	return true;
 }

--- a/far2l/CMakeLists.txt
+++ b/far2l/CMakeLists.txt
@@ -251,7 +251,7 @@ target_include_directories(far2l PRIVATE
 add_dependencies(far2l bootstrap WinPort)
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-    SET (WINPORT -force_load WinPort wineguts utils)
+    SET (WINPORT -Wl,-force_load WinPort wineguts utils)
 else()
     SET (WINPORT -Wl,--whole-archive WinPort -Wl,--no-whole-archive)
 endif()


### PR DESCRIPTION
1. Fix build failures on macOS due to flags passed from CMakeLists.
2. Allow a user to choose wx version on macOS, like it is done for FreeBSD.
3. Fix compile error on < 10.8, `NSUserNotification` does not exist prior to it: https://developer.apple.com/documentation/foundation/nsusernotification 