### PR TITLE
NetRocks: always show username in panel title

### DIFF
--- a/NetRocks/src/PluginImpl.cpp
+++ b/NetRocks/src/PluginImpl.cpp
@@ -123,7 +123,7 @@ void PluginImpl::UpdatePathInfo()
 	std::wstring tmp;
 	if (_remote) {
 		wcsncpy(_format, StrMB2Wide(_location.server).c_str(), ARRAYSIZE(_format) - 1);
-		wcsncpy(_cur_dir, StrMB2Wide(_location.ToString(true)).c_str(), ARRAYSIZE(_cur_dir) - 1 );
+		//wcsncpy(_cur_dir, StrMB2Wide(_location.ToString(true)).c_str(), ARRAYSIZE(_cur_dir) - 1 );
 		// make up URL string start
 		IHost::Identity identity;
 		_remote->GetIdentity(identity);
@@ -139,7 +139,7 @@ void PluginImpl::UpdatePathInfo()
 		tmp += L"/" + StrMB2Wide(_location.ToString(false));
 		wcsncpy(_cur_URL, tmp.c_str(), ARRAYSIZE(_cur_URL) - 1 );
 		// make up URL string end
-		tmp = _cur_dir;
+		//tmp = _cur_dir;
 
 	} else {
 		tmp = StrMB2Wide(_sites_cfg_location.TranslateToPath(false));


### PR DESCRIPTION
NetRocks: always show username in panel title

Before: NetRocks now shows the username in panel title only if username is saved in the Site connections properties.
After: always show username in panel title.

---

До этого в заголовке использовался `_cur_dir` формируемый через `_location.ToString(true)`,
который похоже внутри себя чувствует `username` только если он сохранен в св-вах соединения (см. https://github.com/elfmz/far2l/blob/d77354eed8e48def181811da8a61f72044e678e9/NetRocks/src/Location.cpp#L63-L66 ).
В этом PR я использовал недавно привнесённый @russiandesman функционал, формирующий `_cur_URL`.

Вопрос к @elfmz и @russiandesman насколько текущие правки корректны в общей логике?
Может правильнее доработать `struct Location`?

---

UPD: Мой юзкейс: есть очень похожие соединения куда захожу под с разными пользователями и важно однозначно видеть под кем я зашел, т.е. в заголовке панели нужны **актуальные**: `protocol:username@host:port` + каталог внутри.