### PR TITLE
fix: IsMouseButtonPressed больше не удаляет события клавиатуры

### DIFF
--- a/far2l/src/console/keyboard.cpp
+++ b/far2l/src/console/keyboard.cpp
@@ -441,11 +441,15 @@ unsigned int WINAPI InputRecordToKey(const INPUT_RECORD *r)
 	return KEY_NONE;
 }
 
+
 DWORD IsMouseButtonPressed()
 {
 	INPUT_RECORD rec;
-
 	if (PeekInputRecord(&rec)) {
+		// If it's not a mouse event — don't read it!
+		if (rec.EventType != MOUSE_EVENT) {
+			return MouseButtonState;
+		}
 		GetInputRecord(&rec);
 	}
 	// IsMouseButtonPressed used within loops, so lets sleep to avoid CPU hogging in that loops
@@ -453,6 +457,7 @@ DWORD IsMouseButtonPressed()
 	WINPORT(WaitConsoleInput)(NULL, 10);
 	return MouseButtonState;
 }
+
 
 static DWORD KeyMsClick2ButtonState(DWORD Key, DWORD &Event)
 {

--- a/far2l/src/fileedit.cpp
+++ b/far2l/src/fileedit.cpp
@@ -2175,18 +2175,15 @@ void FileEditor::ResizeConsole()
 	m_editor->PrepareResizedConsole();
 }
 
+
 int FileEditor::ProcessEditorInput(INPUT_RECORD *Rec)
 {
-        static thread_local bool in_progress = false;
-        if (in_progress)
-            return FALSE;
-
-        in_progress = true;
-        int RetCode = CtrlObject->Plugins.ProcessEditorInput(Rec);
-        in_progress = false;
-        return RetCode;
-
+	int RetCode;
+	CtrlObject->Plugins.CurEditor = this;
+	RetCode = CtrlObject->Plugins.ProcessEditorInput(Rec);
+	return RetCode;
 }
+
 
 void FileEditor::SetPluginTitle(const wchar_t *PluginTitle)
 {


### PR DESCRIPTION
## Проблема

В терминале Kitty при печати в редакторе far2l случайным образом пропадали некоторые буквы (например, слово «слепой» превращалось в «се» или «лй»). Логирование ReadInput показывало, что все нажатия клавиш читаются, но часть символов не доходит до редактора.

## Причина

Терминал Kitty отправляет особые escape-последовательности, которые far2l может ошибочно интерпретировать как события мыши. Это приводило к вызову `IsMouseButtonPressed()` в моменты, когда в очереди ввода находились обычные клавиатурные события.

Функция `IsMouseButtonPressed()` (из `keyboard.cpp`) имела дефект: она вызывала `PeekInputRecord()`, а затем безусловно вызывала `GetInputRecord()` для *любого* ожидающего события, после чего удаляла его из очереди. Даже если это было событие клавиатуры (`KEY_EVENT`), оно терялось навсегда и никогда не доходило до редактора.

## Решение

В `IsMouseButtonPressed()` добавлена проверка типа события:

```cpp
if (rec.EventType != MOUSE_EVENT) {
    return MouseButtonState;  // не читаем и не удаляем событие
}
GetInputRecord(&rec);         // читаем только настоящее мышиное событие
```

Теперь функция забирает из очереди исключительно события типа MOUSE_EVENT. Клавиатурные события остаются нетронутыми и успешно обрабатываются основным циклом far2l.

Также вернул своё прошлое изменение в ProcessEditorInput. Обнаружил, что сломалось автодополнение в редакторе. Вернул, как было: автодополнение работает. И теперь не съедаются буквы при работе через kitty. 