### PR TITLE
Overallocation to fix AddOKCancel crash

### DIFF
--- a/far2l/far2sdk/fardlgbuilderbase.hpp
+++ b/far2l/far2sdk/fardlgbuilderbase.hpp
@@ -167,7 +167,7 @@ class DialogBuilderBase
 			// AddDialogItem и аналогичных методов, поэтому размер массива подбираем такой,
 			// чтобы все нормальные диалоги помещались без реаллокации
 			// TODO хорошо бы, чтобы они вообще не инвалидировались
-			DialogItemsAllocated += 32;
+			DialogItemsAllocated += 128;
 			if (!DialogItems)
 			{
 				DialogItems = new T[DialogItemsAllocated];


### PR DESCRIPTION
due to realloc between OK and Cancel creation invalidating OK pointer.

Reported when using portable far2l built on musl via ssh when opening Options->interface settings, which contains in this case 33 elements so that reallocation happens between OK and Cancel buttons creation. Version built on glibc forgives this bug, musl - doesn't

See also modernization attempt with std::vector<std::unique_ptr<T>>  which fixes the issue by overcomplication instead of overallocation https://github.com/elfmz/far2l/compare/master...exkrexpexfex:far2l:reallocdialog

Shall we go with it instead? Please consider