### PR TITLE
Avoid errors on multiline paste execution due to trailing empty lines

### DIFF
--- a/far2l/src/cmdline.cpp
+++ b/far2l/src/cmdline.cpp
@@ -587,6 +587,7 @@ int CommandLine::ProcessKeyIfVisible(FarKey Key)
 				if (ClipText && wcschr(ClipText, L'\n') && wcschr(ClipText, L'\n')[1] != L'\0') {
 					CmdStr.GetString(strStr);
 					FARString strToExec = strStr.SubStr(0, CmdStr.GetCurPos()) + ClipText + strStr.SubStr(CmdStr.GetCurPos());
+					RemoveTrailingSpaces(strToExec);
 					if (Opt.CmdLine.AskOnMultilinePaste) {
 						ExMessager em;
 						em.AddMultiline(Msg::MultilinePaste);


### PR DESCRIPTION
<img width="476" height="202" alt="image" src="https://github.com/user-attachments/assets/8fb66930-2a0c-47f8-a140-0a1733c69acc" />
