### PR TITLE
Runtime platform In help banner

### DIFF
--- a/far2l/bootstrap/scripts/FarEng.hlf.m4
+++ b/far2l/bootstrap/scripts/FarEng.hlf.m4
@@ -5,7 +5,7 @@ m4_include(`farversion.m4')m4_dnl
 
 @Contents
 $^#File and archive manager#
-`$^#'FULLVERSIONNOBRACES`#'
+`$^#%FAR_BUILD% %FAR_PLATFORM%#'
 `$^#©1996-2000 Eugene Roshal, ©2000-2016 FAR Group,' ©COPYRIGHTYEARS `FAR People'#
    ~FAR2L features - Getting Started~@Far2lGettingStarted@
 

--- a/far2l/bootstrap/scripts/FarHun.hlf.m4
+++ b/far2l/bootstrap/scripts/FarHun.hlf.m4
@@ -5,7 +5,7 @@ m4_include(`farversion.m4')m4_dnl
 
 @Contents
 $^#Fájl- és archívumkezelő program#
-`$^#'FULLVERSIONNOBRACES`#'
+`$^#%FAR_BUILD% %FAR_PLATFORM%#'
 $^#Copyright (C) 1996-2000 Eugene Roshal#
 $^#Copyright (C) 2000-2016 FAR Group
 `$^#Copyright (C)' COPYRIGHTYEARS `FAR People'

--- a/far2l/bootstrap/scripts/FarRus.hlf.m4
+++ b/far2l/bootstrap/scripts/FarRus.hlf.m4
@@ -5,7 +5,7 @@ m4_include(`farversion.m4')m4_dnl
 
 @Contents
 $^#Программа управления файлами и архивами#
-`$^#'FULLVERSIONNOBRACES`#'
+`$^#%FAR_BUILD% %FAR_PLATFORM%#'
 `$^#©1996-2000 Eugene Roshal, ©2000-2016 FAR Group,' ©COPYRIGHTYEARS `FAR People'#
    ~Особенности FAR2L - начало работы~@Far2lGettingStarted@
 

--- a/far2l/bootstrap/scripts/FarUkr.hlf.m4
+++ b/far2l/bootstrap/scripts/FarUkr.hlf.m4
@@ -5,7 +5,7 @@ m4_include(`farversion.m4')m4_dnl
 
 @Contents
 $^#Програма управління файлами та архівами#
-`$^#'FULLVERSIONNOBRACES`#'
+`$^#%FAR_BUILD% %FAR_PLATFORM%#'
 `$^#©1996-2000 Eugene Roshal, ©2000-2016 FAR Group,' ©COPYRIGHTYEARS `FAR People'#
  ~Індекс файлу допомоги~@Index@
  ~Як користуватися допомогою~@Help@

--- a/far2l/src/farversion.h
+++ b/far2l/src/farversion.h
@@ -9,6 +9,8 @@ extern const char *Copyright;
 #define FAR_PLATFORM "x64"
 #elif defined(__ppc64__)
 #define FAR_PLATFORM "ppc64"
+#elif defined(__ppc__)
+#define FAR_PLATFORM "ppc"
 #elif defined(__arm64__) || defined(__aarch64__)
 #define FAR_PLATFORM "arm64"
 #elif defined(__arm__)

--- a/far2l/src/help.cpp
+++ b/far2l/src/help.cpp
@@ -54,6 +54,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "exitcode.hpp"
 #include "filestr.hpp"
 #include "stddlg.hpp"
+#include "farversion.h"
 
 // Стек возврата
 class CallBackStack
@@ -107,6 +108,18 @@ static const wchar_t *FoundContents = L"__FoundContents__";
 static const wchar_t *PluginContents = L"__PluginContents__";
 static const wchar_t *HelpOnHelpTopic = L":Help";
 static const wchar_t *HelpContents = L"Contents";
+
+void SubstituteRuntimePlaceholders(FARString& line)
+{
+	if (!line.Contains(L'%'))
+		return;
+
+	static const FARString build(MB2Wide(FAR_BUILD).c_str());
+	static const FARString platform(MB2Wide(FAR_PLATFORM).c_str());
+
+	ReplaceStrings(line, L"%FAR_BUILD%", build.CPtr(), -1);
+	ReplaceStrings(line, L"%FAR_PLATFORM%", platform.CPtr(), -1);
+}
 
 void Help::Present(const wchar_t *Topic, const wchar_t *Mask, DWORD Flags)
 {
@@ -571,6 +584,7 @@ void Help::AddLine(const wchar_t *Line)
 	}
 
 	strLine+= Line;
+	SubstituteRuntimePlaceholders(strLine);
 
 	{
 		HelpRecord AddRecord(strLine);


### PR DESCRIPTION
F1 help header incorrectly shows compile time platform x86-64 when running release universal binary on macOS arm64.