### PR TITLE
CodeQL fixes

### DIFF
--- a/FARStdlib/src/fstd_plg.cpp
+++ b/FARStdlib/src/fstd_plg.cpp
@@ -17,7 +17,7 @@ static void _cdecl idAtExit(void)
 	FP_FSF = NULL;
 	delete[] FP_PluginRootKey;
 	FP_PluginRootKey = NULL;
-	delete[] FP_PluginStartPath;
+	free(FP_PluginStartPath);
 	FP_PluginStartPath = NULL;
 	//	FP_HModule = NULL;
 }
@@ -45,5 +45,7 @@ void WINAPI FP_SetStartupInfo(const PluginStartupInfo *Info, const char *KeyName
 
 SHAREDSYMBOL void PluginModuleOpen(const char *path)
 {
+	if (FP_PluginStartPath)
+		free(FP_PluginStartPath);
 	FP_PluginStartPath = strdup(path);
 }

--- a/hexitor/src/editor.cpp
+++ b/hexitor/src/editor.cpp
@@ -201,7 +201,7 @@ bool editor::edit(const wchar_t* file_name, const UINT64 file_offset /*= 0*/)
 		wnd_heigth,
 		nullptr,
 		dlg_items,
-		sizeof(dlg_items) / sizeof(dlg_items[0]),
+		ARRAYSIZE(dlg_items),
 		0,
 		FDLG_NODRAWSHADOW | FDLG_NODRAWPANEL | FDLG_NONMODAL,
 		(FARWINDOWPROC)&editor::dlg_proc,
@@ -373,7 +373,7 @@ void editor::save_as()
 	wchar_t new_file_name[1024];
 	if (!_PSI.InputBox(
 		I18N(ps_sav_title), I18N(ps_sav_saveas),
-		nullptr, _file.name(), new_file_name, sizeof(new_file_name), nullptr, FIB_EXPANDENV | FIB_BUTTONS | FIB_EDITPATH))
+		nullptr, _file.name(), new_file_name, ARRAYSIZE(new_file_name), nullptr, FIB_EXPANDENV | FIB_BUTTONS | FIB_EDITPATH))
 		return;
 
 	if (file::file_exist(new_file_name)) {

--- a/hexitor/src/find_dlg.cpp
+++ b/hexitor/src/find_dlg.cpp
@@ -90,7 +90,7 @@ void find_dlg::fill_hex()
 {
 	wchar_t txt[MAX_SEQ_SIZE*3 + 1]={};
 	const size_t len = std::min(_seq.size(), MAX_SEQ_SIZE);
-	for (size_t i = 0; i < len; ++i) swprintf_ws2ls(&txt[i*3], sizeof(txt), L"%02X ", (unsigned)_seq[i]);
+	for (size_t i = 0; i < len; ++i) swprintf_ws2ls(&txt[i*3], ARRAYSIZE(txt), L"%02X ", (unsigned)_seq[i]);
 	FarDialogItemData item_data{ len*3, txt };
 	_PSI.SendDlgMessage(_dialog, DM_SETTEXT, DLGID_HEX_EDIT, (LONG_PTR)&item_data);
 }
@@ -159,7 +159,7 @@ intptr_t WINAPI find_dlg::dlg_proc(HANDLE dlg, intptr_t msg, int param1, void* p
 	}
 	else if (msg == DN_CLOSE && param1 >= 0 && param1 != DLGID_BTN_CANCEL && param1 != -1 && instance->_seq.empty()) {
 		const wchar_t* err_msg[] = { I18N(ps_find_title), I18N(ps_find_empty) };
-		_PSI.Message(_PSI.ModuleNumber, FMSG_MB_OK | FMSG_WARNING, nullptr, err_msg, sizeof(err_msg) / sizeof(err_msg[0]), 0);
+		_PSI.Message(_PSI.ModuleNumber, FMSG_MB_OK | FMSG_WARNING, nullptr, err_msg, ARRAYSIZE(err_msg), 0);
 		return 0;
 	}
 	else if (msg == DN_EDITCHANGE) {

--- a/hexitor/src/goto_dlg.cpp
+++ b/hexitor/src/goto_dlg.cpp
@@ -26,9 +26,9 @@ LONG_PTR WINAPI goto_dlg::dlg_proc(HANDLE dlg, int msg, int param1, LONG_PTR par
 		//Check parameters
 		if ( get_val() >= _file_size) {
 			wchar_t scv[80];
-			swprintf(scv, sizeof(scv), I18N(ps_goto_spec), _file_size-1);
+			swprintf(scv, ARRAYSIZE(scv), I18N(ps_goto_spec), _file_size-1);
 			const wchar_t* err_msg[] = { I18N(ps_goto_title), I18N(ps_goto_out_ofr), scv };
-			_PSI.Message(_PSI.ModuleNumber, FMSG_MB_OK | FMSG_WARNING, nullptr, err_msg, sizeof(err_msg) / sizeof(err_msg[0]), 0);
+			_PSI.Message(_PSI.ModuleNumber, FMSG_MB_OK | FMSG_WARNING, nullptr, err_msg, ARRAYSIZE(err_msg), 0);
 			return 0;
 		}
 	}
@@ -71,9 +71,9 @@ bool goto_dlg::show(const UINT64 file_size, UINT64& offset)
 			UINT64 off = get_val();
 			if ( off >= _file_size) {
 				wchar_t scv[80];
-				swprintf(scv, sizeof(scv), I18N(ps_goto_spec), _file_size-1);
+				swprintf(scv, ARRAYSIZE(scv), I18N(ps_goto_spec), _file_size-1);
 				const wchar_t* err_msg[] = { I18N(ps_goto_title), I18N(ps_goto_out_ofr), scv };
-				_PSI.Message(_PSI.ModuleNumber, FMSG_MB_OK | FMSG_WARNING, nullptr, err_msg, sizeof(err_msg) / sizeof(err_msg[0]), 0);
+				_PSI.Message(_PSI.ModuleNumber, FMSG_MB_OK | FMSG_WARNING, nullptr, err_msg, ARRAYSIZE(err_msg), 0);
 				continue;
 			}
 			offset = off;

--- a/hexitor/src/hex_ctl.cpp
+++ b/hexitor/src/hex_ctl.cpp
@@ -63,7 +63,7 @@ void hex_ctl::update(const UINT64 offset, const vector<BYTE>& ori_data, const ma
 
 		//Offset address
 		wchar_t offset_txt[16];
-		const int offset_len = swprintf(offset_txt, sizeof(offset_txt) / sizeof(offset_txt[0]), L"%012llX:", offset + static_cast<UINT64>(row) * 0x10);
+		const int offset_len = swprintf(offset_txt, ARRAYSIZE(offset_txt), L"%012llX:", offset + static_cast<UINT64>(row) * 0x10);
 		write(row, 0, offset_txt, offset_len);
 
 		//Hex values area (common for all codepages)
@@ -73,7 +73,7 @@ void hex_ctl::update(const UINT64 offset, const vector<BYTE>& ori_data, const ma
 
 			//Hex value
 			wchar_t hex_val[3];
-			const int hex_val_len = swprintf(hex_val, sizeof(hex_val) / sizeof(offset_txt[0]), L"%02X", val);
+			const int hex_val_len = swprintf(hex_val, ARRAYSIZE(hex_val), L"%02X", val);
 			write(row, 15 + col * 3, hex_val, hex_val_len);
 
 			 //Set color for updated data

--- a/hexitor/src/plugin.cpp
+++ b/hexitor/src/plugin.cpp
@@ -57,10 +57,10 @@ SHAREDSYMBOL void WINAPI _export GetPluginInfoW(PluginInfo* info)
 	menu_strings[0] = I18N(ps_title);
 
 	info->PluginConfigStrings = menu_strings;
-	info->PluginConfigStringsNumber = sizeof(menu_strings) / sizeof(menu_strings[0]);
+	info->PluginConfigStringsNumber = ARRAYSIZE(menu_strings);
 
 	info->PluginMenuStrings = menu_strings;
-	info->PluginMenuStringsNumber = sizeof(menu_strings) / sizeof(menu_strings[0]);
+	info->PluginMenuStringsNumber = ARRAYSIZE(menu_strings);
 
 #ifdef _DEBUG
 	info->Flags |= PF_PRELOAD;

--- a/hexitor/src/progress.cpp
+++ b/hexitor/src/progress.cpp
@@ -48,7 +48,7 @@ void progress::show()
 	}
 
 	const wchar_t* msg[] = { _title, _bar.c_str() };
-	_PSI.Message(_PSI.ModuleNumber, FMSG_NONE, nullptr, msg, sizeof(msg) / sizeof(msg[0]), 0);
+	_PSI.Message(_PSI.ModuleNumber, FMSG_NONE, nullptr, msg, ARRAYSIZE(msg), 0);
 }
 
 

--- a/hexitor/src/statusbar_ctl.cpp
+++ b/hexitor/src/statusbar_ctl.cpp
@@ -90,7 +90,7 @@ void statusbar_ctl::write_codepage(const UINT cp)
 void statusbar_ctl::write_offset(const UINT64 pos)
 {
 	wchar_t num[16];
-	const int num_len = swprintf(num, sizeof(num) / sizeof(num[0]), L"0x%012llX", pos);
+	const int num_len = swprintf(num, ARRAYSIZE(num), L"0x%012llX", pos);
 	write(0, 61, num, num_len);
 }
 
@@ -100,7 +100,7 @@ void statusbar_ctl::write_position(const unsigned char percent)
 	assert(percent <= 100);
 
 	wchar_t num[8];
-	const int num_len = swprintf(num, sizeof(num) / sizeof(num[0]), L"%d%%", percent);
+	const int num_len = swprintf(num, ARRAYSIZE(num), L"%d%%", percent);
 	for (size_t i = 76; i < 80; ++i)
 		write(0, i, L' ');
 	write(0, 80 - num_len, num, num_len);


### PR DESCRIPTION
* FARStdlib/src/fstd_plg.cpp: Mismatching new/free or malloc/delete - the pair to `strdup()` is `free()` (was `delete[]`)
* hexitor/src/*: "Badly bounded write" - replace `sizeof(` to `ARRAYSIZE(`