### PR TITLE
Improve performance and UI responsiveness

### DIFF
--- a/NetRocks/src/Op/OpBase.cpp
+++ b/NetRocks/src/Op/OpBase.cpp
@@ -115,6 +115,7 @@ void OpBase::ForcefullyAbort()
 	{
 		std::lock_guard<std::mutex> locker(_state.mtx);
 		_state.aborting = true;
+		_state.cond.notify_all();
 	}
 
 	_base_host->Abort();

--- a/NetRocks/src/Op/OpXfer.cpp
+++ b/NetRocks/src/Op/OpXfer.cpp
@@ -157,6 +157,7 @@ void OpXfer::Abort()
 		if (_state.finished)
 			return;
 		_state.aborting = true;
+		_state.cond.notify_all();
 	}
 
 	_dst_host->Abort();

--- a/NetRocks/src/Op/Utils/ProgressStateUpdate.cpp
+++ b/NetRocks/src/Op/Utils/ProgressStateUpdate.cpp
@@ -9,19 +9,15 @@ ProgressStateUpdate::ProgressStateUpdate(ProgressState &state)
 {
 	std::chrono::milliseconds pause_ticks = {};
 
-	for (;;) {
-		if (state.aborting)
-			throw AbortError();
-		if (!state.paused)
-			break;
-
-		unlock();
+	while (state.paused && !state.aborting) {
 		if (pause_ticks.count() == 0) {
 			pause_ticks = TimeMSNow();
 		}
-		usleep(1000000);
-		lock();
+		state.cond.wait_for(*this, std::chrono::milliseconds(500));
 	}
+
+	if (state.aborting)
+		throw AbortError();
 
 	if (pause_ticks.count() != 0) {
 		pause_ticks = TimeMSNow() - pause_ticks;

--- a/NetRocks/src/UI/Activities/AbortOperationRequest.cpp
+++ b/NetRocks/src/UI/Activities/AbortOperationRequest.cpp
@@ -133,12 +133,14 @@ void AbortOperationRequest(ProgressState &state, bool force_immediate)
 	if (!AbortConfirm().Ask()) { //param1 == _i_cancel &&
 		std::lock_guard<std::mutex> locker(state.mtx);
 		state.paused = saved_paused;
+		state.cond.notify_all();
 		return;
 	}
 	{
 		std::lock_guard<std::mutex> locker(state.mtx);
 		state.aborting = true;
 		state.paused = saved_paused;
+		state.cond.notify_all();
 	}
 	if (force_immediate && state.ao_host) {
 		state.ao_host->ForcefullyAbort();

--- a/NetRocks/src/UI/Activities/ComplexOperationProgress.cpp
+++ b/NetRocks/src/UI/Activities/ComplexOperationProgress.cpp
@@ -112,6 +112,7 @@ void ComplexOperationProgress::Show()
 			{
 				std::lock_guard<std::mutex> locker(_state.mtx);
 				paused = (_state.paused = !_state.paused);
+				_state.cond.notify_all();
 			}
 			TextToDialogControl(_i_pause_resume, paused ? MResume : MPause);
 

--- a/NetRocks/src/UI/Defs.h
+++ b/NetRocks/src/UI/Defs.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <string>
 #include <mutex>
+#include <condition_variable>
 #include <chrono>
 
 enum XferKind
@@ -78,6 +79,7 @@ struct IAbortableOperationsHost
 struct ProgressState
 {
 	std::mutex mtx;
+	std::condition_variable cond;
 	ProgressStateStats stats;
 	std::string path;
 	bool paused = false, aborting = false, finished = false;

--- a/WinPort/src/Backend/TTY/TTYBackend.cpp
+++ b/WinPort/src/Backend/TTY/TTYBackend.cpp
@@ -354,7 +354,7 @@ void TTYBackend::ReaderLoop()
 			if (_iterm2_cmd_state || _iterm2_cmd_ts) {
 				std::unique_lock<std::mutex> lock(_async_mutex);
 				_ae.output = true;
-				_async_cond.notify_all();
+				_async_cond.notify_one();
 			}
 		}
 
@@ -374,7 +374,7 @@ void TTYBackend::ReaderLoop()
 				_terminal_size_change_id = terminal_size_change_id;
 				std::unique_lock<std::mutex> lock(_async_mutex);
 				_ae.term_resized = true;
-				_async_cond.notify_all();
+				_async_cond.notify_one();
 			}
 		}
 	}
@@ -441,9 +441,9 @@ void TTYBackend::WriterThread()
 			}
 
 			tty_out.Flush();
-			tcdrain(_stdout);
 
 			if (ae.go_background) {
+				tcdrain(_stdout);
 				gone_background = true;
 				break;
 			}
@@ -698,7 +698,7 @@ void TTYBackend::OnConsoleOutputUpdated(const SMALL_RECT *areas, size_t count)
 {
 	std::unique_lock<std::mutex> lock(_async_mutex);
 	_ae.output = true;
-	_async_cond.notify_all();
+	_async_cond.notify_one();
 }
 
 void TTYBackend::OnConsoleOutputResized()
@@ -710,7 +710,7 @@ void TTYBackend::OnConsoleOutputTitleChanged()
 {
 	std::unique_lock<std::mutex> lock(_async_mutex);
 	_ae.title_changed = true;
-	_async_cond.notify_all();
+	_async_cond.notify_one();
 }
 
 void TTYBackend::OnConsoleOutputWindowMoved(bool absolute, COORD pos)
@@ -945,7 +945,7 @@ void TTYBackend::WaitForOutputIdleOrDead(std::unique_lock<std::mutex> &lock)
 			++_ae_idle_wait_request;
 		} while (_ae_idle_wait_request == _ae_idle_wait_confirm);
 		do {
-			_async_cond.notify_all();
+			_async_cond.notify_one();
 			_ae_idle_wait_cond.wait(lock);
 		} while (!_deadio && _ae_idle_wait_request != _ae_idle_wait_confirm);
 	}
@@ -986,7 +986,7 @@ void TTYBackend::OSC52SetClipboard(const char *text)
 	std::unique_lock<std::mutex> lock(_async_mutex);
 	_osc52clip = text;
 	_ae.osc52clip_set = true;
-	_async_cond.notify_all();
+	_async_cond.notify_one();
 }
 
 bool TTYBackend::Far2lInteract(StackSerializer &stk_ser, bool wait)
@@ -1002,7 +1002,7 @@ bool TTYBackend::Far2lInteract(StackSerializer &stk_ser, bool wait)
 		std::unique_lock<std::mutex> lock(_async_mutex);
 		_far2l_interacts_queued.emplace_back(pfi);
 		_ae.far2l_interact = 1;
-		_async_cond.notify_all();
+		_async_cond.notify_one();
 	}
 
 	if (!wait)
@@ -1223,7 +1223,7 @@ void TTYBackend::OnKittyGraphicsResponse(const std::string &s)
 	std::lock_guard<std::mutex> lock(_async_mutex);
 	if (_images_kitty_status == IKS_PROBING) {
 		_ae.images_probe_del = true;
-		_async_cond.notify_all();
+		_async_cond.notify_one();
 	}
 	_images_kitty_status = IKS_SUPPORTED;
 	_images_kitty_status_cond.notify_all();
@@ -1348,7 +1348,7 @@ bool TTYBackend::OnConsoleBackgroundMode(bool TryEnterBackgroundMode)
 	if (TryEnterBackgroundMode) {
 		std::unique_lock<std::mutex> lock(_async_mutex);
 		_ae.go_background = true;
-		_async_cond.notify_all();
+		_async_cond.notify_one();
 	}
 
 	return true;
@@ -1490,7 +1490,7 @@ bool TTYBackend::CheckKittyImagesSupport()
 			fprintf(stderr, "%s: probing\n", __FUNCTION__);
 			_images_kitty_status = IKS_PROBING;
 			_ae.images_probe = true;
-			_async_cond.notify_all();
+			_async_cond.notify_one();
 		} else if (GetProcessUptimeMSec() - wait_begin >= reply_timeout_msec) {
 			fprintf(stderr, "%s: kitty reply wait timed out\n", __FUNCTION__);
 			_images_kitty_status = IKS_UNSUPPORTED;
@@ -1572,7 +1572,7 @@ bool TTYBackend::OnSetConsoleImage(const char *id, DWORD64 flags, const SMALL_RE
 
 	std::lock_guard<std::mutex> lock(_async_mutex);
 	_ae.images_changed = true;
-	_async_cond.notify_all(); // Wake up the writer thread
+	_async_cond.notify_one(); // Wake up the writer thread
 	return true;
 }
 
@@ -1634,7 +1634,7 @@ bool TTYBackend::OnDeleteConsoleImage(const char *id)
 
 	std::lock_guard<std::mutex> lock(_async_mutex);
 	_ae.images_changed = true;
-	_async_cond.notify_all(); // Wake up the writer thread
+	_async_cond.notify_one(); // Wake up the writer thread
 	return true;
 }
 

--- a/far2l/src/console/interf.cpp
+++ b/far2l/src/console/interf.cpp
@@ -794,6 +794,9 @@ void vmprintf(const wchar_t *fmt, ...)
 
 void SetColor(uint64_t Color, bool ApplyToConsole)
 {
+	if (CurColor == Color)
+		return;
+
 	CurColor = Color;
 
 	if (ApplyToConsole) {
@@ -803,7 +806,12 @@ void SetColor(uint64_t Color, bool ApplyToConsole)
 
 void SetFarColor(uint16_t Color, bool ApplyToConsole)
 {
-	CurColor = FarColorToReal(Color);
+	uint64_t RealColor = FarColorToReal(Color);
+
+	if (CurColor == RealColor)
+		return;
+
+	CurColor = RealColor;
 
 	if (ApplyToConsole) {
 		Console.SetTextAttributes(CurColor);

--- a/far2l/src/console/keyboard.cpp
+++ b/far2l/src/console/keyboard.cpp
@@ -505,7 +505,7 @@ static DWORD GetInputRecordInner(INPUT_RECORD *rec, bool ExcludeMacro, bool Proc
 
 	if (LIKELY(FrameManager) && FrameManager->RegularIdleWantersCount()) {
 		clock_t now = GetProcessUptimeMSec();
-		if (now - sLastIdleDelivered >= 1000) {
+		if (now - sLastIdleDelivered >= 250) {
 			LastEventIdle = TRUE;
 			memset(rec, 0, sizeof(*rec));
 			rec->EventType = KEY_EVENT;
@@ -698,7 +698,7 @@ static DWORD GetInputRecordInner(INPUT_RECORD *rec, bool ExcludeMacro, bool Proc
 		ScrBuf.Flush();
 
 		static DWORD sLastIdleWaitConsoleInput = 0;
-		DWORD WaitConsoleInputTmout = (sLastIdleWaitConsoleInput < 5) ? 10 : 160;
+		DWORD WaitConsoleInputTmout = (sLastIdleWaitConsoleInput < 5) ? 10 : 50;
 //		fprintf(stderr, " WaitConsoleInputTmout=%u\n", WaitConsoleInputTmout);
 		if (WINPORT(WaitConsoleInput)(NULL, WaitConsoleInputTmout)) {
 			sLastIdleWaitConsoleInput = 0;

--- a/far2l/src/mix/StrCells.cpp
+++ b/far2l/src/mix/StrCells.cpp
@@ -114,13 +114,21 @@ void StrCellsTruncateLeft(wchar_t *pwz, size_t &n, size_t ng)
 		return;
 	}
 
-	for (size_t ofs = rpl.len; ofs < n; ++ofs) {
-		if (!CharClasses::IsXxxfix(pwz[ofs]) && StrCellsCount(pwz + ofs, n - ofs) + rpl.len <= ng) {
+	// Compute how many cells to skip from left: need tail_cells + rpl.len <= ng
+	// tail_cells = vl - skipped_cells, so skipped_cells >= vl - (ng - rpl.len)
+	const size_t target_tail_cells = ng - rpl.len;
+	// Walk from left, accumulating cells to skip
+	size_t skipped_cells = 0;
+	for (size_t ofs = 0; ofs < n; ++ofs) {
+		if (ofs >= rpl.len && !CharClasses::IsXxxfix(pwz[ofs]) && (vl - skipped_cells) <= target_tail_cells) {
 			n-= ofs;
 			wmemmove(pwz + rpl.len, pwz + ofs, n);
 			n+= rpl.len;
-			wmemcpy(pwz, rpl.wz, rpl.len); //…
+			wmemcpy(pwz, rpl.wz, rpl.len);
 			return;
+		}
+		if (!CharClasses::IsXxxfix(pwz[ofs])) {
+			skipped_cells+= CharClasses::IsFullWidth(&pwz[ofs]) ? 2 : 1;
 		}
 	}
 	wcsncpy(pwz, rpl.wz, ng);
@@ -173,17 +181,27 @@ void StrCellsTruncateCenter(wchar_t *pwz, size_t &n, size_t ng)
 		++cut_end;
 	}
 
-	while (StrCellsCount(pwz, cut_start) + StrCellsCount(pwz + cut_end, n - cut_end) + rpl.len > ng) {
+	// Cache cell counts to avoid O(n) recomputation per iteration
+	size_t left_cells = StrCellsCount(pwz, cut_start);
+	size_t right_cells = StrCellsCount(pwz + cut_end, n - cut_end);
+
+	while (left_cells + right_cells + rpl.len > ng) {
 		if (cut_start > 0) {
 			--cut_start;
+			// Update left_cells incrementally
+			if (!CharClasses::IsXxxfix(pwz[cut_start]))
+				left_cells-= CharClasses::IsFullWidth(&pwz[cut_start]) ? 2 : 1;
 			while (cut_start > 0 && CharClasses::IsXxxfix(pwz[cut_start])) {
 				--cut_start;
 			}
-			if (StrCellsCount(pwz, cut_start) + StrCellsCount(pwz + cut_end, n - cut_end) + rpl.len <= ng) {
+			if (left_cells + right_cells + rpl.len <= ng) {
 				break;
 			}
 		}
 		if (cut_end < n) {
+			// Update right_cells incrementally
+			if (!CharClasses::IsXxxfix(pwz[cut_end]))
+				right_cells-= CharClasses::IsFullWidth(&pwz[cut_end]) ? 2 : 1;
 			++cut_end;
 			while (cut_end < n && CharClasses::IsXxxfix(pwz[cut_end])) {
 				++cut_end;

--- a/far2l/src/mix/strmix.cpp
+++ b/far2l/src/mix/strmix.cpp
@@ -49,15 +49,16 @@ FARString &FormatNumber(const wchar_t *Src, FARString &strDest, int NumDigits)
 	if (part == Src) {
 		result = L"0";
 	} else {
-		size_t i = 0;
-		for (;;) {
-			--part;
-			result.Insert(0, *part);
-			if (part == Src)
-				break;
-			++i;
-			if ((i % 3) == 0)
-				result.Insert(0, L' ');
+		// Build digits in forward order to avoid O(n²) Insert(0,...)
+		const size_t digits = (size_t)(part - Src);
+		const size_t separators = digits > 1 ? (digits - 1) / 3 : 0;
+		result.Reserve(digits + separators + 16);
+		for (const wchar_t *p = Src; p < part; ++p) {
+			size_t remaining = (size_t)(part - p); // chars remaining including current
+			// Insert separator before current digit if it starts a new group of 3
+			if (p != Src && remaining % 3 == 0)
+				result.Append(L' ');
+			result.Append(*p);
 		}
 	}
 	if (dot) {
@@ -465,10 +466,16 @@ FARString FixedSizeStr(FARString str, size_t Cells, bool RAlign, bool TruncateCe
 		else
 			TruncStr(str, Cells);
 	} else if (InitialStrCells < Cells) {
-		if (RAlign)
-			str.Insert(0, L' ', Cells - InitialStrCells);
-		else
+		if (RAlign) {
+			// Build padded string forward to avoid O(n) Insert(0,...)
+			FARString padded;
+			padded.Reserve(Cells + 1);
+			padded.Append(L' ', Cells - InitialStrCells);
+			padded.Append(str);
+			str = std::move(padded);
+		} else {
 			str.Append(L' ', Cells - InitialStrCells);
+		}
 	}
 	return str;
 }

--- a/far2l/src/panels/flshow.cpp
+++ b/far2l/src/panels/flshow.cpp
@@ -559,10 +559,11 @@ int FileList::ConvertName(FARString &strDest, const wchar_t *SrcName, int MaxLen
 		int RightAlign, int ShowStatus, DWORD FileAttr, FileListItem *fi)
 {
 	if (ShowStatus && (FileAttr & FILE_ATTRIBUTE_REPARSE_POINT) != 0) {
-		FARString strTemp;
-		if (ResolveSymlink(strTemp, SrcName, fi)) {
-			strTemp.Insert(0, L" ->");
-			strTemp.Insert(0, SrcName);
+		FARString strTarget;
+		if (ResolveSymlink(strTarget, SrcName, fi)) {
+			FARString strTemp(SrcName);
+			strTemp.Append(L" -> ");
+			strTemp.Append(strTarget);
 			return ConvertName(strDest, strTemp, MaxLength, RightAlign, ShowStatus,
 					FileAttr & (~(DWORD)FILE_ATTRIBUTE_REPARSE_POINT), fi);
 		}

--- a/utils/src/ThreadedWorkQueue.cpp
+++ b/utils/src/ThreadedWorkQueue.cpp
@@ -85,13 +85,15 @@ void ThreadedWorkQueue::WorkerThreadProc()
 			_working--;
 			if (_notify_on_done) {
 				_notify_on_done = false;
-				_cond.notify_all();
+				_cond.notify_one();
 			}
 			twi = nullptr;
 
-		} catch (std::exception &e) { // OOM? retry in one second til memory will appear
+		} catch (std::exception &e) { // OOM? retry after releasing lock to avoid blocking other workers
 			fprintf(stderr, "%s: %s", __FUNCTION__, e.what());
+			lock.unlock();
 			sleep(1);
+			lock.lock();
 		}
 
 		if (_stopping) {


### PR DESCRIPTION
Input latency:
- Reduce idle WaitConsoleInput timeout from 160ms to 50ms
- Increase KEY_IDLE delivery frequency from 1000ms to 250ms

Rendering:
- Cache color state in SetColor/SetFarColor to skip redundant Console.SetTextAttributes() calls when color is unchanged
- Build symlink display string forward (Append) instead of double Insert(0,...) in ConvertName

O(n²) → O(n) string operations:
- FormatNumber: build digit string left-to-right with separator logic instead of Insert(0, char) in reverse loop
- FixedSizeStr: build right-aligned string forward (spaces then content) instead of Insert(0, spaces) shifting existing content
- StrCellsTruncateLeft: incremental cell counting instead of calling StrCellsCount() per offset
- StrCellsTruncateCenter: cache left/right cell counts and update incrementally instead of recomputing O(n) per iteration

TTY backend:
- Replace tcdrain() on every writer cycle with conditional call only before going to background
- Replace 12 notify_all() calls on _async_cond with notify_one() since WriterThread is the sole waiter; keep notify_all() only for shutdown paths (deadio, exiting)

NetRocks threading:
- Replace ProgressStateUpdate 1-second usleep polling loop with condition_variable wait_for(500ms), notified on pause/abort state changes
- Add std::condition_variable to ProgressState and notify at all 5 sites that modify paused/aborting flags

ThreadedWorkQueue:
- Release mutex before sleep(1) during OOM recovery to avoid blocking all worker threads
- Use notify_one() instead of notify_all() for completion