### PR TITLE
Fix missed dot-slash prefix for Ctrl+Enter

### DIFF
--- a/far2l/src/cfg/ConfigOpt.cpp
+++ b/far2l/src/cfg/ConfigOpt.cpp
@@ -390,7 +390,6 @@ const ConfigOpt g_cfg_opts[] {
 	{true,  NSecPanel, "CaseSensitiveCompareSelect", &Opt.PanelCaseSensitiveCompareSelect, 1},
 	{true,  NSecPanel, "ReverseSort", &Opt.ReverseSort, 1},
 	{false, NSecPanel, "RightClickRule", &Opt.PanelRightClickRule, 2},
-	{false, NSecPanel, "CtrlFRule", &Opt.PanelCtrlFRule, 1},
 	{false, NSecPanel, "CtrlAltShiftRule", &Opt.PanelCtrlAltShiftRule, 0},
 	{false, NSecPanel, "RememberLogicalDrives", &Opt.RememberLogicalDrives, 0},
 	{true,  NSecPanel, "AutoUpdateLimit", &Opt.AutoUpdateLimit, 0},

--- a/far2l/src/cfg/config.hpp
+++ b/far2l/src/cfg/config.hpp
@@ -528,8 +528,6 @@ struct Options
 	int ClassicHotkeyLinkResolving;
 	int PanelRightClickRule;	// задает поведение правой клавиши мыши
 	int PanelCtrlAltShiftRule;	// задает поведение Ctrl-Alt-Shift для панелей.
-	// Panel/CtrlFRule в реестре - задает поведение Ctrl-F. Если = 0, то штампуется файл как есть, иначе - с учетом отображения на панели
-	int PanelCtrlFRule;
 	/*
 		битовые флаги, задают поведение Ctrl-Alt-Shift
 			бит установлен - функция включена:

--- a/far2l/src/mix/panelmix.cpp
+++ b/far2l/src/mix/panelmix.cpp
@@ -224,8 +224,7 @@ int _MakePath1(DWORD Key, FARString &strPathName, const wchar_t *Param2, int esc
 					if (NeedRealName && SrcPanel->GetType() == FILE_PANEL
 							&& SrcPanel->GetMode() != PLUGIN_PANEL) {
 						FileList *SrcFilePanel = (FileList *)SrcPanel;
-						SrcFilePanel->CreateFullPathName(strPathName, FILE_ATTRIBUTE_DIRECTORY, strPathName,
-								true);
+						SrcFilePanel->CreateFullPathName(strPathName, strPathName, true);
 					}
 
 					AddEndSlash(strPathName);

--- a/far2l/src/panels/filelist.hpp
+++ b/far2l/src/panels/filelist.hpp
@@ -399,8 +399,8 @@ public:
 	int PluginPanelHelp(HANDLE hPlugin);
 	virtual long GetFileCount() { return ListData.Count(); }
 
-	FARString &CreateFullPathName(const wchar_t *Name, DWORD FileAttr, FARString &strDest, bool RealName);
-	FARString &PluginGetURL(const wchar_t *Name, DWORD FileAttr, FARString &strDest);
+	FARString &CreateFullPathName(const wchar_t *Name, FARString &strDest, bool RealName);
+	FARString &PluginGetURL(const wchar_t *Name, FARString &strDest);
 
 	virtual const void *GetItem(int Index);
 	virtual BOOL UpdateKeyBar();


### PR DESCRIPTION
fix regression after #3021
    Fix missed dot-slash prefix for Ctrl+Enter
    Factor out URL fetching from plugins
