### PR TITLE
Fixed mouse selection performance with line numbers on

### DIFF
--- a/far2l/src/editor.hpp
+++ b/far2l/src/editor.hpp
@@ -248,6 +248,11 @@ private:
 	bool m_bWordWrap;
 	int m_WrapMaxVisibleLineLength;
 	bool m_MouseButtonIsHeld;
+	
+	// Line number caching for performance
+	int m_CachedTotalLines;
+	int m_CachedLineNumWidth;
+	bool m_LineCountDirty;
 
 private:
 	int FindVisualLine(Edit* line, int Pos);


### PR DESCRIPTION
There is performance problem with big files (on slow machines especially) when line numbers in enabled. The root cause is:
The CalculateLineNumberWidth() function was calling CalculateTotalLines() on every mouse move event, which iterated through ALL lines in the file. Variable caching improves performance to the same extent with or without line numbers.

I compiled and ran on far2l on PC with [Xeon W3503 from 2009](https://www.cpubenchmark.net/cpu.php?cpu=Intel+Xeon+W3503+%40+2.40GHz&id=1264) on Ubuntu 24.04.3. It's an ancient CPU with 2 threads and usually it takes like 20-35 sec just to open firefox on this machine. I don't see any difference between selecting with mouse with or without line numbers now.