### PR TITLE
Made detection of IME events more precise

### DIFF
--- a/WinPort/src/Backend/WX/wxMain.cpp
+++ b/WinPort/src/Backend/WX/wxMain.cpp
@@ -1638,7 +1638,7 @@ void WinPortPanel::OnChar( wxKeyEvent& event )
 		// See also: https://github.com/wxWidgets/wxWidgets/issues/25379
 
 		const wxKeyEvent& last_keydown = _key_tracker.LastKeydown();
-		if (event.GetKeyCode() == 0 || event.GetTimestamp() != last_keydown.GetTimestamp())
+		if (event.GetRawKeyCode() == 0 || event.GetTimestamp() != last_keydown.GetTimestamp())
 		{
 			// Likely an IME-generated event or a desynchronized event. Use the safe fallback.
 			ir.Event.KeyEvent.wVirtualKeyCode = VK_NONAME;


### PR DESCRIPTION
edac0d99b17e952f73c14d2186d0bbc5854d20dc caused a regression: virtual key codes were lost when entering non-latin characters. This PR fixes it

<img width="1280" height="854" alt="image" src="https://github.com/user-attachments/assets/c3480d88-15f2-4ac2-a694-ebe6a712e639" />
