### PR TITLE
Remove vpython3 shebangs

### DIFF
--- a/python/configs/plug/far2l/fardialogbuilder.py
+++ b/python/configs/plug/far2l/fardialogbuilder.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env vpython3
 import io
 import logging
 from . import fardialogsizer as sizer

--- a/python/configs/plugins/udockerio.py
+++ b/python/configs/plugins/udockerio.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env vpython3
 import os
 import stat
 import time

--- a/python/configs/plugins/uminer.py
+++ b/python/configs/plugins/uminer.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env vpython3
 import random
 import logging
 from far2l.plugin import PluginBase


### PR DESCRIPTION
They are not needed since these files are imported, not called directly.

And this fixes warnings reported by Debian's Lintian tool:
https://udd.debian.org/lintian/?packages=far2l