### PR TITLE
Fix quickview interface hanging

### DIFF
--- a/far2l/src/console/keyboard.cpp
+++ b/far2l/src/console/keyboard.cpp
@@ -445,12 +445,13 @@ unsigned int WINAPI InputRecordToKey(const INPUT_RECORD *r)
 DWORD IsMouseButtonPressed()
 {
 	INPUT_RECORD rec;
-	if (PeekInputRecord(&rec)) {
+	if (Console.PeekInput(rec)) {
 		// If it's not a mouse event — don't read it!
-		if (rec.EventType != MOUSE_EVENT) {
-			return MouseButtonState;
+		if (rec.EventType == MOUSE_EVENT) {
+			GetInputRecord(&rec);
+		} else {
+			return 0;
 		}
-		GetInputRecord(&rec);
 	}
 	// IsMouseButtonPressed used within loops, so lets sleep to avoid CPU hogging in that loops
 	// it would be nicer to sleep inside of that loops instead, but keep to original code for now


### PR DESCRIPTION
on mouse click after #3330

Steps to reproduce: on current master WX GUI press ctrl+Q when on far2l/LICENSE.txt, then right click with mouse on the quick view panel, interface hangs in endless loop, sample stack trace below
```
Thread 3:
0   libsystem_kernel.dylib                 0x1850a350c __psynch_cvwait + 8
1   libsystem_pthread.dylib                0x1850e4128 _pthread_cond_wait + 980
2   libc++.1.dylib                         0x184ff9858 std::__1::condition_variable::wait(std::__1::unique_lock<std::__1::mutex>&) + 32
3   far2l_gui.so                           0x107d0a788 InMainCallerBase<std::__1::__bind<void (WinPortPanel::*)(bool), WinPortPanel*, bool>>::Do() + 204
4   far2l_gui.so                           0x107d06660 non-virtual thunk to WinPortPanel::OnConsoleOutputFlushDrawing() + 132
5   far2l                                  0x103047164 WINPORT_SetConsoleRepaintsDefer + 84
6   far2l                                  0x102fb0be4 ScreenBuf::Flush() + 52
7   far2l                                  0x102f9ee58 PeekInputRecord(_INPUT_RECORD*, bool) + 36
8   far2l                                  0x102f9edd4 IsMouseButtonPressed() + 40
9   far2l                                  0x102f5f7b8 Viewer::ProcessMouse(_MOUSE_EVENT_RECORD*) + 1248
10  far2l                                  0x102f924e4 QuickView::ProcessMouse(_MOUSE_EVENT_RECORD*) + 128
11  far2l                                  0x102f06eec FilePanels::ProcessMouse(_MOUSE_EVENT_RECORD*) + 76
12  far2l                                  0x102f349d0 Manager::ProcessMainLoop() + 236
13  far2l                                  0x102f35bd8 Manager::EnterMainLoop() + 48
14  far2l                                  0x102f326f0 FarAppMain(int, char**) + 5840
15  far2l_gui.so                           0x107cfeff4 WinPortAppThread::Entry() + 40
16  libwx_baseu-3.3.2.0.0.dylib            0x107ff9784 wxThreadInternal::PthreadStart(wxThread*) + 512
17  libsystem_pthread.dylib                0x1850e3c58 _pthread_start + 136
18  libsystem_pthread.dylib                0x1850dec1c thread_start + 8
```

now we return 0 to avoid looping, also streamline heavy PeekInputRecord to Console.PeekInput