### PR TITLE
fix build on DrgagonFlyBSD after commit 7b93ee9

### DIFF
--- a/arclite/src/open.cpp
+++ b/arclite/src/open.cpp
@@ -20,9 +20,11 @@
 #include <linux/fs.h>
 #elif defined(__APPLE__)
 #include <sys/disk.h>
-#elif defined(__FreeBSD__) || defined(__DragonFly__)
+#elif defined(__FreeBSD__)
 #include <sys/disk.h>
 #include <sys/disklabel.h>
+#elif defined(__DragonFly__)
+#include <sys/diskslice.h>
 #elif defined(__HAIKU__)
 #include <Drivers.h>
 #endif


### PR DESCRIPTION
disk.h should not be included by userland programs

See https://github.com/DragonFlyBSD/DragonFlyBSD/blob/47484253dd3c134d6437dff7672360f955050bea/sys/sys/disk.h#L48

DIOCGMEDIASIZE and DIOCGSECTORSIZE were defined in diskslice.h

See commit https://github.com/DragonFlyBSD/DragonFlyBSD/commit/853408102638f879124210299f70d3db026715a3