### PR TITLE
Fix AltGr input acting as functional hotkeys

### DIFF
--- a/WinPort/src/Backend/WX/wxWinTranslations.cpp
+++ b/WinPort/src/Backend/WX/wxWinTranslations.cpp
@@ -225,8 +225,13 @@ int wxKeyCode2WinKeyCode(int code)
 	case L'(': return '9';
 	case L')': return '0';
 	}
-	//fprintf(stderr, "not translated %u %lc", code, code);
-	return code;
+
+	//fprintf(stderr, "not translated %u %lc\n", code, code);
+
+	if ((code >= '0' && code <= '9') || (code >= 'A' && code <= 'Z')) {
+		return code;
+	}
+	return VK_NONAME;
 }
 
 


### PR DESCRIPTION
by ensuring wxKeyCode2WinKeyCode returns VK_NONAME for unrecognized non-alphanumeric keys

Touch #3089