### PR TITLE
incsrch: install activation macros

### DIFF
--- a/incsrch/CMakeLists.txt
+++ b/incsrch/CMakeLists.txt
@@ -35,4 +35,5 @@ add_custom_command(TARGET incsrch POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/UTF8/isrcbel.lng "${INSTALL_DIR}/Plugins/incsrch/plug"
     COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/ENG/incsrche.hlf "${INSTALL_DIR}/Plugins/incsrch/plug"
     COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/UTF8/incsrchr.hlf "${INSTALL_DIR}/Plugins/incsrch/plug"
+    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/key_macros.ini "${INSTALL_DIR}/Plugins/incsrch/plug"
 )


### PR DESCRIPTION
It does not merge macros into global far config, but at least installs it for user reference.