### PR TITLE
Fix crash on far:config

### DIFF
--- a/far2l/src/cfg/ConfigOpt.cpp
+++ b/far2l/src/cfg/ConfigOpt.cpp
@@ -129,7 +129,7 @@ const ConfigOpt g_cfg_opts[] {
 	{true,  NSecColors, "TempColors256", TEMP_COLORS256_SIZE, g_tempcolors256, nullptr},
 	{true,  NSecColors, "TempColorsRGB", TEMP_COLORSRGB_SIZE, (BYTE *)g_tempcolorsRGB, nullptr},
 
-	{true,  NSecColors, "CurrentTheme", &Opt.CurrentTheme, nullptr },
+	{true,  NSecColors, "CurrentTheme", &Opt.CurrentTheme, L"" },
 	{true,  NSecColors, "CurrentThemeIsSystemWide", &Opt.IsSystemTheme, 0 },
 
 	{true,  NSecScreen, "Clock", &Opt.Clock, 1},


### PR DESCRIPTION
```
* thread #8, stop reason = EXC_BAD_ACCESS (code=1, address=0x0)
  * frame #0: 0x000000019edef944 libsystem_c.dylib`wcslen + 4
    frame #1: 0x000000010001025c far2l`StrLength(str=0x0000000000000000) at locale.hpp:43:14
    frame #2: 0x000000010001e704 far2l`FARString::operator==(this=0x00000001004b0820, Str=0x0000000000000000) const at FARString.hpp:225:87
    frame #3: 0x000000010021b414 far2l`ConfigOptProps::MenuListAppend(this=0x00000001701cc528, vm=0x00000001701cc580, len_sections=20, len_keys=29, len_sections_keys=39, hide_unchanged=false, align_dot=false, update_id=-1) const at ConfigOptEdit.cpp:188:23
    frame #4: 0x000000010021a6d8 far2l`ConfigOptEdit() at ConfigOptEdit.cpp:556:5
    frame #5: 0x000000010000c750 far2l`CommandLine::ProcessFarCommands(this=0x0000000c539e8800, CmdLine=L"far:config") at cmdline.cpp:1127:3
    frame #6: 0x000000010000c420 far2l`CommandLine::ProcessKey_Enter(this=0x0000000c539e8800, Key=13) at cmdline.cpp:535:7
    frame #7: 0x000000010000ded0 far2l`CommandLine::ProcessKeyIfVisible(this=0x0000000c539e8800, Key=13) at cmdline.cpp:614:11
    frame #8: 0x000000010000d7fc far2l`CommandLine::ProcessKey(this=0x0000000c539e8800, Key=13) at cmdline.cpp:601:9
    frame #9: 0x0000000100193b48 far2l`FileList::ProcessKey(this=0x0000000c551fc600, Key=13) at filelist.cpp:1310:26
    frame #10: 0x00000001000c5280 far2l`FilePanels::ProcessKey(this=0x0000000c54ec7800, Key=13) at filepanels.cpp:815:27
    frame #11: 0x00000001001202b8 far2l`Manager::ProcessKey(this=0x0000000c553d80c0, Key=13) at manager.cpp:1014:17
    frame #12: 0x000000010011e538 far2l`Manager::ProcessMainLoop(this=0x0000000c553d80c0) at manager.cpp:742:4
    frame #13: 0x000000010011fa30 far2l`Manager::EnterMainLoop(this=0x0000000c553d80c0) at manager.cpp:706:3
    frame #14: 0x000000010011bebc far2l`MainProcess(strEditViewArg=FARString @ 0x00000001701ceca8, strDestName1=FARString @ 0x00000001701ceca0, strDestName2=FARString @ 0x00000001701cec98, StartLine=-1, StartChar=-1, cfgNeedSave=false) at main.cpp:355:18
    frame #15: 0x000000010011ad98 far2l`FarAppMain(argc=1, argv=0x0000000100f415e0) at main.cpp:700:15
    frame #16: 0x00000001054c26ac far2l_gui.so`WinPortAppThread::Entry(this=0x0000000c54ccd100) at wxMain.cpp:89:16
    frame #17: 0x0000000105881aac libwx_baseu-3.3.1.0.0.dylib`wxThreadInternal::PthreadStart(wxThread*) + 484
    frame #18: 0x000000019ef3fc08 libsystem_pthread.dylib`_pthread_start + 136
```