### PR TITLE
Tree panel: fixes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,7 +8,7 @@ or via `git log --no-merges --pretty=format:"%as: %B"`).
 * Editor: Word wrap (like in Windows Notepad or HTML textareas). Toggled by **F3** or **Alt+W**
 * Tree panel: Option to exclude subtrees from scanning using a mask (default: hidden folders `.*`).
   Option to set the maximum recursive scanning depth (default: 4). 
-  Right Arrow expands excluded subtrees, and Left Arrow collapses subtree in focus, if it's alreayd collapsed - navigates one level up.
+  Right Arrow expands excluded subtrees, and Left Arrow collapses subtree in focus, if it's already collapsed - navigates one level up.
   Ctrl+Number expands all branches to the chosen depth.
 * _New:_ Options of the special command `edit:[line,col]` for openening file with position
 * _hexitor plugin_: fix broken layout with narrow window

--- a/far2l/src/scantree.cpp
+++ b/far2l/src/scantree.cpp
@@ -76,7 +76,8 @@ void ScanTree::CheckForEnterSubdir(FAR_FIND_DATA_EX *fdata)
 		return;
 
 	if ((fdata->dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0
-		&& (fmpExclSubTree.Compare(fdata->strFileName, false) || (MaxDepth > 0 && ScanDirStack.size() > MaxDepth) ) )
+		&& (fmpExclSubTree.Compare(fdata->strFileName, false)
+				|| (MaxDepth > 0 && ScanDirStack.size() > static_cast<size_t>(MaxDepth))) )
 	{
         fdata->dwFileAttributes |= FILE_ATTRIBUTE_PINNED; //mark as potentially expandable since skipped by settings
 		return;


### PR DESCRIPTION
- collapse marker is always visible
- navigating into subfolders expands existing tree instead of rebuilding
- selection is preserved across expansions
- cache revived, collapsed state cached
- faulty sort optimization removed
- compiler warning silenced in scantree