### PR TITLE
NetRocks: fix SCP path quoting and shell injection

### DIFF
--- a/NetRocks/src/Protocol/SSH/ProtocolSCP.cpp
+++ b/NetRocks/src/Protocol/SSH/ProtocolSCP.cpp
@@ -38,12 +38,12 @@
 
 static std::string QuotedArg(const std::string &s)
 {
-	if (s.find_first_of("\"\r\n\t' ") == std::string::npos) {
+	if (s.find_first_of(" \"\r\n\t\';&|()<>`$\\!{}[]*?#~^=") == std::string::npos) {
 		return s;
 	}
 
 	std::string out = "\"";
-	out+= EscapeQuotes(s);
+	out+= EscapeCmdStr(s);
 	out+= '\"';
 	return out;
 }


### PR DESCRIPTION
fix #2087
Функция QuotedArg() не учитывала метасимволы оболочки, а используемый метод экранирования позволял интерпретировать части путей как переменные или команды.