### PR TITLE
#3138, remaining

### DIFF
--- a/far2l/src/editor.cpp
+++ b/far2l/src/editor.cpp
@@ -1986,7 +1986,6 @@ int Editor::ProcessKey(FarKey Key)
 			{
 				if (!CurLine->m_next && (m_CurVisualLineInLogicalLine + 1 >= CurLine->GetVisualLineCount()))
 				{
-					// We are on the very last visual line of the very last logical line. Do nothing.
 					Show();
 					return TRUE;
 				}
@@ -2001,18 +2000,25 @@ int Editor::ProcessKey(FarKey Key)
 
 				if (OldLine == CurLine)
 				{
-					// Moved within the same logical line.
 					if (SelFirst) {
 						BlockStart = CurLine;
 						BlockStartLine = NumLine;
-						CurLine->Select(OldPos, CurLine->GetCurPos());
+						CurLine->Select(std::min(OldPos, CurLine->GetCurPos()), std::max(OldPos, CurLine->GetCurPos()));
 					} else if (SelAtBeginning) {
-						CurLine->Select(CurLine->GetCurPos(), OldSelEnd);
+						if (OldSelEnd == -1 || CurLine->GetCurPos() <= OldSelEnd) {
+							CurLine->Select(CurLine->GetCurPos(), OldSelEnd);
+						} else {
+							CurLine->Select(OldSelEnd, CurLine->GetCurPos());
+						}
 					} else {
-						CurLine->Select(OldSelStart, CurLine->GetCurPos());
+						if (CurLine->GetCurPos() >= OldSelStart) {
+							CurLine->Select(OldSelStart, CurLine->GetCurPos());
+						} else {
+							CurLine->Select(CurLine->GetCurPos(), OldSelStart);
+						}
 					}
 				}
-				else // Crossed a logical line boundary
+				else
 				{
 					if (SelFirst) {
 						BlockStart = OldLine;
@@ -2020,11 +2026,23 @@ int Editor::ProcessKey(FarKey Key)
 						OldLine->Select(OldPos, -1);
 						CurLine->Select(0, CurLine->GetCurPos());
 					} else if (SelAtBeginning) {
-						BlockStart = CurLine;
-						BlockStartLine = NumLine;
-						OldLine->Select(-1, 0); // Deselect the old line
+						if (OldSelEnd == -1) {
+							OldLine->Select(-1, 0);
+							BlockStart = CurLine;
+							BlockStartLine = NumLine;
 
-						//CurLine->Select(CurLine->GetCurPos(), OldSelEnd); // This assumes OldSelEnd is on the new line, which is not true. Should be empty.
+							int CurSelStart, CurSelEnd;
+							CurLine->GetRealSelection(CurSelStart, CurSelEnd);
+
+							if (CurSelEnd == -1 || CurLine->GetCurPos() <= CurSelEnd) {
+								CurLine->Select(CurLine->GetCurPos(), CurSelEnd);
+							} else {
+								CurLine->Select(CurSelEnd, CurLine->GetCurPos());
+							}
+						} else {
+							OldLine->Select(OldSelEnd, -1);
+							CurLine->Select(0, CurLine->GetCurPos());
+						}
 					} else {
 						OldLine->Select(OldSelStart, -1);
 						CurLine->Select(0, CurLine->GetCurPos());
@@ -2115,59 +2133,72 @@ int Editor::ProcessKey(FarKey Key)
 		case KEY_SHIFTNUMPAD8: {
 			if (m_bWordWrap)
 			{
-				if (m_CurVisualLineInLogicalLine > 0)
+				if (!CurLine->m_prev && m_CurVisualLineInLogicalLine == 0)
 				{
-					// --- Case 1: Moving selection UP within the SAME logical line ---
-					const int OldPos = CurLine->GetCurPos();
-					int OldSelStart, OldSelEnd;
-					CurLine->GetRealSelection(OldSelStart, OldSelEnd);
+					Show();
+					return TRUE;
+				}
 
-					Up(); // Move cursor up one visual line
-					UpdateCursorPosition(m_WordWrapMaxRightPos);
+				const int OldPos = CurLine->GetCurPos();
+				Edit* OldLine = CurLine;
+				int OldSelStart, OldSelEnd;
+				OldLine->GetRealSelection(OldSelStart, OldSelEnd);
 
+				Up();
+				UpdateCursorPosition(m_WordWrapMaxRightPos);
+
+				if (OldLine == CurLine)
+				{
 					if (SelFirst) {
 						BlockStart = CurLine;
 						BlockStartLine = NumLine;
-						CurLine->Select(CurLine->GetCurPos(), OldPos);
+						CurLine->Select(std::min(OldPos, CurLine->GetCurPos()), std::max(OldPos, CurLine->GetCurPos()));
 					} else if (SelAtBeginning) {
-						CurLine->Select(CurLine->GetCurPos(), OldSelEnd);
+						if (CurLine->GetCurPos() <= OldSelEnd || OldSelEnd == -1) {
+							CurLine->Select(CurLine->GetCurPos(), OldSelEnd);
+						} else {
+							CurLine->Select(OldSelEnd, CurLine->GetCurPos());
+						}
 					} else {
-						CurLine->Select(OldSelStart, CurLine->GetCurPos());
+						if (CurLine->GetCurPos() >= OldSelStart) {
+							CurLine->Select(OldSelStart, CurLine->GetCurPos());
+						} else {
+							CurLine->Select(CurLine->GetCurPos(), OldSelStart);
+						}
 					}
 				}
-				else // On the first visual line
+				else
 				{
-					// --- Case 2: Moving selection UP to the PREVIOUS logical line ---
-					if (!CurLine->m_prev)
-					{
-						Show(); // At top of file, do nothing but ensure redraw
-						return TRUE;
-					}
-
-					const int OldPos = CurLine->GetCurPos();
-					Edit* OldCurLine = CurLine;
-					int OldSelStart, OldSelEnd;
-					OldCurLine->GetRealSelection(OldSelStart, OldSelEnd);
-
-					Up(); // This moves CurLine to CurLine->m_prev
-					UpdateCursorPosition(m_WordWrapMaxRightPos);
-
 					if (SelFirst) {
-						// Starting a new selection that crosses lines
-						BlockStart = CurLine; // The new line is now the start
-						BlockStartLine = NumLine;
-						CurLine->Select(CurLine->GetCurPos(), -1); // Select from new cursor pos to end of new line
-						OldCurLine->Select(0, OldPos); // On the old line, select from start to old cursor pos
-					} else if (SelAtBeginning) {
-						// Expanding an existing selection upwards
 						BlockStart = CurLine;
 						BlockStartLine = NumLine;
-						CurLine->Select(CurLine->GetCurPos(), -1); // New start line is selected from cursor to end
-						OldCurLine->Select(0, OldSelEnd); // The old line remains selected from its start to its previous end
+						CurLine->Select(CurLine->GetCurPos(), -1);
+						OldLine->Select(0, OldPos);
+					} else if (SelAtBeginning) {
+						BlockStart = CurLine;
+						BlockStartLine = NumLine;
+						CurLine->Select(CurLine->GetCurPos(), -1);
+						OldLine->Select(0, OldSelEnd);
 					} else {
-						// Shrinking an existing selection from the bottom
-						OldCurLine->Select(-1, 0); // Deselect the old line completely
-						CurLine->Select(OldSelStart, CurLine->GetCurPos()); // On the new current line, adjust the selection end
+						if (BlockStartLine < NumLine + 1) {
+							OldLine->Select(-1, 0);
+
+							int CurSelStart, CurSelEnd;
+							CurLine->GetRealSelection(CurSelStart, CurSelEnd);
+
+							if (CurSelEnd == -1 || CurLine->GetCurPos() >= CurSelStart) {
+								CurLine->Select(CurSelStart, CurLine->GetCurPos());
+							} else {
+								CurLine->Select(CurLine->GetCurPos(), CurSelStart);
+								BlockStart = CurLine;
+								BlockStartLine = NumLine;
+							}
+						} else {
+							OldLine->Select(0, OldSelStart);
+							CurLine->Select(CurLine->GetCurPos(), -1);
+							BlockStart = CurLine;
+							BlockStartLine = NumLine;
+						}
 					}
 				}
 				Show();


### PR DESCRIPTION
- In editor.cpp within KEY_SHIFTDOWN and KEY_SHIFTUP blocks (for WordWrap mode),

add UpdateCursorPosition(m_WordWrapMaxRightPos) right after Down() and Up() respectively. This ensures the cursor preserves its horizontal offset across visual lines.

- Clean up redundant selection marking logic from KEY_SHIFTUP which is already handled globally by the main KEY_SHIFT* pre-processing block.