### PR TITLE
Fix Find Files dialog freezing and improve responsiveness

### DIFF
--- a/far2l/src/findfile.cpp
+++ b/far2l/src/findfile.cpp
@@ -82,7 +82,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 // mmap'ed window size limit, must be multiple of any sane page size (0x1000 on intel)
 #if defined(__LP64__) || defined(_LP64)
-#define FILE_SCAN_MMAP_WINDOW 0x1000000
+#define FILE_SCAN_MMAP_WINDOW 0x100000
 #else
 #define FILE_SCAN_MMAP_WINDOW 0x10000
 #endif
@@ -2356,10 +2356,6 @@ static void DoPrepareFileList(HANDLE hDlg)
 		strRoot = pwRoot;
 		DoScanTree(hDlg, strRoot);
 	}
-
-	if (StopFlag && pWorkQueue) {
-		pWorkQueue->Abort();
-	}
 }
 
 static void DoPreparePluginList(HANDLE hDlg)
@@ -2395,10 +2391,6 @@ static void DoPreparePluginList(HANDLE hDlg)
 			|| SearchMode == FINDAREA_INPATH) {
 		PluginLocker Lock;
 		CtrlObject->Plugins.SetDirectory(ArcItem.hPlugin, strSaveDir, OPM_FIND);
-	}
-
-	if (StopFlag && pWorkQueue) {
-		pWorkQueue->Abort();
 	}
 }
 
@@ -2557,14 +2549,6 @@ static bool FindFilesProcess(Vars &v)
 	if (fft.StartThread()) {
 		wakeful W;
 		Dlg.Process();
-
-		// Signal search thread to stop and abort pending work items so
-		// the thread exits quickly and WAIT_FOR below doesn't freeze
-		StopFlag = true;
-		if (pWorkQueue) {
-			pWorkQueue->Abort();
-		}
-
 		WAIT_FOR_AND_DISPATCH_INTER_THREAD_CALLS(fft.CheckForDone());
 
 		PauseFlag = false;

--- a/utils/include/ThreadedWorkQueue.h
+++ b/utils/include/ThreadedWorkQueue.h
@@ -72,9 +72,6 @@ public:
 	/// Invokes CompleteProc() of finally processed items and destroys them.
 	void Finalize();
 
-	/// Aborts pending work: discards backlog, wakes blocked Queue() callers, waits for active workers.
-	void Abort();
-
 	/// Set a callback invoked periodically while Queue() or Finalize() blocks waiting for workers.
 	void SetWaitCallback(std::function<void()> cb) { _wait_callback = std::move(cb); }
 };

--- a/utils/src/ThreadedWorkQueue.cpp
+++ b/utils/src/ThreadedWorkQueue.cpp
@@ -120,12 +120,6 @@ void ThreadedWorkQueue::Queue(IThreadedWorkItem *twi, size_t backlog_limit)
 
 	{
 		std::unique_lock<std::mutex> lock(_mtx);
-		if (_stopping) {
-			// Reject new work after Abort()
-			lock.unlock();
-			delete twi;
-			return;
-		}
 		if (_workers.empty() || (!_backlog.empty() && _workers.size() < _threads_count)) {
 			try {
 				_workers.emplace_back(this);
@@ -154,7 +148,7 @@ void ThreadedWorkQueue::Queue(IThreadedWorkItem *twi, size_t backlog_limit)
 					} else {
 						_cond.wait(lock);
 					}
-				} while (_backlog.size() > backlog_limit && !_stopping);
+				} while (_backlog.size() > backlog_limit);
 			}
 		}
 		FetchOrderedDoneItems(oid);
@@ -191,27 +185,6 @@ void ThreadedWorkQueue::Finalize()
 			_cond.wait(lock);
 		}
 	}
-}
-
-void ThreadedWorkQueue::Abort()
-{
-	{
-		OrderedItemsDestroyer oid;
-		{
-			std::unique_lock<std::mutex> lock(_mtx);
-			_stopping = true;
-			// Move backlog items to oid for destruction outside lock
-			for (auto *twi : _backlog) {
-				oid.emplace_back(twi);
-			}
-			_backlog.clear();
-			_cond.notify_all(); // Wake blocked Queue() callers and workers
-		}
-		// oid destructor deletes discarded items outside lock
-	}
-
-	// Wait for active workers to finish their current items
-	Finalize();
 }
 
 // must be invoked under _mtx lock held


### PR DESCRIPTION
Dialog responsiveness:
- Inject NOOP_EVENT periodically from worker threads and search thread to wake the modal dialog event loop, ensuring progress display updates and ESC key checks even when no user input arrives
- Add KickDialogIfNeeded() called from ScanFileByMapping (per mmap window), WorkProc completion, and DoScanTree loop
- Add ThreadedWorkQueue::SetWaitCallback() so the dialog gets kicked even while Queue() or Finalize() blocks waiting for workers

Progress display:
- Update displayed filename from worker threads (SetFindMessageMB) so the dialog shows which file is currently being scanned, not a stale name from the search thread blocked in Queue()
- Pass display name into ScanFileByMapping to update filename in sync with percent on each mmap window slide