### PR TITLE
hexitor

### DIFF
--- a/hexitor/src/editor.cpp
+++ b/hexitor/src/editor.cpp
@@ -483,6 +483,7 @@ bool editor::move_handle_key(int key)
 				update_buffer(_view_offset + 0x10);
 			break;
 
+		case KEY_MSWHEEL_UP:
 		case KEY_NUMPAD8:
 		case KEY_UP:
 			if (ctrl_pressed) {
@@ -504,6 +505,7 @@ bool editor::move_handle_key(int key)
 			}
 			break;
 
+		case KEY_MSWHEEL_DOWN:
 		case KEY_NUMPAD2:
 		case KEY_DOWN:
 			if (ctrl_pressed) {
@@ -582,7 +584,7 @@ bool editor::move_handle_mouse(int msg, int ctrl, MOUSE_EVENT_RECORD *rec)
 		//Mouse click on fake button?
 		const WORD btn_id = _keybar.get_button(rec->dwMousePosition.X);
 		if (btn_id > 0)
-			event_handled = sckey_handle(VK_F1 + btn_id - 1);
+			event_handled = sckey_handle(KEY_F1 + btn_id - 1);
 	}
 	else if( ctrl == ID_EDITOR ){
 		if (msg == DN_MOUSECLICK) {

--- a/hexitor/src/find_dlg.cpp
+++ b/hexitor/src/find_dlg.cpp
@@ -126,7 +126,7 @@ void find_dlg::fill_u16()
 }
 
 
-intptr_t WINAPI find_dlg::dlg_proc(HANDLE dlg, intptr_t msg, intptr_t param1, void* param2)
+intptr_t WINAPI find_dlg::dlg_proc(HANDLE dlg, intptr_t msg, int param1, void* param2)
 {
 	find_dlg* instance = nullptr;
 	if (msg != DN_INITDIALOG)
@@ -151,7 +151,7 @@ intptr_t WINAPI find_dlg::dlg_proc(HANDLE dlg, intptr_t msg, intptr_t param1, vo
 		_PSI.SendDlgMessage(dlg, DM_SETMAXTEXTLENGTH, DLGID_U8_EDIT, (LONG_PTR)MAX_SEQ_SIZE);
 		return 1;
 	}
-	else if (msg == DN_CLOSE && param1 >= 0 && param1 != DLGID_BTN_CANCEL && instance->_seq.empty()) {
+	else if (msg == DN_CLOSE && param1 >= 0 && param1 != DLGID_BTN_CANCEL && param1 != -1 && instance->_seq.empty()) {
 		const wchar_t* err_msg[] = { _PSI.GetMsg(_PSI.ModuleNumber, ps_find_title), _PSI.GetMsg(_PSI.ModuleNumber, ps_find_empty) };
 		_PSI.Message(_PSI.ModuleNumber, FMSG_MB_OK | FMSG_WARNING, nullptr, err_msg, sizeof(err_msg) / sizeof(err_msg[0]), 0);
 		return 0;

--- a/hexitor/src/find_dlg.h
+++ b/hexitor/src/find_dlg.h
@@ -43,7 +43,7 @@ private:
 	void fill_u8() noexcept;
 
 	//Far dialog's callback
-	static intptr_t WINAPI dlg_proc(HANDLE dlg, intptr_t msg, intptr_t param1, void* param2);
+	static intptr_t WINAPI dlg_proc(HANDLE dlg, intptr_t msg, int param1, void* param2);
 
 private:
 	HANDLE			_dialog;		///< Dialog window handle


### PR DESCRIPTION
fixes #2947
- Using the mouse wheel to scroll
- The F7 dialog can be closed with ESC, just like pressing the Cancel button
- Support for clicking on the keybar while holding down the Shift/Ctrl/Alt key
