### PR TITLE
Avoid redrawing background shadow on progress message updates

### DIFF
--- a/far2l/src/dirinfo.cpp
+++ b/far2l/src/dirinfo.cpp
@@ -52,7 +52,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "wakeful.hpp"
 #include "config.hpp"
 
-static void DrawGetDirInfoMsg(const wchar_t *Title, const wchar_t *Name, const UINT64 Size)
+static void DrawGetDirInfoMsg(const wchar_t *Title, const wchar_t *Name, const UINT64 Size, DWORD Flags = 0)
 {
 	if (Title == nullptr || Name == nullptr) {
 		return;
@@ -61,7 +61,7 @@ static void DrawGetDirInfoMsg(const wchar_t *Title, const wchar_t *Name, const U
 	FARString strSize;
 	FileSizeToStr(strSize, Size, 8, COLUMN_FLOATSIZE | COLUMN_COMMAS);
 	RemoveLeadingSpaces(strSize);
-	Message(0, 0, Title, Msg::ScanningFolder, Name, strSize);
+	Message(Flags, 0, Title, Msg::ScanningFolder, Name, strSize);
 	PreRedrawItem preRedrawItem = PreRedraw.Peek();
 	preRedrawItem.Param.Param1 = (void *)Title;
 	preRedrawItem.Param.Param2 = (void *)Name;
@@ -122,6 +122,7 @@ int GetDirInfo(const wchar_t *Title, const wchar_t *DirName, uint32_t &DirCount,
 	const bool use_filter = (Flags & GETDIRINFO_USEFILTER) != 0;
 	const bool scan_symlinks = ScTree.IsSymlinksScanEnabled();
 	const bool can_break = !CtrlObject->Macro.IsExecuting() && !WinPortTesting();
+	bool ProgressShown = false;
 
 	struct stat s = {0};
 	if (sdc_stat(Wide2MB(DirName).c_str(), &s) == 0) {
@@ -171,7 +172,9 @@ int GetDirInfo(const wchar_t *Title, const wchar_t *DirName, uint32_t &DirCount,
 				MsgWaitTime = 500;
 				OldTitle.Set(L"%ls %ls", Msg::ScanningFolder.CPtr(), ShowDirName);	// покажем заголовок консоли
 				SetCursorType(FALSE, 0);
-				DrawGetDirInfoMsg(Title, ShowDirName, FileSize);
+				DrawGetDirInfoMsg(Title, ShowDirName, FileSize,
+					ProgressShown ? MSG_KEEPBACKGROUND : 0);
+			ProgressShown = true;
 			}
 		}
 

--- a/far2l/src/editor.cpp
+++ b/far2l/src/editor.cpp
@@ -4934,6 +4934,7 @@ BOOL Editor::Search(int Next)
 		CurPtr = CurLine;
 		DWORD StartTime = WINPORT(GetTickCount)();
 		int StartLine = NumLine;
+		bool ProgressShown = false;
 		wakeful W;
 
 		while (CurPtr) {
@@ -4947,7 +4948,9 @@ BOOL Editor::Search(int Next)
 				SetCursorType(FALSE, -1);
 				int Total = ReverseSearch ? StartLine : NumLastLine - StartLine;
 				int Current = abs(NewNumLine - StartLine);
-				EditorShowMsg(Msg::EditSearchTitle, Msg::EditSearchingFor, strMsgStr, ToPercent64(Current, Total));
+				EditorShowMsg(Msg::EditSearchTitle, Msg::EditSearchingFor, strMsgStr, ToPercent64(Current, Total),
+						ProgressShown ? MSG_KEEPBACKGROUND : 0);
+				ProgressShown = true;
 
 				if (CheckForEscSilent()) {
 					if (ConfirmAbortOp()) {
@@ -7941,7 +7944,7 @@ void Editor::SetSavePosMode(int SavePos, int SaveShortPos)
 		EdOpt.SaveShortPos = SaveShortPos;
 }
 
-void Editor::EditorShowMsg(const wchar_t *Title, const wchar_t *Msg, const wchar_t *Name, int Percent)
+void Editor::EditorShowMsg(const wchar_t *Title, const wchar_t *Msg, const wchar_t *Name, int Percent, DWORD Flags)
 {
 	FARString strProgress;
 
@@ -7962,7 +7965,7 @@ void Editor::EditorShowMsg(const wchar_t *Title, const wchar_t *Msg, const wchar
 		strProgress+= strTmp;
 	}
 
-	Message(0, 0, Title, Msg, Name, strProgress.IsEmpty() ? nullptr : strProgress.CPtr());
+	Message(Flags, 0, Title, Msg, Name, strProgress.IsEmpty() ? nullptr : strProgress.CPtr());
 	PreRedrawItem preRedrawItem = PreRedraw.Peek();
 	preRedrawItem.Param.Param1 = (void *)Title;
 	preRedrawItem.Param.Param2 = (void *)Msg;

--- a/far2l/src/editor.hpp
+++ b/far2l/src/editor.hpp
@@ -322,7 +322,7 @@ void GoToVisualLine(int VisualLine);
 	void VPaste(wchar_t *ClipText);
 	void VBlockShift(int Left);
 	Edit *GetStringByNumber(int DestLine);
-	static void EditorShowMsg(const wchar_t *Title, const wchar_t *Msg, const wchar_t *Name, int Percent);
+	static void EditorShowMsg(const wchar_t *Title, const wchar_t *Msg, const wchar_t *Name, int Percent, DWORD Flags = 0);
 
 	int SetBookmark(DWORD Pos);
 	int GotoBookmark(DWORD Pos);

--- a/far2l/src/fileedit.cpp
+++ b/far2l/src/fileedit.cpp
@@ -1525,6 +1525,7 @@ int FileEditor::LoadFile(const wchar_t *Name, int &UserBreak)
 	UINT64 FileSize = 0;
 	EditFile.GetSize(FileSize);
 	DWORD StartTime = WINPORT(GetTickCount)();
+	bool ProgressShown = false;
 
 	// Enable bulk loading mode for faster file loading
 	m_editor->BeginBulkLoad();
@@ -1554,7 +1555,9 @@ int FileEditor::LoadFile(const wchar_t *Name, int &UserBreak)
 					Percent = 100;
 				}
 			}
-			Editor::EditorShowMsg(Msg::EditTitle, Msg::EditReading, Name, Percent);
+			Editor::EditorShowMsg(Msg::EditTitle, Msg::EditReading, Name, Percent,
+					ProgressShown ? MSG_KEEPBACKGROUND : 0);
+			ProgressShown = true;
 
 			if (CheckForEscSilent()) {
 				if (ConfirmAbortOp()) {
@@ -1641,7 +1644,7 @@ bool FileEditor::ReloadFile(const wchar_t *Name)
 
 // TextFormat и Codepage используются ТОЛЬКО, если bSaveAs = true!
 void FileEditor::SaveContent(const wchar_t *Name, BaseContentWriter *Writer, bool bSaveAs, int TextFormat,
-		UINT codepage, bool AddSignature, int Phase)
+		UINT codepage, bool AddSignature, int Phase, bool &ProgressShown)
 {
 	DWORD dwSignature = 0;
 	DWORD SignLength = 0;
@@ -1688,12 +1691,14 @@ void FileEditor::SaveContent(const wchar_t *Name, BaseContentWriter *Writer, boo
 
 		if (CurTime - StartTime > RedrawTimeout) {
 			StartTime = CurTime;
+			DWORD MsgFlags = ProgressShown ? MSG_KEEPBACKGROUND : 0;
+			ProgressShown = true;
 			if (Phase == 0)
 				Editor::EditorShowMsg(Msg::EditTitle, Msg::EditSaving, Name,
-						(int)(LineNumber * 50 / m_editor->NumLastLine));
+						(int)(LineNumber * 50 / m_editor->NumLastLine), MsgFlags);
 			else
 				Editor::EditorShowMsg(Msg::EditTitle, Msg::EditSaving, Name,
-						(int)(50 + (LineNumber * 50 / m_editor->NumLastLine)));
+						(int)(50 + (LineNumber * 50 / m_editor->NumLastLine)), MsgFlags);
 		}
 
 		const wchar_t *SaveStr, *EndSeq;
@@ -1986,9 +1991,10 @@ int FileEditor::SaveFile(const wchar_t *Name, int Ask, bool bSaveAs, int TextFor
 		SetCursorType(FALSE, 0);
 		TPreRedrawFuncGuard preRedrawFuncGuard(Editor::PR_EditorShowMsg);
 
+		bool ProgressShown = false;
 		try {
 			ContentMeasurer cm;
-			SaveContent(Name, &cm, bSaveAs, TextFormat, codepage, AddSignature, 0);
+			SaveContent(Name, &cm, bSaveAs, TextFormat, codepage, AddSignature, 0, ProgressShown);
 
 			try {
 				File EditFile;
@@ -2013,7 +2019,7 @@ int FileEditor::SaveFile(const wchar_t *Name, int Ask, bool bSaveAs, int TextFor
 				}
 
 				ContentSaver cs(EditFile);
-				SaveContent(Name, &cs, bSaveAs, TextFormat, codepage, AddSignature, 1);
+				SaveContent(Name, &cs, bSaveAs, TextFormat, codepage, AddSignature, 1, ProgressShown);
 				cs.Flush();
 
 				EditFile.SetEnd();

--- a/far2l/src/fileedit.hpp
+++ b/far2l/src/fileedit.hpp
@@ -187,7 +187,7 @@ private:
 	bool ReloadFile(const wchar_t *Name);
 	// TextFormat, Codepage и AddSignature используются ТОЛЬКО, если bSaveAs = true!
 	void SaveContent(const wchar_t *Name, BaseContentWriter *Writer, bool bSaveAs, int TextFormat,
-			UINT codepage, bool AddSignature, int Phase);
+			UINT codepage, bool AddSignature, int Phase, bool &ProgressShown);
 	int SaveFile(const wchar_t *Name, int Ask, bool bSaveAs, int TextFormat = 0, UINT Codepage = CP_UTF8,
 			bool AddSignature = false);
 	void SetTitle(const wchar_t *Title);

--- a/far2l/src/panels/flupdate.cpp
+++ b/far2l/src/panels/flupdate.cpp
@@ -102,9 +102,9 @@ void FileList::UpdateIfRequired()
 	}
 }
 
-void ReadFileNamesMsg(const wchar_t *Msg)
+void ReadFileNamesMsg(const wchar_t *Msg, DWORD Flags = 0)
 {
-	Message(0, 0, Msg::ReadingTitleFiles, Msg);
+	Message(Flags, 0, Msg::ReadingTitleFiles, Msg);
 	PreRedrawItem preRedrawItem = PreRedraw.Peek();
 	preRedrawItem.Param.Param1 = (void *)Msg;
 	PreRedraw.SetParam(preRedrawItem.Param);
@@ -233,6 +233,7 @@ void FileList::ReadFileNames(int KeepSelection, int IgnoreVisible, int DrawMessa
 	CachedFileGroupLookup cached_groups;
 
 	DWORD StartTime = WINPORT(GetTickCount)();
+	bool ProgressShown = false;
 
 	while (Find.Get(fdata)) {
 		FindErrorCode = WINPORT(GetLastError)();
@@ -309,7 +310,9 @@ void FileList::ReadFileNames(int KeepSelection, int IgnoreVisible, int DrawMessa
 					strReadMsg.Format(Msg::ReadingFiles, ListData.Count());
 
 					if (DrawMessage) {
-						ReadFileNamesMsg(strReadMsg);
+						ReadFileNamesMsg(strReadMsg,
+								ProgressShown ? MSG_KEEPBACKGROUND : 0);
+						ProgressShown = true;
 					} else {
 						TruncStr(strReadMsg, TitleLength - 2);
 						int MsgLength = (int)strReadMsg.GetLength();


### PR DESCRIPTION
Use MSG_KEEPBACKGROUND on subsequent progress Message() calls to
prevent re-darkening the background on every update. This fixes
visible flicker during:
- Directory size calculation (F3)
- Editor file loading (F4 on large files)
- Editor file saving
- Editor search with progress bar
- Panel directory reading progress

Track whether progress message has been shown with a bool flag
in each loop, pass MSG_KEEPBACKGROUND on second and subsequent
calls. PreRedraw callbacks are left unchanged (flags=0) since
they run after full screen repaint where the popup must be fully
redrawn including border and shadow.