### PR TITLE
Use VK_NONAME instead of 0 to fix cyrillic input on Mint 21

### DIFF
--- a/WinPort/src/Backend/WX/wxMain.cpp
+++ b/WinPort/src/Backend/WX/wxMain.cpp
@@ -1618,7 +1618,8 @@ void WinPortPanel::OnChar( wxKeyEvent& event )
 		ir.Event.KeyEvent.wRepeatCount = 1;
 		// we can not determine correct VirtualKeyCode value here because of
 		// https://github.com/wxWidgets/wxWidgets/issues/25379
-		ir.Event.KeyEvent.wVirtualKeyCode = wxKeyCode2WinKeyCode(_key_tracker.LastKeydown().GetKeyCode());
+		WORD temp_key_code = wxKeyCode2WinKeyCode(_key_tracker.LastKeydown().GetKeyCode());
+		ir.Event.KeyEvent.wVirtualKeyCode = temp_key_code ? temp_key_code : VK_NONAME;
 		if (event.GetUnicodeKey() <= 0x7f) { 
 			if (_key_tracker.LastKeydown().GetTimestamp() == event.GetTimestamp()) {
 				wx2INPUT_RECORD irx(TRUE, _key_tracker.LastKeydown(), _key_tracker);


### PR DESCRIPTION
… and in some other setups.

Fixes #2895