### PR TITLE
Reset search position to the beginning of a file on Home key press

### DIFF
--- a/far2l/src/viewer.cpp
+++ b/far2l/src/viewer.cpp
@@ -1770,7 +1770,7 @@ int Viewer::ProcessKey(FarKey Key)
 			if (ViewFile.Opened()) {
 				FilePos = 0;
 				Show();
-				//				LastSelPos=FilePos;
+				LastSelPos=FilePos;
 			}
 
 			return TRUE;


### PR DESCRIPTION
Fixes #2939