### PR TITLE
generate_metainfo: Print a warning message about unknown headers

### DIFF
--- a/far2l/DE/generate_metainfo.py
+++ b/far2l/DE/generate_metainfo.py
@@ -38,12 +38,16 @@ release_elem = None
 
 for elem in html_root:
     if elem.tag == "h2":
-        if elem.text[0].isdecimal():
-            match = release_re.match(elem.text)
+        if match := release_re.match(elem.text):
             release = match.groupdict()
             if release["type"] == "beta":
                 release["type"] = "development"
             release_elem = ET.SubElement(releases, "release", release)
+        elif elem.text != "Master (current development)":
+            print(
+                f"Warning: cannot parse header {elem.text!r} in {changelog_file}",
+                file=sys.stderr,
+            )
     elif elem.tag == "ul" and release_elem is not None:
         for child_elem in elem.iter():
             # https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-description


### PR DESCRIPTION
Previously, if `changelog.md` had a header that started with a digit but had wrong format, this script was failing with an exception:
```
[ 17%] Generating DE/io.github.elfmz.far2l.metainfo.xml
Traceback (most recent call last):
  File "/home/dkms/devel/far2l/far2l/DE/generate_metainfo.py", line 43, in <module>
    release = match.groupdict()
              ^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'groupdict'
```

This was reported in the Telegram chat: <https://t.me/far2l_ru/54234>.