### PR TITLE
Specify 3.9 as required version of Python 3

### DIFF
--- a/far2l/CMakeLists.txt
+++ b/far2l/CMakeLists.txt
@@ -304,7 +304,7 @@ else()
         COMPONENT desktop
         PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ GROUP_EXECUTE GROUP_READ WORLD_READ WORLD_EXECUTE)
 
-    find_package(Python3 COMPONENTS Interpreter)
+    find_package(Python3 3.9 COMPONENTS Interpreter)
 
     if(Python3_Interpreter_FOUND)
         execute_process(COMMAND "${Python3_EXECUTABLE}" -c "import markdown"
@@ -332,7 +332,7 @@ else()
             message(WARNING "Python-Markdown not found. Skipping AppStream metainfo generation.")
         endif()
     else()
-        message(WARNING "Python3 interpreter not found. Skipping AppStream metainfo generation.")
+        message(WARNING "Python >=3.9 interpreter not found. Skipping AppStream metainfo generation.")
     endif()
 
 endif()


### PR DESCRIPTION
`xml.etree.ElementTree.indent()` was [added][1] in that version.

This fixes an error reported in Telegram chat:

```
[ 18%] Generating DE/io.github.elfmz.far2l.metainfo.xml
Traceback (most recent call last):
  File "/home/vstarostin/aaa/src/far2l_unxed/far2l/DE/generate_metainfo.py", line 55, in <module>
    ET.indent(tree)
AttributeError: module 'xml.etree.ElementTree' has no attribute 'indent'
```

[1]: https://docs.python.org/3/library/xml.etree.elementtree.html#xml.etree.ElementTree.indent