### PR TITLE
Adjust the length argument passed to Wide2MB in OSC52ClipboardBackend::OnClipboardSetData.

### DIFF
--- a/WinPort/src/Backend/TTY/OSC52ClipboardBackend.cpp
+++ b/WinPort/src/Backend/TTY/OSC52ClipboardBackend.cpp
@@ -11,7 +11,7 @@ void *OSC52ClipboardBackend::OnClipboardSetData(UINT format, void *data)
 {
 	if (format == CF_UNICODETEXT) {
 		std::string str;
-		Wide2MB((const wchar_t *)data, WINPORT(ClipboardSize)(data), str);
+		Wide2MB((const wchar_t *)data, WINPORT(ClipboardSize)(data) / sizeof(wchar_t), str);
 		_interactor->OSC52SetClipboard(str.c_str());
 	}
 	return FSClipboardBackend::OnClipboardSetData(format, data);


### PR DESCRIPTION
ClipboardSize returns the size in bytes, but Wide2MB expects the number of wchar_t characters.
Fixes #3252