### PR TITLE
Make arclite plugin compatible with uClibc-ng

### DIFF
--- a/arclite/src/Patch7zCP.cpp
+++ b/arclite/src/Patch7zCP.cpp
@@ -778,7 +778,7 @@ bool get_faddrs(void *handle)
 
 static bool patch_plt(void *handle)
 {
-#if defined(__APPLE__)
+#if defined(__APPLE__) || defined(__UCLIBC__)
 	return false;
 #else
 	struct link_map *map;


### PR DESCRIPTION
Do not use the 'dlinfo' function when building arclite plugin with uClibc-ng, as this function is not present in the library.