### PR TITLE
[WIP] Trying to fix broken paste and OSC52 clipboard initialization.

### DIFF
--- a/WinPort/src/Backend/TTY/OSC52ClipboardBackend.cpp
+++ b/WinPort/src/Backend/TTY/OSC52ClipboardBackend.cpp
@@ -9,7 +9,7 @@ OSC52ClipboardBackend::OSC52ClipboardBackend(IOSC52Interactor *interactor) :
 
 void *OSC52ClipboardBackend::OnClipboardSetData(UINT format, void *data)
 {
-	if (format == CF_UNICODETEXT) {
+	if (format == CF_UNICODETEXT && data) {
 		std::string str;
 		Wide2MB((const wchar_t *)data, WINPORT(ClipboardSize)(data) / sizeof(wchar_t), str);
 		_interactor->OSC52SetClipboard(str.c_str());

--- a/WinPort/src/Backend/TTY/TTYBackend.cpp
+++ b/WinPort/src/Backend/TTY/TTYBackend.cpp
@@ -1265,26 +1265,28 @@ void TTYBackend::OnUsingExtension(char extension)
 	}
 }
 
-void TTYBackend::OnInspectKeyEvent(KEY_EVENT_RECORD &event)
+void TTYBackend::OnInspectKeyEvent(KEY_EVENT_RECORD &event, bool fast)
 {
 	bool in_kernel = 0;
-	// In kernel console use kernel control keys info even if using TTY|X for clipboard
-	#if defined(__linux__) || defined(__FreeBSD__) || defined(__DragonFly__)
-		int kd_mode;
-		#if defined(__linux__)
-		if (ioctl(_stdin, KDGETMODE, &kd_mode) == 0) {
-		#else
-		if (ioctl(_stdin, KDGKBMODE, &kd_mode) == 0) {
+	if (!fast) {
+		// In kernel console use kernel control keys info even if using TTY|X for clipboard
+		#if defined(__linux__) || defined(__FreeBSD__) || defined(__DragonFly__)
+			int kd_mode;
+			#if defined(__linux__)
+			if (ioctl(_stdin, KDGETMODE, &kd_mode) == 0) {
+			#else
+			if (ioctl(_stdin, KDGKBMODE, &kd_mode) == 0) {
+			#endif
+				in_kernel = 1;
+			}
 		#endif
-			in_kernel = 1;
+
+		if (_ttyx && !_using_extension && !in_kernel) {
+			_ttyx->InspectKeyEvent(event);
+
+		} else {
+			event.dwControlKeyState|= QueryControlKeys();
 		}
-	#endif
-
-	if (_ttyx && !_using_extension && !in_kernel) {
-		_ttyx->InspectKeyEvent(event);
-
-	} else {
-		event.dwControlKeyState|= QueryControlKeys();
 	}
 
 	if (!event.wVirtualKeyCode) {

--- a/WinPort/src/Backend/TTY/TTYBackend.h
+++ b/WinPort/src/Backend/TTY/TTYBackend.h
@@ -176,7 +176,7 @@ protected:
 
 	// ITTYInputSpecialSequenceHandler
 	virtual void OnUsingExtension(char extension);
-	virtual void OnInspectKeyEvent(KEY_EVENT_RECORD &event);
+	virtual void OnInspectKeyEvent(KEY_EVENT_RECORD &event, bool fast = false);
 	virtual void OnFocusChange(bool focused);
 	virtual void OnFar2lEvent(StackSerializer &stk_ser);
 	virtual void OnFar2lReply(StackSerializer &stk_ser);

--- a/WinPort/src/Backend/TTY/TTYInput.cpp
+++ b/WinPort/src/Backend/TTY/TTYInput.cpp
@@ -19,8 +19,8 @@ void TTYInput::PostCharEvent(wchar_t ch)
 	ir.Event.KeyEvent.wRepeatCount = 1;
 	ir.Event.KeyEvent.uChar.UnicodeChar = ch;
 
-	if (_handler && !_parser.IsBracketedPasteMode()) {
-		_handler->OnInspectKeyEvent(ir.Event.KeyEvent);
+	if (_handler) {
+		_handler->OnInspectKeyEvent(ir.Event.KeyEvent, _parser.IsBracketedPasteMode());
 	}
 
 	g_winport_con_in->Enqueue(&ir, 1);

--- a/WinPort/src/Backend/TTY/TTYInputSequenceParser.cpp
+++ b/WinPort/src/Backend/TTY/TTYInputSequenceParser.cpp
@@ -273,7 +273,7 @@ size_t TTYInputSequenceParser::ParseNChars2Key(const char *s, size_t l)
 					ir.Event.KeyEvent.uChar.UnicodeChar = wc;
 					ir.Event.KeyEvent.dwControlKeyState|= LEFT_ALT_PRESSED;
 					ir.Event.KeyEvent.bKeyDown = TRUE;
-					_handler->OnInspectKeyEvent(ir.Event.KeyEvent);
+					_handler->OnInspectKeyEvent(ir.Event.KeyEvent, _bracketed_paste_mode);
 					_ir_pending.emplace_back(ir); // g_winport_con_in->Enqueue(&ir, 1);
 					ir.Event.KeyEvent.bKeyDown = FALSE;
 					_ir_pending.emplace_back(ir); // g_winport_con_in->Enqueue(&ir, 1);
@@ -575,8 +575,7 @@ void TTYInputSequenceParser::AddPendingKeyEvent(const TTYInputKey &k)
 	ir.Event.KeyEvent.wVirtualKeyCode = k.vk;
 	ir.Event.KeyEvent.dwControlKeyState = k.control_keys | _extra_control_keys;
 	ir.Event.KeyEvent.wVirtualScanCode = WINPORT(MapVirtualKey)(k.vk,MAPVK_VK_TO_VSC);
-	if (!_bracketed_paste_mode)
-		_handler->OnInspectKeyEvent(ir.Event.KeyEvent);
+	_handler->OnInspectKeyEvent(ir.Event.KeyEvent, _bracketed_paste_mode);
 	_ir_pending.emplace_back(ir); // g_winport_con_in->Enqueue(&ir, 1);
 	ir.Event.KeyEvent.bKeyDown = FALSE;
 	_ir_pending.emplace_back(ir); // g_winport_con_in->Enqueue(&ir, 1);

--- a/WinPort/src/Backend/TTY/TTYInputSequenceParser.h
+++ b/WinPort/src/Backend/TTY/TTYInputSequenceParser.h
@@ -66,7 +66,7 @@ template <size_t N> using NChars2Key = NCharsMap<N, TTYInputKey>;
 struct ITTYInputSpecialSequenceHandler
 {
 	virtual void OnUsingExtension(char extension) = 0;
-	virtual void OnInspectKeyEvent(KEY_EVENT_RECORD &event) = 0;
+	virtual void OnInspectKeyEvent(KEY_EVENT_RECORD &event, bool fast = false) = 0;
 	virtual void OnFocusChange(bool focused) = 0;
 	virtual void OnFar2lEvent(StackSerializer &stk_ser) = 0;
 	virtual void OnFar2lReply(StackSerializer &stk_ser) = 0;

--- a/far2l/src/main.cpp
+++ b/far2l/src/main.cpp
@@ -654,6 +654,7 @@ int FarAppMain(int argc, char **argv)
 
 	InitConsole();
 	WINPORT(SetConsoleCursorBlinkTime)(NULL, Opt.CursorBlinkTime);
+	ApplyConfig();
 
 	bool cfgNeedSave = false;
 	//нужно проверить локаль до начала отрисовки интерфейса

--- a/far2l/src/main.cpp
+++ b/far2l/src/main.cpp
@@ -654,7 +654,6 @@ int FarAppMain(int argc, char **argv)
 
 	InitConsole();
 	WINPORT(SetConsoleCursorBlinkTime)(NULL, Opt.CursorBlinkTime);
-	ApplyConfig();
 
 	bool cfgNeedSave = false;
 	//нужно проверить локаль до начала отрисовки интерфейса
@@ -672,6 +671,7 @@ int FarAppMain(int argc, char **argv)
 			"Too many language messages. Need to refactor code to eliminate use of IsPtr.");
 
 	if (!Lang.Init(g_strFarPath, true, Msg::NewFileName.ID())) {
+	ApplyConfig();
 		LPCWSTR LngMsg;
 		switch (Lang.LastError()) {
 			case LERROR_BAD_FILE:


### PR DESCRIPTION
1. Update ITTYInputSpecialSequenceHandler and TTYBackend to support a 'fast' inspection mode that skips heavy syscalls/IPC during high-traffic input.

2. Implement the 'fast' logic in TTYBackend::OnInspectKeyEvent to ensure wVirtualKeyCode is always populated even during bracketed paste.

3. Update TTYInput::PostCharEvent to perform fast inspection during paste instead of skipping it entirely.

4. Call ApplyConfig() in main.cpp to ensure backend settings (like OSC52) are pushed to the TTY backend immediately at startup.

Touch #3268