### PR TITLE
Add multiline command line support

### DIFF
--- a/far2l/src/cmdline.cpp
+++ b/far2l/src/cmdline.cpp
@@ -247,7 +247,9 @@ CommandLine::CommandLine()
 					| EditControl::EC_ENABLEFNCOMPLETE_ESCAPED),
 //	BackgroundScreen(nullptr),
 	LastCmdPartLength(-1),
-	PushDirStackSize(0)
+	PushDirStackSize(0),
+	m_multilineExtraLines(0),
+	m_multilineActiveLine(-1)
 {
 	CmdStr.SetEditBeyondEnd(FALSE);
 	SetPersistentBlocks(Opt.CmdLine.EditBlock);
@@ -293,51 +295,473 @@ void CommandLine::DisplayObject()
 	if (!IsVisible())
 		return;
 
-	FARString strTruncDir;
-	GetPrompt(strTruncDir);
-	TruncPathStr(strTruncDir, (X2 - X1) / 2);
-	GotoXY(X1, Y1);
-	SetFarColor(COL_COMMANDLINEPREFIX);
-	Text(strTruncDir);
-	CmdStr.SetObjectColor(FarColorToReal(COL_COMMANDLINE), FarColorToReal(COL_COMMANDLINESELECTED));
-	CmdStr.SetPosition(X1 + (int)strTruncDir.CellsCount(), Y1, X2, Y2);
+	const bool has_multiline = !m_multilineLines.empty();
+	const int input_y = Y2;
+	if (has_multiline) {
+		int view_lines = 0;
+		const int view_top = GetMultilineViewTop(view_lines);
+		const int view_y = input_y - view_lines + 1;
+		for (int i = 0; i < view_lines; ++i) {
+			const int line_index = view_top + i;
+			const int y = view_y + i;
+			FARString prompt;
+			GetMultilinePrompt(line_index, prompt);
+			const int prompt_len = (int)prompt.CellsCount();
+			GotoXY(X1, y);
+			SetFarColor(COL_COMMANDLINEPREFIX);
+			Text(prompt);
+			FARString line;
+			if (line_index != m_multilineActiveLine)
+				line = m_multilineLines[line_index];
+			const int content_width = std::max(0, X2 - (X1 + prompt_len) + 1);
+			if (line.CellsCount() > content_width)
+				line.TruncateByCells(content_width);
+			if (line.CellsCount() < content_width)
+				line.Append(L' ', content_width - line.CellsCount());
+			GotoXY(X1 + prompt_len, y);
+			SetFarColor(COL_COMMANDLINE);
+			Text(line);
+			if (y != input_y) {
+				GotoXY(X2 + 1, y);
+				Text(L" ");
+			}
+		}
+		FARString active_prompt;
+		GetMultilinePrompt(m_multilineActiveLine, active_prompt);
+		const int active_y = view_y + m_multilineActiveLine - view_top;
+		CmdStr.SetObjectColor(FarColorToReal(COL_COMMANDLINE), FarColorToReal(COL_COMMANDLINESELECTED));
+		CmdStr.SetPosition(X1 + (int)active_prompt.CellsCount(), active_y, X2, active_y);
+	} else {
+		FARString prompt;
+		GetPrompt(prompt);
+		TruncPathStr(prompt, (X2 - X1) / 2);
+		GotoXY(X1, input_y);
+		SetFarColor(COL_COMMANDLINEPREFIX);
+		Text(prompt);
+		CmdStr.SetObjectColor(FarColorToReal(COL_COMMANDLINE), FarColorToReal(COL_COMMANDLINESELECTED));
+		CmdStr.SetPosition(X1 + (int)prompt.CellsCount(), input_y, X2, input_y);
+	}
 
 	CmdStr.Show();
 
-	DrawComboBoxMark(0x2191);
+	DrawComboBoxMark(0x2191, input_y);
 }
 
-void CommandLine::DrawComboBoxMark(wchar_t MarkChar)
+void CommandLine::DrawComboBoxMark(wchar_t MarkChar, int y)
 {
 	wchar_t MarkWz[2] = {MarkChar, 0};
-	GotoXY(X2 + 1, Y1);
+	GotoXY(X2 + 1, y);
 	SetFarColor(COL_COMMANDLINEPREFIX);
 	Text(MarkWz);
 }
 
 void CommandLine::SetCurPos(int Pos, int LeftPos)
 {
+	if (!m_multilineLines.empty()) {
+		SyncActiveMultilineLine();
+		int remaining = std::max(0, Pos);
+		for (int i = 0; i < (int)m_multilineLines.size(); ++i) {
+			const int length = (int)m_multilineLines[i].GetLength();
+			if (remaining <= length || i + 1 == (int)m_multilineLines.size()) {
+				if (i == m_multilineActiveLine)
+					CmdStr.SetCurPos(std::min(remaining, length));
+				else
+					SetActiveMultilineLine(i, std::min(remaining, length));
+				CmdStr.SetLeftPos(LeftPos);
+				Show();
+				return;
+			}
+			remaining-= length + 1;
+		}
+	}
 	CmdStr.SetLeftPos(LeftPos);
 	CmdStr.SetCurPos(Pos);
 	CmdStr.Redraw();
 }
 
+int CommandLine::GetCurPos()
+{
+	if (m_multilineLines.empty())
+		return CmdStr.GetCurPos();
+	return GetMultilineLineOffset(m_multilineActiveLine) + CmdStr.GetCurPos();
+}
+
+bool CommandLine::IsNotEmpty() const
+{
+	if (CmdStr.CalcRTrimmedStrSize() > 0)
+		return true;
+
+	for (int i = 0; i < (int)m_multilineLines.size(); ++i) {
+		if (i == m_multilineActiveLine)
+			continue;
+		FARString line = m_multilineLines[i];
+		RemoveTrailingSpaces(line);
+		if (!line.IsEmpty())
+			return true;
+	}
+
+	return false;
+}
+
+bool CommandLine::IsContinuationLine(const FARString &line) const
+{
+	size_t backslashes = 0;
+	for (size_t i = line.GetLength(); i > 0 && line[i - 1] == L'\\'; --i)
+		++backslashes;
+	return (backslashes & 1) != 0;
+}
+
+bool CommandLine::AddHereDocDelimiters(const FARString &line)
+{
+	bool added = false;
+	bool in_single_quotes = false;
+	bool in_double_quotes = false;
+	bool escaped = false;
+	int arithmetic_depth = 0;
+	int conditional_depth = 0;
+	const size_t length = line.GetLength();
+
+	for (size_t i = 0; i < length; ++i) {
+		const wchar_t ch = line[i];
+		if (escaped) {
+			escaped = false;
+			continue;
+		}
+		if (!in_single_quotes && !in_double_quotes) {
+			if (arithmetic_depth) {
+				if (ch == L'(' && i + 1 < length && line[i + 1] == L'(') {
+					++arithmetic_depth;
+					++i;
+				} else if (ch == L')' && i + 1 < length && line[i + 1] == L')') {
+					--arithmetic_depth;
+					++i;
+				}
+				continue;
+			}
+			if (conditional_depth) {
+				if (ch == L']' && i + 1 < length && line[i + 1] == L']') {
+					--conditional_depth;
+					++i;
+				}
+				continue;
+			}
+			if (ch == L'(' && i + 1 < length && line[i + 1] == L'(') {
+				++arithmetic_depth;
+				++i;
+				continue;
+			}
+			if (ch == L'[' && i + 1 < length && line[i + 1] == L'[') {
+				++conditional_depth;
+				++i;
+				continue;
+			}
+			if (ch == L'#' && (i == 0 || IsSpace(line[i - 1])))
+				break;
+		}
+		if (ch == L'\\' && !in_single_quotes) {
+			escaped = true;
+			continue;
+		}
+		if (ch == L'\'' && !in_double_quotes) {
+			in_single_quotes = !in_single_quotes;
+			continue;
+		}
+		if (ch == L'"' && !in_single_quotes) {
+			in_double_quotes = !in_double_quotes;
+			continue;
+		}
+		if (in_single_quotes || in_double_quotes || ch != L'<' || i + 1 >= length || line[i + 1] != L'<')
+			continue;
+
+		size_t pos = i + 2;
+		if (pos < length && line[pos] == L'<') { // here-string (<<<), not a heredoc
+			i = pos;
+			continue;
+		}
+
+		HereDocDelimiter delimiter;
+		delimiter.strip_tabs = pos < length && line[pos] == L'-';
+		if (delimiter.strip_tabs)
+			++pos;
+		while (pos < length && IsSpace(line[pos]))
+			++pos;
+		if (pos >= length)
+			break;
+
+		if (line[pos] == L'\'' || line[pos] == L'"') {
+			const wchar_t quote = line[pos++];
+			while (pos < length && line[pos] != quote)
+				delimiter.text.Append(line[pos++]);
+			if (pos == length || delimiter.text.IsEmpty())
+				break;
+			++pos;
+		} else {
+			while (pos < length) {
+				const wchar_t word_ch = line[pos];
+				if (IsSpace(word_ch) || wcschr(L";|&<>()", word_ch))
+					break;
+				if (word_ch == L'\\' && pos + 1 < length)
+					++pos;
+				delimiter.text.Append(line[pos++]);
+			}
+			if (delimiter.text.IsEmpty())
+				continue;
+		}
+
+		m_hereDocDelimiters.emplace_back(delimiter);
+		added = true;
+		i = pos ? pos - 1 : pos;
+	}
+
+	return added;
+}
+
+bool CommandLine::IsHereDocTerminator(const FARString &line) const
+{
+	if (m_hereDocDelimiters.empty())
+		return false;
+
+	size_t start = 0;
+	if (m_hereDocDelimiters.front().strip_tabs)
+		while (start < line.GetLength() && line[start] == L'\t')
+			++start;
+	const FARString &delimiter = m_hereDocDelimiters.front().text;
+	return line.Equal(start, line.GetLength() - start, delimiter.CPtr(), delimiter.GetLength());
+}
+
+FARString CommandLine::BuildMultilineCommand(const FARString &line) const
+{
+	FARString result;
+	const int count = (int)m_multilineLines.size();
+	const int active = (m_multilineActiveLine >= 0 && m_multilineActiveLine < count)
+		? m_multilineActiveLine
+		: (count > 0 ? count - 1 : -1);
+	for (int i = 0; i < count; ++i) {
+		if (i == active)
+			result+= line;
+		else
+			result+= m_multilineLines[i];
+		if (i + 1 < count)
+			result+= L'\n';
+	}
+	if (count == 0)
+		result = line;
+	return result;
+}
+
+void CommandLine::ApplyMultilineText(const FARString &text, BOOL Redraw)
+{
+	FARString normalized(text);
+	NormalizeMultilineForExec(normalized);
+	m_multilineLines.clear();
+	m_hereDocDelimiters.clear();
+	m_multilineActiveLine = -1;
+	FARString current;
+	for (size_t i = 0; i < normalized.GetLength(); ++i) {
+		wchar_t ch = normalized[i];
+		if (ch == L'\n') {
+			m_multilineLines.emplace_back(current);
+			current.Clear();
+		} else {
+			current.Append(ch);
+		}
+	}
+	m_multilineLines.emplace_back(current);
+	if (m_multilineLines.size() <= 1) {
+		CmdStr.SetString(m_multilineLines[0].CPtr());
+		ClearMultilineState();
+		if (Redraw)
+			Show();
+		return;
+	}
+	m_multilineActiveLine = (int)m_multilineLines.size() - 1;
+	CmdStr.SetString(m_multilineLines[m_multilineActiveLine].CPtr());
+	UpdateMultilineLayout();
+	if (Redraw)
+		Show();
+}
+
+void CommandLine::ClearMultilineState()
+{
+	m_multilineLines.clear();
+	m_hereDocDelimiters.clear();
+	m_multilineActiveLine = -1;
+	SetMultilineExtraLines(0);
+}
+
+void CommandLine::SetMultilineExtraLines(int extra_lines)
+{
+	const int new_extra_lines = std::max(0, std::min(extra_lines, GetMaxVisibleMultilineLines() - 1));
+	if (new_extra_lines == m_multilineExtraLines)
+		return;
+	m_multilineExtraLines = new_extra_lines;
+	if (CtrlObject && CtrlObject->Cp()) {
+		auto *cp = CtrlObject->Cp();
+		cp->SetPanelPositions(cp->LeftPanel->IsFullScreen(), cp->RightPanel->IsFullScreen(), Opt.PanelsDisposition);
+	}
+}
+
+int CommandLine::GetMaxVisibleMultilineLines() const
+{
+	constexpr int min_panel_height = 6;
+	const int keybar = Opt.ShowKeyBar ? 1 : 0;
+	int available_extra = 0;
+
+	if (!Opt.PanelsDisposition) {
+		const int panel_top = Opt.ShowMenuBar ? 1 : 0;
+		const int left_bottom = ScrY - 1 - keybar - Opt.LeftHeightDecrement;
+		const int right_bottom = ScrY - 1 - keybar - Opt.RightHeightDecrement;
+		available_extra = std::min(left_bottom, right_bottom) - panel_top + 1 - min_panel_height;
+	} else {
+		const int left_bottom = (ScrY - (Opt.ShowMenuBar ? 1 : 0)) / 2 - keybar
+				- Opt.LeftHeightDecrement / 2;
+		const int right_top = left_bottom + 1 - Opt.WidthDecrement;
+		const int right_bottom = ScrY - keybar - 1 - Opt.RightHeightDecrement;
+		available_extra = right_bottom - right_top + 1 - min_panel_height;
+	}
+
+	return std::max(1, std::max(0, available_extra) + 1);
+}
+
+int CommandLine::GetExtraLines() const
+{
+	return std::min(m_multilineExtraLines, GetMaxVisibleMultilineLines() - 1);
+}
+
+int CommandLine::GetMultilineLineOffset(int line) const
+{
+	int offset = 0;
+	for (int i = 0; i < line && i < (int)m_multilineLines.size(); ++i)
+		offset+= (int)m_multilineLines[i].GetLength() + 1;
+	return offset;
+}
+
+int CommandLine::GetMultilineViewTop(int &visible_lines) const
+{
+	const int total_lines = (int)m_multilineLines.size();
+	visible_lines = std::min(total_lines, std::max(1, Y2 - Y1 + 1));
+	const int max_top = std::max(0, total_lines - visible_lines);
+	return std::min(std::max(0, m_multilineActiveLine - visible_lines + 1), max_top);
+}
+
+void CommandLine::GetMultilinePrompt(int line, FARString &prompt)
+{
+	if (line == 0) {
+		GetPrompt(prompt);
+		TruncPathStr(prompt, (X2 - X1) / 2);
+	} else {
+		prompt = line == m_multilineActiveLine ? L"> " : L": ";
+	}
+}
+
+void CommandLine::SyncActiveMultilineLine()
+{
+	if (m_multilineActiveLine >= 0 && m_multilineActiveLine < (int)m_multilineLines.size()) {
+		FARString current;
+		CmdStr.GetString(current);
+		m_multilineLines[m_multilineActiveLine] = current;
+	}
+}
+
+void CommandLine::UpdateMultilineLayout()
+{
+	const int count = (int)m_multilineLines.size();
+	if (count <= 1) {
+		if (count == 1)
+			CmdStr.SetString(m_multilineLines[0].CPtr());
+		ClearMultilineState();
+		return;
+	}
+	if (m_multilineActiveLine < 0 || m_multilineActiveLine >= count)
+		m_multilineActiveLine = count - 1;
+	SetMultilineExtraLines(std::min(count, GetMaxVisibleMultilineLines()) - 1);
+}
+
+void CommandLine::ContinueMultilineInput(const FARString &line)
+{
+	if (m_multilineLines.empty()) {
+		m_multilineLines.emplace_back(line);
+		m_multilineActiveLine = 0;
+	} else {
+		m_multilineLines[m_multilineActiveLine] = line;
+	}
+
+	const int insert_pos = m_multilineActiveLine + 1;
+	m_multilineLines.insert(m_multilineLines.begin() + insert_pos, FARString());
+	m_multilineActiveLine = insert_pos;
+	CmdStr.SetString(L"", FALSE);
+	UpdateMultilineLayout();
+	Show();
+}
+
+void CommandLine::SetActiveMultilineLine(int line, int cursor_pos)
+{
+	if (line < 0 || line >= (int)m_multilineLines.size())
+		return;
+	SyncActiveMultilineLine();
+	m_multilineActiveLine = line;
+	CmdStr.DisableAC();
+	CmdStr.SetString(m_multilineLines[line].CPtr());
+	CmdStr.SetLeftPos(0);
+	CmdStr.Select(-1, 0);
+	CmdStr.SetCurPos(std::max(0, std::min(cursor_pos, CmdStr.GetLength())));
+	CmdStr.RevertAC();
+}
+
+bool CommandLine::MoveMultilineLine(int delta)
+{
+	if (m_multilineLines.empty())
+		return false;
+	const int count = (int)m_multilineLines.size();
+	const int next = m_multilineActiveLine + delta;
+	if (next < 0 || next >= count)
+		return true;
+
+	const int desired_pos = CmdStr.GetCurPos();
+	SetActiveMultilineLine(next, desired_pos);
+	Show();
+	return true;
+}
+
 int64_t CommandLine::VMProcess(MacroOpcode OpCode, void *vParam, int64_t iParam)
 {
 	if (OpCode >= MCODE_C_CMDLINE_BOF && OpCode <= MCODE_C_CMDLINE_SELECTED)
-		return CmdStr.VMProcess(OpCode - MCODE_C_CMDLINE_BOF + MCODE_C_BOF, vParam, iParam);
+		OpCode = static_cast<MacroOpcode>(OpCode - MCODE_C_CMDLINE_BOF + MCODE_C_BOF);
 
-	if (OpCode >= MCODE_C_BOF && OpCode <= MCODE_C_SELECTED)
-		return CmdStr.VMProcess(OpCode, vParam, iParam);
-
-	if (OpCode == MCODE_V_ITEMCOUNT || OpCode == MCODE_V_CURPOS)
-		return CmdStr.VMProcess(OpCode, vParam, iParam);
+	if (OpCode >= MCODE_C_BOF && OpCode <= MCODE_C_SELECTED) {
+		switch (OpCode) {
+			case MCODE_C_EMPTY:
+				return !IsNotEmpty();
+			case MCODE_C_BOF:
+				return GetCurPos() == 0;
+			case MCODE_C_EOF: {
+				FARString command;
+				GetString(command);
+				return GetCurPos() >= (int)command.GetLength();
+			}
+			default:
+				return CmdStr.VMProcess(OpCode, vParam, iParam);
+		}
+	}
 
 	if (OpCode == MCODE_V_CMDLINE_ITEMCOUNT || OpCode == MCODE_V_CMDLINE_CURPOS)
-		return CmdStr.VMProcess(OpCode - MCODE_V_CMDLINE_ITEMCOUNT + MCODE_V_ITEMCOUNT, vParam, iParam);
+		OpCode = static_cast<MacroOpcode>(OpCode - MCODE_V_CMDLINE_ITEMCOUNT + MCODE_V_ITEMCOUNT);
 
-	if (OpCode == MCODE_F_EDITOR_SEL)
-		return CmdStr.VMProcess(MCODE_F_EDITOR_SEL, vParam, iParam);
+	if (OpCode == MCODE_V_ITEMCOUNT) {
+		FARString command;
+		GetString(command);
+		return command.GetLength();
+	}
+	if (OpCode == MCODE_V_CURPOS)
+		return GetCurPos() + 1;
+
+	if (OpCode == MCODE_F_EDITOR_SEL) {
+		int64_t result = CmdStr.VMProcess(MCODE_F_EDITOR_SEL, vParam, iParam);
+		const int action = (int)((INT_PTR)vParam);
+		if (!m_multilineLines.empty() && action == 0 && result > 0 && (iParam == 1 || iParam == 3))
+			result+= GetMultilineLineOffset(m_multilineActiveLine);
+		return result;
+	}
 
 	return 0;
 }
@@ -501,12 +925,22 @@ void CommandLine::ProcessKey_ShowCommandsHistory()
 			CmdStr.DisableAC();
 		}
 		SetString(strStr);
+		SetCurPos((int)strStr.GetLength());
 		if (SelectType < 3 || SelectType == 7) {
 			ProcessKey(SelectType == 7 ? static_cast<int>(KEY_CTRLALTENTER)
 									: (SelectType == 1 ? static_cast<int>(KEY_ENTER)
 														: static_cast<int>(KEY_SHIFTENTER)));
 			CmdStr.RevertAC();
 		}
+	}
+}
+
+void CommandLine::AddHistory(const wchar_t* Str)
+{
+	if (!(Opt.ExcludeCmdHistory & EXCLUDECMDHISTORY_NOTCMDLINE)) {
+		FARString strCurDirFromPanel;
+		CtrlObject->Cp()->ActivePanel->GetCurDirPluginAware(strCurDirFromPanel);
+		CtrlObject->CmdHistory->AddToHistoryExtra(Str, strCurDirFromPanel);
 	}
 }
 
@@ -517,7 +951,39 @@ int CommandLine::ProcessKey_Enter(FarKey Key)
 	CmdStr.Select(-1, 0);
 	CmdStr.Show();
 	CmdStr.GetString(strStr);
-	RemoveTrailingSpaces(strStr, true); // RemoveTrailingSpaces and taking into account last escaping symbol
+	if (m_hereDocDelimiters.empty())
+		RemoveTrailingSpaces(strStr, true); // RemoveTrailingSpaces and taking into account last escaping symbol
+
+	if (!m_hereDocDelimiters.empty()) {
+		if (IsHereDocTerminator(strStr)) {
+			m_hereDocDelimiters.erase(m_hereDocDelimiters.begin());
+			if (m_hereDocDelimiters.empty()) {
+				m_multilineLines[m_multilineActiveLine] = strStr;
+			} else {
+				ContinueMultilineInput(strStr);
+				return TRUE;
+			}
+		} else {
+			ContinueMultilineInput(strStr);
+			return TRUE;
+		}
+	}
+
+	if (AddHereDocDelimiters(strStr) || IsContinuationLine(strStr)) {
+		ContinueMultilineInput(strStr);
+		return TRUE;
+	}
+
+	if (!m_multilineLines.empty()) {
+		if (!IsNotEmpty()) {
+			CmdStr.SetString(L"", FALSE);
+			ClearMultilineState();
+			Show();
+			return TRUE;
+		}
+		strStr = BuildMultilineCommand(strStr);
+		ClearMultilineState();
+	}
 
 	if (strStr.IsEmpty())
 		return FALSE;
@@ -527,9 +993,7 @@ int CommandLine::ProcessKey_Enter(FarKey Key)
 	FARString strCurDirFromPanel;
 	ActivePanel->GetCurDirPluginAware(strCurDirFromPanel);
 
-	if (!(Opt.ExcludeCmdHistory & EXCLUDECMDHISTORY_NOTCMDLINE)) {
-		CtrlObject->CmdHistory->AddToHistoryExtra(strStr, strCurDirFromPanel);
-	}
+	AddHistory(strStr);
 
 	Redraw();
 	if ( ProcessFarCommands(strStr.CPtr()) ) {
@@ -627,10 +1091,9 @@ int CommandLine::ProcessKeyIfVisible(FarKey Key)
 					LastCmdPartLength = CurCmdPartLength;
 				}
 				CmdStr.DisableAC();
-				CmdStr.SetString(strStr);
-				CmdStr.Select(LastCmdPartLength, static_cast<int>(strStr.GetLength()));
+				SetString(strStr);
+				Select(LastCmdPartLength, static_cast<int>(strStr.GetLength()));
 				CmdStr.RevertAC();
-				Show();
 				return TRUE;
 			}
 			break;
@@ -638,6 +1101,77 @@ int CommandLine::ProcessKeyIfVisible(FarKey Key)
 		case KEY_TAB: case KEY_SHIFTTAB:
 			ProcessTabCompletion();
 			return TRUE;
+	}
+
+	if (!m_multilineLines.empty()) {
+		int sel_start = -1;
+		int sel_end = 0;
+		CmdStr.GetSelection(sel_start, sel_end);
+		const bool has_selection = !(sel_start == -1 && sel_end == 0);
+		if (Key == KEY_UP || Key == KEY_NUMPAD8)
+			return MoveMultilineLine(-1);
+		if (Key == KEY_DOWN || Key == KEY_NUMPAD2)
+			return MoveMultilineLine(1);
+		if (!has_selection) {
+			if (Key == KEY_LEFT || Key == KEY_NUMPAD4) {
+				if (CmdStr.GetCurPos() == 0 && m_multilineActiveLine > 0) {
+					const int previous = m_multilineActiveLine - 1;
+					SetActiveMultilineLine(previous, (int)m_multilineLines[previous].GetLength());
+					Show();
+					return TRUE;
+				}
+			}
+			if (Key == KEY_RIGHT || Key == KEY_NUMPAD6) {
+				if (CmdStr.GetCurPos() == CmdStr.GetLength()
+						&& m_multilineActiveLine + 1 < (int)m_multilineLines.size()) {
+					SetActiveMultilineLine(m_multilineActiveLine + 1, 0);
+					Show();
+					return TRUE;
+				}
+			}
+			if (Key == KEY_DEL) {
+				if (CmdStr.GetCurPos() == CmdStr.GetLength()
+						&& m_multilineActiveLine + 1 < (int)m_multilineLines.size()) {
+					SyncActiveMultilineLine();
+					FARString current = m_multilineLines[m_multilineActiveLine];
+					FARString next = m_multilineLines[m_multilineActiveLine + 1];
+					const int new_pos = (int)current.GetLength();
+					current+= next;
+					m_multilineLines[m_multilineActiveLine] = current;
+					m_multilineLines.erase(m_multilineLines.begin() + m_multilineActiveLine + 1);
+					CmdStr.DisableAC();
+					CmdStr.SetString(current.CPtr());
+					CmdStr.SetLeftPos(0);
+					CmdStr.Select(-1, 0);
+					CmdStr.SetCurPos(new_pos);
+					CmdStr.RevertAC();
+					UpdateMultilineLayout();
+					Show();
+					return TRUE;
+				}
+			}
+		}
+		if (!has_selection && Key == KEY_BS) {
+			if (CmdStr.GetCurPos() == 0 && m_multilineActiveLine > 0) {
+				SyncActiveMultilineLine();
+				FARString prev = m_multilineLines[m_multilineActiveLine - 1];
+				FARString current = m_multilineLines[m_multilineActiveLine];
+				const int new_pos = (int)prev.GetLength();
+				prev+= current;
+				m_multilineLines[m_multilineActiveLine - 1] = prev;
+				m_multilineLines.erase(m_multilineLines.begin() + m_multilineActiveLine);
+				m_multilineActiveLine--;
+				CmdStr.DisableAC();
+				CmdStr.SetString(prev.CPtr());
+				CmdStr.SetLeftPos(0);
+				CmdStr.Select(-1, 0);
+				CmdStr.SetCurPos(new_pos);
+				CmdStr.RevertAC();
+				UpdateMultilineLayout();
+				Show();
+				return TRUE;
+			}
+		}
 	}
 
 	if (Key != KEY_NONE) {
@@ -691,6 +1225,12 @@ int CommandLine::ProcessKeyIfVisible(FarKey Key)
 
 		case KEY_ESC:
 			if (Key == KEY_ESC) {
+				if (!m_multilineLines.empty()) {
+					CmdStr.SetString(L"", FALSE);
+					ClearMultilineState();
+					Show();
+					return TRUE;
+				}
 				// $ 24.09.2000 SVS - Если задано поведение по "Несохранению при Esc", то позицию в хистори не меняем и ставим в первое положение.
 				if (Opt.CmdHistoryRule)
 					CtrlObject->CmdHistory->ResetPosition();
@@ -761,24 +1301,25 @@ int CommandLine::ProcessKeyIfVisible(FarKey Key)
 
 				const wchar_t *ClipText = clip.CPtr();
 				if (ClipText && wcschr(ClipText, L'\n') && wcschr(ClipText, L'\n')[1] != L'\0') {
-					CmdStr.GetString(strStr);
-					FARString strToExec = strStr.SubStr(0, CmdStr.GetCurPos()) + ClipText + strStr.SubStr(CmdStr.GetCurPos());
+					GetString(strStr);
+					const int cursor_pos = GetCurPos();
+					FARString strToExec = strStr.SubStr(0, cursor_pos) + ClipText + strStr.SubStr(cursor_pos);
+					NormalizeMultilineForExec(strToExec);
 					RemoveTrailingSpaces(strToExec);
-					if (Opt.CmdLine.AskOnMultilinePaste) {
+					if (Opt.CmdLine.AskOnMultilinePaste)
+					{
 						int res = ShowMultilinePasteDialog(strToExec);
-						if (res == 1) {
-							ExecString(strToExec);
-						}
-						else if (res ==2) {
+
+						if (res == 0)
+							break;
+
+						if (res == 2)
 							Opt.CmdLine.AskOnMultilinePaste = false;
-							ExecString(strToExec);
-						}
-						break;
 					}
-					else {
-						ExecString(strToExec);
-						break;
-					}
+
+					AddHistory(strToExec);
+					ExecString(strToExec);
+					break;
 				}
 			}
 
@@ -817,13 +1358,37 @@ int CommandLine::GetCurDir(FARString &strCurDir)
 	return (int)strCurDir.GetLength();
 }
 
+void CommandLine::GetString(FARString &strStr)
+{
+	if (m_multilineLines.empty()) {
+		CmdStr.GetString(strStr);
+		return;
+	}
+
+	FARString active_line;
+	CmdStr.GetString(active_line);
+	strStr = BuildMultilineCommand(active_line);
+}
+
 void CommandLine::SetString(const wchar_t *Str, BOOL Redraw)
 {
 	if (!IsVisible())
 		return;
 
+	FARString normalized(Str ? Str : L"");
+	NormalizeMultilineForExec(normalized);
+	size_t newline_pos = 0;
+	if (normalized.Pos(newline_pos, L'\n')) {
+		LastCmdPartLength = -1;
+		ApplyMultilineText(normalized, Redraw);
+		return;
+	}
+
+	if (!m_multilineLines.empty())
+		ClearMultilineState();
+
 	LastCmdPartLength = -1;
-	CmdStr.SetString(Str);
+	CmdStr.SetString(normalized);
 	CmdStr.SetLeftPos(0);
 	if (Redraw)
 		CmdStr.Show();
@@ -840,21 +1405,104 @@ void CommandLine::ExecString(const wchar_t *Str, bool SeparateWindow, bool Direc
 
 void CommandLine::InsertString(const wchar_t *Str)
 {
-	if (!IsVisible())
+	if (!IsVisible() || !Str)
 		return;
 
 	LastCmdPartLength = -1;
+	FARString insertion(Str);
+	NormalizeMultilineForExec(insertion);
+	size_t newline_pos = 0;
+	if (insertion.Pos(newline_pos, L'\n')) {
+		FARString command;
+		GetString(command);
+		const int cursor_pos = GetCurPos();
+		command = command.SubStr(0, cursor_pos) + insertion + command.SubStr(cursor_pos);
+		SetString(command);
+		SetCurPos(cursor_pos + (int)insertion.GetLength());
+		return;
+	}
+
 	CmdStr.DisableAC();
-	CmdStr.InsertString(Str);
+	CmdStr.InsertString(insertion);
 	CmdStr.Show();
 	CmdStr.RevertAC();
 }
 
+void CommandLine::GetSelection(int &Start, int &End)
+{
+	CmdStr.GetSelection(Start, End);
+	if (!m_multilineLines.empty() && Start >= 0) {
+		const int offset = GetMultilineLineOffset(m_multilineActiveLine);
+		Start+= offset;
+		End+= offset;
+	}
+}
+
+void CommandLine::Select(int Start, int End)
+{
+	if (m_multilineLines.empty() || Start < 0) {
+		CmdStr.Select(Start, End);
+		return;
+	}
+
+	SyncActiveMultilineLine();
+	for (int i = 0; i < (int)m_multilineLines.size(); ++i) {
+		const int offset = GetMultilineLineOffset(i);
+		const int length = (int)m_multilineLines[i].GetLength();
+		if (Start >= offset && End >= Start && End <= offset + length) {
+			if (i == m_multilineActiveLine)
+				CmdStr.SetCurPos(std::min(End - offset, length));
+			else
+				SetActiveMultilineLine(i, std::min(End - offset, length));
+			CmdStr.Select(Start - offset, End - offset);
+			Show();
+			return;
+		}
+	}
+
+	CmdStr.Select(-1, 0);
+}
+
+void CommandLine::ResizeConsole()
+{
+	if (!m_multilineLines.empty()) {
+		UpdateMultilineLayout();
+		Show();
+	}
+}
+
 int CommandLine::ProcessMouse(MOUSE_EVENT_RECORD *MouseEvent)
 {
-	if (MouseEvent->dwButtonState & FROM_LEFT_1ST_BUTTON_PRESSED && MouseEvent->dwMousePosition.X == X2 + 1) {
+	if (MouseEvent->dwButtonState & FROM_LEFT_1ST_BUTTON_PRESSED
+			&& MouseEvent->dwMousePosition.X == X2 + 1 && MouseEvent->dwMousePosition.Y == Y2) {
 		return ProcessKey(KEY_ALTF8);
 	}
+
+	if (!m_multilineLines.empty() && MouseEvent->dwButtonState & FROM_LEFT_1ST_BUTTON_PRESSED
+			&& MouseEvent->dwMousePosition.X >= X1 && MouseEvent->dwMousePosition.X <= X2) {
+		int visible_lines = 0;
+		const int view_top = GetMultilineViewTop(visible_lines);
+		const int view_y = Y2 - visible_lines + 1;
+		if (MouseEvent->dwMousePosition.Y >= view_y && MouseEvent->dwMousePosition.Y <= Y2) {
+			const int line = view_top + MouseEvent->dwMousePosition.Y - view_y;
+			FARString prompt;
+			GetMultilinePrompt(line, prompt);
+			const int editor_x = X1 + (int)prompt.CellsCount();
+			SetActiveMultilineLine(line, 0);
+			Show();
+			if (MouseEvent->dwMousePosition.X < editor_x) {
+				CmdStr.SetCurPos(0);
+				CmdStr.Show();
+				return TRUE;
+			}
+
+			MOUSE_EVENT_RECORD edit_event = *MouseEvent;
+			const int active_view_top = GetMultilineViewTop(visible_lines);
+			edit_event.dwMousePosition.Y = Y2 - visible_lines + 1 + line - active_view_top;
+			return CmdStr.ProcessMouse(&edit_event);
+		}
+	}
+
 	int r = CmdStr.ProcessMouse(MouseEvent);
 	if (r == 0) {
 		if (MouseEvent->dwButtonState & FROM_LEFT_1ST_BUTTON_PRESSED) {
@@ -1093,7 +1741,7 @@ void CommandLine::RedrawWithoutComboBoxMark()
 
 	Redraw();
 	// erase \x2191 character...
-	DrawComboBoxMark(L' ');
+	DrawComboBoxMark(L' ', Y2);
 }
 
 bool CommandLine::ProcessFarCommands(const wchar_t *CmdLine)

--- a/far2l/src/cmdline.hpp
+++ b/far2l/src/cmdline.hpp
@@ -37,6 +37,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "edit.hpp"
 #include <WinCompat.h>
 #include "FARString.hpp"
+#include <vector>
 
 enum
 {
@@ -57,6 +58,12 @@ struct PushPopRecord
 class CommandLine : public ScreenObject
 {
 private:
+	struct HereDocDelimiter
+	{
+		FARString text;
+		bool strip_tabs;
+	};
+
 	EditControl CmdStr;
 	ConsoleForkScope BackgroundConsole;
 	FARString strCurDir;
@@ -64,6 +71,10 @@ private:
 	FARString strLastCompletionCmdStr;
 	int LastCmdPartLength;
 	int PushDirStackSize;
+	std::vector<FARString> m_multilineLines;
+	std::vector<HereDocDelimiter> m_hereDocDelimiters;
+	int m_multilineExtraLines;
+	int m_multilineActiveLine;
 
 private:
 	virtual void DisplayObject();
@@ -73,7 +84,7 @@ private:
 	BOOL IntChDir(const wchar_t *CmdLine, int ClosePlugin, bool Silent = false);
 	bool ProcessOSCommands(const wchar_t *CmdLine, bool SeparateWindow, bool &PrintCommand);
 	void ProcessTabCompletion();
-	void DrawComboBoxMark(wchar_t MarkChar);
+	void DrawComboBoxMark(wchar_t MarkChar, int y);
 	void ChangeDirFromHistory(bool PluginPath, int SelectType, FARString strDir, FARString strFile=L"");
 	void CheckForKeyPressAfterCmd(int r);
 
@@ -83,6 +94,23 @@ private:
 	void ProcessKey_ShowCommandsHistory();
 	int ProcessKey_Enter(FarKey Key);
 	int ProcessKeyIfVisible(FarKey Key);
+	bool IsContinuationLine(const FARString &line) const;
+	bool AddHereDocDelimiters(const FARString &line);
+	bool IsHereDocTerminator(const FARString &line) const;
+	FARString BuildMultilineCommand(const FARString &line) const;
+	void ContinueMultilineInput(const FARString &line);
+	bool MoveMultilineLine(int delta);
+	void SetActiveMultilineLine(int line, int cursor_pos);
+	void SyncActiveMultilineLine();
+	void UpdateMultilineLayout();
+	void ApplyMultilineText(const FARString &text, BOOL Redraw);
+	void ClearMultilineState();
+	void SetMultilineExtraLines(int extra_lines);
+	int GetMaxVisibleMultilineLines() const;
+	int GetMultilineLineOffset(int line) const;
+	int GetMultilineViewTop(int &visible_lines) const;
+	void GetMultilinePrompt(int line, FARString &prompt);
+	void AddHistory(const wchar_t *Str);
 
 public:
 	CommandLine();
@@ -93,6 +121,7 @@ public:
 	virtual int ProcessKey(FarKey Key);
 	virtual int ProcessMouse(MOUSE_EVENT_RECORD *MouseEvent);
 	virtual int64_t VMProcess(MacroOpcode OpCode, void *vParam = nullptr, int64_t iParam = 0);
+	virtual void ResizeConsole();
 
 	virtual void Show();
 
@@ -100,8 +129,9 @@ public:
 	int GetCurDir(FARString &strCurDir);
 	BOOL SetCurDir(const wchar_t *CurDir);
 
-	void GetString(FARString &strStr) { CmdStr.GetString(strStr); };
-	bool IsNotEmpty() const { return CmdStr.CalcRTrimmedStrSize() > 0; };
+	void GetString(FARString &strStr);
+	bool IsNotEmpty() const;
+	bool IsMultiline() const { return !m_multilineLines.empty(); }
 	void SetString(const wchar_t *Str, BOOL Redraw = TRUE);
 	void InsertString(const wchar_t *Str);
 
@@ -115,8 +145,9 @@ public:
 	void ShowViewEditHistory();
 
 	void SetCurPos(int Pos, int LeftPos = 0);
-	int GetCurPos() { return CmdStr.GetCurPos(); };
+	int GetCurPos();
 	int GetLeftPos() { return CmdStr.GetLeftPos(); };
+	int GetExtraLines() const;
 
 	void SetPersistentBlocks(int Mode);
 	void SetDelRemovesBlocks(int Mode);
@@ -124,8 +155,8 @@ public:
 	void SetWaitKeypress(int Mode);
 
 	void GetSelString(FARString &strStr) { CmdStr.GetSelString(strStr); };
-	void GetSelection(int &Start, int &End) { CmdStr.GetSelection(Start, End); };
-	void Select(int Start, int End) { CmdStr.Select(Start, End); };
+	void GetSelection(int &Start, int &End);
+	void Select(int Start, int End);
 
 	void SaveBackground();
 	void ShowBackground(bool showanyway = false);

--- a/far2l/src/edit.cpp
+++ b/far2l/src/edit.cpp
@@ -451,7 +451,18 @@ void Edit::FastShow()
 				case 0x2066 ... 0x206F:
 					wc = L'\x2194'; // ↔
 					break;
+				case 0x000A: //line feed
+					wc = L'\x240A'; // ␊
+					break;
+				case 0x000D: //carriage return
+					wc = L'\x240D'; // ␍
+					break;
 			}
+		} else {
+			if (wc == L'\n')
+				wc = L'\x21B5'; // ↵
+			else if (wc == L'\r')
+				wc = L'\x240D'; // ␍
 		}
 
 		if (wc == L'\t') {

--- a/far2l/src/filepanels.cpp
+++ b/far2l/src/filepanels.cpp
@@ -222,12 +222,12 @@ void FilePanels::UpdateCmdLineVisibility(bool repos)
 {
 	int left_x1, left_x2, left_y1, left_y2;
 	int right_x1, right_x2, right_y1, right_y2;
-	int cl_x1, cl_x2, cl_y;
+	int cl_x1, cl_x2, cl_y1, cl_y2;
 	bool cl_visible = CtrlObject->CmdLine->IsVisible(), new_cl_visible;
 
 	LeftPanel->GetPosition(left_x1, left_y1, left_x2, left_y2);
 	RightPanel->GetPosition(right_x1, right_y1, right_x2, right_y2);
-	CtrlObject->CmdLine->GetPosition(cl_x1, cl_y, cl_x2, cl_y);
+	CtrlObject->CmdLine->GetPosition(cl_x1, cl_y1, cl_x2, cl_y2);
 
 	const bool left_overlap = LeftPanel->IsVisible() && left_y2 + Opt.ShowKeyBar >= ScrY;
 	const bool right_overlap = RightPanel->IsVisible() && right_y2 + Opt.ShowKeyBar >= ScrY;
@@ -237,7 +237,10 @@ void FilePanels::UpdateCmdLineVisibility(bool repos)
 	else
 		new_cl_visible = !left_overlap && !right_overlap;
 
-	int new_cl_x1 = 0, new_cl_x2 = ScrX - 1, new_cl_y = ScrY - (Opt.ShowKeyBar);
+	const int extra = CtrlObject->CmdLine->GetExtraLines();
+	int new_cl_x1 = 0, new_cl_x2 = ScrX - 1;
+	int new_cl_y2 = ScrY - (Opt.ShowKeyBar);
+	int new_cl_y1 = new_cl_y2 - extra;
 	if (new_cl_visible) {
 		if (left_overlap) {
 			new_cl_x1 = right_x1;
@@ -245,12 +248,12 @@ void FilePanels::UpdateCmdLineVisibility(bool repos)
 			new_cl_x2 = left_x2 - 1;
 		}
 	}
-	bool cl_repos = (new_cl_x1 != cl_x1 || new_cl_x2 != cl_x2 || new_cl_y != cl_y);
+	bool cl_repos = (new_cl_x1 != cl_x1 || new_cl_x2 != cl_x2 || new_cl_y1 != cl_y1 || new_cl_y2 != cl_y2);
 	if (cl_visible != new_cl_visible) {
 		CtrlObject->CmdLine->SetVisible(new_cl_visible);
 	}
 	if (cl_repos || repos) {
-		CtrlObject->CmdLine->SetPosition(new_cl_x1, new_cl_y, new_cl_x2, new_cl_y);
+		CtrlObject->CmdLine->SetPosition(new_cl_x1, new_cl_y1, new_cl_x2, new_cl_y2);
 	}
 
 	if (cl_visible != new_cl_visible || cl_repos || repos) {
@@ -281,8 +284,9 @@ void FilePanels::SetPanelPositions(int LeftFullScreen, int RightFullScreen, int 
 		if (Opt.WidthDecrement > (ScrX / 2 - 10))
 			Opt.WidthDecrement = (ScrX / 2 - 10);
 
-		const int LeftY2 = ScrY - 1 - (Opt.ShowKeyBar) - Opt.LeftHeightDecrement;
-		const int RightY2 = ScrY - 1 - (Opt.ShowKeyBar) - Opt.RightHeightDecrement;
+		const int extra = CtrlObject && CtrlObject->CmdLine ? CtrlObject->CmdLine->GetExtraLines() : 0;
+		const int LeftY2 = ScrY - 1 - (Opt.ShowKeyBar) - Opt.LeftHeightDecrement - extra;
+		const int RightY2 = ScrY - 1 - (Opt.ShowKeyBar) - Opt.RightHeightDecrement - extra;
 
 		if (LeftFullScreen) {
 			LeftPanel->SetPosition(0, Opt.ShowMenuBar ? 1 : 0, ScrX, LeftY2);
@@ -334,8 +338,9 @@ void FilePanels::SetPanelPositions(int LeftFullScreen, int RightFullScreen, int 
 			Opt.WidthDecrement = ((ScrY - Opt.LeftHeightDecrement) / 2 - 6);
 #endif
 
+		const int extra = CtrlObject && CtrlObject->CmdLine ? CtrlObject->CmdLine->GetExtraLines() : 0;
 		const int LeftY2 = (ScrY - Opt.ShowMenuBar) / 2 - (Opt.ShowKeyBar) - Opt.LeftHeightDecrement / 2;
-		int RightY2 = ScrY - (Opt.ShowKeyBar) - 1 - Opt.RightHeightDecrement;
+		int RightY2 = ScrY - (Opt.ShowKeyBar) - 1 - Opt.RightHeightDecrement - extra;
 
 #if 0
 		if (LeftFullScreen) {
@@ -484,6 +489,13 @@ int FilePanels::ProcessKey(FarKey Key)
 {
 	if (!Key)
 		return TRUE;
+
+	if (CtrlObject->CmdLine->IsMultiline()
+			&& (Key == KEY_UP || Key == KEY_NUMPAD8 || Key == KEY_DOWN || Key == KEY_NUMPAD2
+					|| Key == KEY_LEFT || Key == KEY_NUMPAD4 || Key == KEY_RIGHT || Key == KEY_NUMPAD6)) {
+		CtrlObject->CmdLine->ProcessKey(Key);
+		return TRUE;
+	}
 
 	if ((Key == KEY_CTRLLEFT || Key == KEY_CTRLRIGHT || Key == KEY_CTRLNUMPAD4 || Key == KEY_CTRLNUMPAD6
 				/* || Key==KEY_CTRLUP || Key==KEY_CTRLDOWN || Key==KEY_CTRLNUMPAD8 || Key==KEY_CTRLNUMPAD2 */)

--- a/far2l/src/hist/history.cpp
+++ b/far2l/src/hist/history.cpp
@@ -178,16 +178,25 @@ void History::AddToHistoryLocal(const wchar_t *Str, const wchar_t *Extra, const 
 
 static void AppendWithLFSeparator(std::wstring &str, const FARString &ap, bool first)
 {
-	if (!first) {
+	if (!first)
 		str+= L'\n';
-	}
-	size_t p = str.size();
+	size_t pos = str.size();
 	str.append(ap.CPtr(), ap.GetLength());
-	for (; p < str.size(); ++p) {
-		if (str[p] == L'\n') {
-			str[p] = L'\r';
-		}
+	for (; pos < str.size(); ++pos) {
+		if (str[pos] == L'\n')
+			str[pos] = L'\r';
 	}
+}
+
+static void RestoreLFSeparator(FARString &str)
+{
+	ReplaceStrings(str, L"\r", L"\n", -1);
+}
+
+static void MakeHistoryDisplayText(FARString &str)
+{
+	ReplaceStrings(str, L"\r", L"\x240D", -1);
+	ReplaceStrings(str, L"\n", L"\x21B5", -1);
 }
 
 bool History::SaveHistory()
@@ -285,6 +294,7 @@ bool History::ReadLastItem(const char *RegKey, FARString &strStr)
 	if (strStr.Pos(p, L'\n'))
 		strStr.Remove(p, strStr.GetLength() - p);
 
+	RestoreLFSeparator(strStr);
 	return true;
 }
 
@@ -318,8 +328,10 @@ bool History::ReadHistory(bool bOnlyLines)
 
 		HistoryRecord *AddRecord = HistoryList.Unshift();
 		AddRecord->strName = strLines.SubStr(LinesPos, LineEnd - LinesPos);
+		RestoreLFSeparator(AddRecord->strName);
 		LinesPos = LineEnd + 1;
 		AddRecord->strExtra = strExtras.SubStr(ExtrasPos, ExtraEnd - ExtrasPos);
+		RestoreLFSeparator(AddRecord->strExtra);
 		ExtrasPos = ExtraEnd + 1;
 
 		if (TypesPos < strTypes.GetLength()) {
@@ -661,6 +673,8 @@ int History::ProcessMenu(FARString &strStr, const wchar_t *Title, VMenu &History
 					if (TypeHistory == HISTORYTYPE_CMD && CurrentRecord) {
 						FARString strCmd = CurrentRecord->strName;
 						FARString strDir = CurrentRecord->strExtra;
+						MakeHistoryDisplayText(strCmd);
+						MakeHistoryDisplayText(strDir);
 						TruncStrFromCenter(strCmd, std::max(ScrX - 32, 32));
 						TruncStrFromCenter(strDir, std::max(ScrX - 32, 32));
 						strCmd.Insert(0, Msg::HistoryCommandLine);

--- a/far2l/src/panels/qview.cpp
+++ b/far2l/src/panels/qview.cpp
@@ -47,6 +47,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "execute.hpp"
 #include "dirinfo.hpp"
 #include "pathmix.hpp"
+#include "strmix.hpp"
 #include "mix.hpp"
 #include "constitle.hpp"
 #include "syslog.hpp"
@@ -454,6 +455,8 @@ void QuickView::SetTitle()
 		} else {
 			FARString strCmdText;
 			CtrlObject->CmdLine->GetString(strCmdText);
+			ReplaceStrings(strCmdText, L"\r", L"\x240D", -1);
+			ReplaceStrings(strCmdText, L"\n", L"\x21B5", -1);
 			strTitleDir+= strCmdText;
 		}
 

--- a/far2l/src/vmenu.cpp
+++ b/far2l/src/vmenu.cpp
@@ -61,6 +61,17 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "UsedChars.hpp"
 #include "help.hpp"
 
+namespace
+{
+FARString MenuDisplayText(const FARString &text)
+{
+	FARString display(text);
+	ReplaceStrings(display, L"\r", L"\x240D", -1);
+	ReplaceStrings(display, L"\n", L"\x21B5", -1);
+	return display;
+}
+}
+
 VMenu::VMenu(const wchar_t *Title,		// заголовок меню
 		MenuDataEx *Data,				// пункты меню
 		int ItemCount,					// количество пунктов меню
@@ -1019,10 +1030,11 @@ int VMenu::ProcessKey(FarKey Key)
 				int _len;
 
 				for (int I = 0; I < ItemCount; ++I) {
+					const FARString itemText = MenuDisplayText(Item[I]->strName);
 					if (CheckFlags(VMENU_SHOWAMPERSAND))
-						_len = static_cast<int>(Item[I]->strName.CellsCount());
+						_len = static_cast<int>(itemText.CellsCount());
 					else
-						_len = HiStrCellsCount(Item[I]->strName);
+						_len = HiStrCellsCount(itemText);
 
 					if (_len >= MaxLineWidth)
 						Item[I]->ShowPos = _len - MaxLineWidth;
@@ -1426,11 +1438,12 @@ bool VMenu::ShiftItemShowPos(int Pos, int Direct)
 {
 	int _len;
 	int ItemShowPos = Item[Pos]->ShowPos;
+	const FARString itemText = MenuDisplayText(Item[Pos]->strName);
 
 	if (VMFlags.Check(VMENU_SHOWAMPERSAND))
-		_len = (int)Item[Pos]->strName.CellsCount();
+		_len = (int)itemText.CellsCount();
 	else
-		_len = HiStrCellsCount(Item[Pos]->strName);
+		_len = HiStrCellsCount(itemText);
 
 	if (_len < MaxLineWidth || (Direct < 0 && !ItemShowPos) || (Direct > 0 && ItemShowPos > _len))
 		return false;
@@ -1441,7 +1454,7 @@ bool VMenu::ShiftItemShowPos(int Pos, int Direct)
 		else
 			ItemShowPos++;
 	} else {
-		ItemShowPos = HiFindNextVisualPos(Item[Pos]->strName, ItemShowPos, Direct);
+		ItemShowPos = HiFindNextVisualPos(itemText, ItemShowPos, Direct);
 	}
 
 	if (ItemShowPos < 0)
@@ -1696,11 +1709,12 @@ void VMenu::ShowMenu(bool IsParent, bool ForceFrameRedraw)
 	// BUGBUG, this must be optimized
 	for (int i = 0; i < ItemCount; i++) {
 		int ItemLen;
+		const FARString itemText = MenuDisplayText(Item[i]->strName);
 
 		if (CheckFlags(VMENU_SHOWAMPERSAND))
-			ItemLen = static_cast<int>(Item[i]->strName.CellsCount());
+			ItemLen = static_cast<int>(itemText.CellsCount());
 		else
-			ItemLen = HiStrCellsCount(Item[i]->strName);
+			ItemLen = HiStrCellsCount(itemText);
 
 		if (ItemLen > MaxItemLength)
 			MaxItemLength = ItemLen;
@@ -1894,10 +1908,11 @@ void VMenu::ShowMenu(bool IsParent, bool ForceFrameRedraw)
 					GotoXY(X1, Y);
 
 				FARString strMenuLine;
+				FARString itemText = MenuDisplayText(Item[I]->strName);
 
 				int ShowPos =
-						HiFindRealPos(Item[I]->strName, Item[I]->ShowPos, CheckFlags(VMENU_SHOWAMPERSAND));
-				FARString strMItemPtr(Item[I]->strName.CPtr() + ShowPos);
+						HiFindRealPos(itemText, Item[I]->ShowPos, CheckFlags(VMENU_SHOWAMPERSAND));
+				FARString strMItemPtr(itemText.CPtr() + ShowPos);
 				const int strMItemPtrLen = CheckFlags(VMENU_SHOWAMPERSAND)
 					? static_cast<int>(strMItemPtr.CellsCount())
 					: HiStrCellsCount(strMItemPtr);


### PR DESCRIPTION
This PR adds multiline input to the command line. Multiline mode starts when Enter is pressed after either:
  - a line ending in an unescaped `\`;
  - a here-document redirection such as `<<EOF` or `<<-EOF`.

The command line supports cursor and mouse navigation between logical lines. Multiline commands are preserved in command history and displayed there with visible line-break markers.

The initial proposal is included below for context. Following the discussion in the comments, that approach was discarded in favor of direct multiline command entry.
_______________________________________
 Follow up #3227, suggestion from contributors
> а можно теперь этим диалогом текущее содержимое командной строки редактировать? 
> Бывает, исполнишь какое нибудь страшное заклинание с десятками аргументов и кучей "&&" и когда достаешь его из истории, хочется покрутить его в мултилайне без риска исполнить случайно. Например, на ALT+e вызвать.

Modern shells support such function, bash: crtl+x ctrl+e, fish: alt+e

So I have drafted it with the new dialogue, but I'm not sure about the target UX: multiline execution and history.
It would be nice to get some feedback before merging
@Dazzar56 @unxed @akruphi @spnethw 