### PR TITLE
Fix Delete to Trash on macOS

### DIFF
--- a/far2l/bootstrap/trash.sh
+++ b/far2l/bootstrap/trash.sh
@@ -21,7 +21,7 @@ elif command -v trash-put >/dev/null 2>&1; then
 	trash-put "$1" 2>"$2"
 
 elif command -v trash >/dev/null 2>&1; then
-	if trash --help 2>&1 | grep -q 'fileToMoveToTrash'; then
+	if [ "$(uname)" = "Darwin" ]; then
 		trash "$1" 2>"$2"
 	else
 		trash put "$1" 2>"$2"


### PR DESCRIPTION
The trash helper treated every "trash" binary like trash-cli and invoked "trash put <path>". On macOS, "/usr/bin/trash" expects files directly, so far2l tried to trash a literal file named "put" and every Delete-to-Trash operation failed with a bogus file-not-found error. Detect the macOS CLI signature and use the correct invocation while preserving the existing trash-cli path.