### PR TITLE
ImageViewer

### DIFF
--- a/ImageViewer/ImageViewer.cpp
+++ b/ImageViewer/ImageViewer.cpp
@@ -88,7 +88,7 @@ static bool InspectFileFormat(struct ViewerData *data)
 	}
 
 	std::string cmd = StrPrintf(
-		"ffprobe -v error -select_streams v:0 -count_packets -show_entries stream=nb_read_packets -of csv=p=0 '%s'",
+		"ffprobe -v error -select_streams v:0 -count_packets -show_entries stream=nb_read_packets -of csv=p=0 -- '%s'",
 		data->cur_file.c_str());
 
 	std::string frames_count;
@@ -142,7 +142,7 @@ static bool LoadAndShowImage(struct ViewerData *data)
 
 
 	// 1. Получаем оригинальные размеры картинки
-	std::string cmd = "identify -format \"%w %h\" \"";
+	std::string cmd = "identify -format \"%w %h\" -- \"";
 	cmd += data->render_file;
 	cmd += "\"";
 
@@ -180,7 +180,7 @@ static bool LoadAndShowImage(struct ViewerData *data)
 	if (resize_w > 8000 || resize_h > 8000) {
 		cmd += "timeout 3 "; // workaround for stuck on too huge images
 	}
-	cmd += "convert \"";
+	cmd += "convert -- \"";
 	cmd += data->render_file;
 	cmd += "\" -background black -gravity Center";
 
@@ -275,7 +275,7 @@ static LONG_PTR WINAPI ViewerDlgProc(HANDLE hDlg, int Msg, int Param1, LONG_PTR 
 		case DN_KEY:
 		{
 			int Key = (int)Param2;
-			if (Key == '=' || Key == KEY_CLEAR) {
+			if (Key == '=' || Key == '*' || Key == KEY_MULTIPLY || Key == KEY_CLEAR) {
 				data->dx = data->dy = 0;
 				data->scale = 100;
 				LoadAndShowImage(data);
@@ -329,8 +329,8 @@ static LONG_PTR WINAPI ViewerDlgProc(HANDLE hDlg, int Msg, int Param1, LONG_PTR 
 				else if (data->scale > 10) data->scale-= 10;
 				LoadAndShowImage(data);
 
-			} else if (Key == KEY_ESC || Key == KEY_F10 || Key == KEY_ENTER) {
-				data->exited_by_enter = (Key == KEY_ENTER);
+			} else if (Key == KEY_ESC || Key == KEY_F10 || Key == KEY_ENTER || Key == KEY_NUMENTER) {
+				data->exited_by_enter = (Key == KEY_ENTER || Key == KEY_NUMENTER);
 				g_far.SendDlgMessage(hDlg, DM_CLOSE, 1, 0);
 
 			} else if (Key == KEY_INS) {

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Python (optional scripting support),
 arclite <sub>(now as experimental version which partially more effective then multiarc;
 arclite disabled by default, to enable manually turn on
 F9->Options->Plugins configuration->ArcLite->[x] Enable Arclite plugin)</sub>,
-hexitor, OpenWith.
+hexitor, OpenWith, ImageViewer.
 
 FreeBSD/MacOS (Cirrus CI): [![Cirrus](https://api.cirrus-ci.com/github/elfmz/far2l.svg)](https://cirrus-ci.com/github/elfmz/far2l)
 
@@ -281,7 +281,7 @@ To control how RAR archives will be handled in multiarc:
 There're also options to toggle other plugins build in same way:
 `-DALIGN=no`, `-DARCLITE=no`, `-DAUTOWRAP=no`, `-DCALC=no`, `-DCOLORER=no`, `-DCOMPARE=no`, `-DDRAWLINE=no`, `-DEDITCASE=no`, `-DEDITORCOMP=no`,
 `-DFARFTP=yes` <sub>(by default it is disabled)</sub>,
-`-DFILECASE=no`, `-DHEXITOR=no`, `-DINCSRCH=no`, `-DINSIDE=no`, `-DMULTIARC=no`, `-DNETROCKS=no`,
+`-DFILECASE=no`, `-DHEXITOR=no`, `-DIMAGEVIEWER=no`, `-DINCSRCH=no`, `-DINSIDE=no`, `-DMULTIARC=no`, `-DNETROCKS=no`,
 `-DOPENWITH=no`, `-DSIMPLEINDENT=no`, `-DTMPPANEL=no`
 (see in [CMakeLists.txt](CMakeLists.txt)) and for NetRocks components (see in [NetRocks/CMakeLists.txt](NetRocks/CMakeLists.txt)).
 

--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,10 @@ or via `git log --no-merges --pretty=format:"%as: %B"`).
   Ctrl+Number expands all branches to the chosen depth.
 * _New:_ Options of the special command `edit:[line,col]` for openening file with position
 * _hexitor plugin_: fix broken layout with narrow window
+* _ImageViewer plugin_:  New plugin (**F11**->**I** to open image/video file.
+  Uses ImageMagic for graphics operations and ffmpeg for video preview,
+  works in GUI and in TTY|F and TTY|k,
+  see [#3028](https://github.com/elfmz/far2l/pull/3028#issuecomment-3508025346)))
 
 ## 2.7.0 beta (2025-10-26)
 * Far2l internal virtual terminal: Now the original output of applications is preserved. The Far2l VT window applies dynamic formatting with correct line wrapping. Operations such as F3/F4 and copy/paste use the original, unwrapped lines.

--- a/far2l/DE/io.github.elfmz.far2l.metainfo.xml.in
+++ b/far2l/DE/io.github.elfmz.far2l.metainfo.xml.in
@@ -38,6 +38,7 @@
       <li>editorcomp</li>
       <li>filecase</li>
       <li>hexitor</li>
+      <li>ImageViewer</li>
       <li>incsrch</li>
       <li>inside</li>
       <li>multiarc</li>


### PR DESCRIPTION
* fix processing files starting with '-'
* add forgotten NumPadEnter as Enter
* '*' also make initial scale (as '=')
* add info in changelog and readme

---

Далее напишу что бы ещё тут было полезно, может @elfmz или @unxed найдут время и прикрутят.

При обработке фильма нужно окно с предупреждением, что идёт подготовка предпросмотра,
(в идеале с возможностью прервать длительную операцию, а также прогресс-баром),
а то я стал тестить на mp4-файле (331M, около 2ч длительности)
и у меня плагин черным экраном светил чуть более минуты.

Также длительные задержки при открытии соседних файлов по PgUp/PgDn и возврате по Home - и тут хорошо бы окно с предупреждением.
Просится в `LoadAndShowImage(` в начале показывать окно хотя бы с текстом
```
"Image View: Processing file\n\"%ls\""
```
которое после окончания обработки будет скрываться.

Погоняв ImageViewer понял, что кроме `+` и `-`
очень хочется по `/` иметь возможность сбросить масштаб на истинный размер 1:1.
Ну и текущее открытие мелкого изображения как растянутого на всю область (погонял у себя каталог с подборкой мелких значков) - это визуально боль - напрашивается, что если картинка меньше области показа, то её не масштабировать.