### PR TITLE
arclite: define __STDC_FORMAT_MACROS prior to including inttypes.h

### DIFF
--- a/arclite/src/headers.hpp
+++ b/arclite/src/headers.hpp
@@ -41,6 +41,9 @@
 #include <future>
 #include <condition_variable>
 
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
 //#include <cinttypes>
 #include <inttypes.h>
 


### PR DESCRIPTION
Fixes this error:
```
FAILED: [code=1] arclite/CMakeFiles/arclite.dir/src/open.cpp.o
/opt/local/bin/g++-mp-14 -DNDEBUG -Darclite_EXPORTS -I/opt/local/var/macports/build/far2l-d0d3bcc5/work/far2l-5d81e87f3780081490f7fd5dd86562e07c5c4027/utils/include -I/opt/local/var/macports/build/far2l-d0d3bcc5/work/far2l-5d81e87f3780081490f7fd5dd86562e07c5c4027/arclite/../WinPort -I/opt/local/var/macports/build/far2l-d0d3bcc5/work/far2l-5d81e87f3780081490f7fd5dd86562e07c5c4027/arclite/../utils/include -I/opt/local/var/macports/build/far2l-d0d3bcc5/work/far2l-5d81e87f3780081490f7fd5dd86562e07c5c4027/arclite/../far2l/far2sdk -I/opt/local/var/macports/build/far2l-d0d3bcc5/work/far2l-5d81e87f3780081490f7fd5dd86562e07c5c4027/arclite/../far2l/src/base -pipe -I/opt/local/libexec/openssl3/include -Os -DNDEBUG -I/opt/local/libexec/openssl3/include -isystem/opt/local/include/LegacySupport -isystem/opt/local/include -D_GLIBCXX_USE_CXX11_ABI=0 -DRUNTIME_ICU -Wall -fPIC -Wno-unused-function -D_FILE_OFFSET_BITS=64 -DWINPORT_REGISTRY -std=c++17 -arch ppc -mmacosx-version-min=10.6 -fPIC -fvisibility=hidden -Winvalid-pch -include /opt/local/var/macports/build/far2l-d0d3bcc5/work/build/arclite/CMakeFiles/arclite.dir/cmake_pch.hxx -MD -MT arclite/CMakeFiles/arclite.dir/src/open.cpp.o -MF arclite/CMakeFiles/arclite.dir/src/open.cpp.o.d -o arclite/CMakeFiles/arclite.dir/src/open.cpp.o -c /opt/local/var/macports/build/far2l-d0d3bcc5/work/far2l-5d81e87f3780081490f7fd5dd86562e07c5c4027/arclite/src/open.cpp
/opt/local/var/macports/build/far2l-d0d3bcc5/work/far2l-5d81e87f3780081490f7fd5dd86562e07c5c4027/arclite/src/open.cpp: In member function 'LONG DataRelayStream<UseVirtualDestructor>::Seek(Int64, UInt32, UInt64*)':
/opt/local/var/macports/build/far2l-d0d3bcc5/work/far2l-5d81e87f3780081490f7fd5dd86562e07c5c4027/arclite/src/open.cpp:114:96: error: expected ')' before 'PRId64'
  114 |                                         fprintf(stderr, "DataRelayStream: Error: neg offset %" PRId64 "\n", offset);
      |                                                                                                ^~~~~~
/opt/local/var/macports/build/far2l-d0d3bcc5/work/far2l-5d81e87f3780081490f7fd5dd86562e07c5c4027/arclite/src/open.cpp:114:48: note: to match this '('
  114 |                                         fprintf(stderr, "DataRelayStream: Error: neg offset %" PRId64 "\n", offset);
      |                                                ^
/opt/local/var/macports/build/far2l-d0d3bcc5/work/far2l-5d81e87f3780081490f7fd5dd86562e07c5c4027/arclite/src/open.cpp:118:112: error: expected ')' before 'PRId64'
  118 |                                         fprintf(stderr, "DataRelayStream: Error: offset out of buffer range %" PRId64 "\n", offset);
      |                                                                                                                ^~~~~~
/opt/local/var/macports/build/far2l-d0d3bcc5/work/far2l-5d81e87f3780081490f7fd5dd86562e07c5c4027/arclite/src/open.cpp:118:48: note: to match this '('
  118 |                                         fprintf(stderr, "DataRelayStream: Error: offset out of buffer range %" PRId64 "\n", offset);
      |                                                ^
/opt/local/var/macports/build/far2l-d0d3bcc5/work/far2l-5d81e87f3780081490f7fd5dd86562e07c5c4027/arclite/src/open.cpp:136:112: error: expected ')' before 'PRId64'
  136 |                                         fprintf(stderr, "DataRelayStream: Error: offset out of buffer range %" PRId64 "\n", offset);
      |                                                                                                                ^~~~~~[/code]
```