### PR TITLE
Update far2lOverlays.nix build instruction

### DIFF
--- a/far2lOverlays.nix
+++ b/far2lOverlays.nix
@@ -43,7 +43,6 @@ in
           description = "7z format plugin from ip7z/7zip";
           homepage = "https://github.com/ip7z/7zip";
           license = licenses.lgpl21Plus;
-          platforms = platforms.linux;
         };
       };
     })


### PR DESCRIPTION
Update build version
also added 25.01 7z fresh library build
removed unnecessary build deps 