### PR TITLE
SDL: workaround for opengl driver and composer in KDE Plasma

### DIFF
--- a/WinPort/src/Backend/SDL/SDLConsoleRendererImpl.hpp
+++ b/WinPort/src/Backend/SDL/SDLConsoleRendererImpl.hpp
@@ -159,7 +159,8 @@ public:
 	bool Initialize(SDL_Window *window)
 	{
 		_window = window;
-		SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "0"); // keep glyphs pixel-crisp
+		// VK: moved to SDLMain as we should setup hints prior to create first window
+		// SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "0"); // keep glyphs pixel-crisp
 		{
 			SDL_version ver{};
 			SDL_GetVersion(&ver);

--- a/WinPort/src/Backend/SDL/SDLMain.cpp
+++ b/WinPort/src/Backend/SDL/SDLMain.cpp
@@ -2518,6 +2518,9 @@ bool SDLConsoleApp::Initialize()
 		}
 	}
 
+	SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "0"); // keep glyphs pixel-crisp
+	SDL_SetHint(SDL_HINT_VIDEO_X11_NET_WM_BYPASS_COMPOSITOR, "0"); // do not touch KDE plasma
+
 	_window = SDL_CreateWindow(
 		"far2l (SDL backend)",
 		init_x,
@@ -2550,9 +2553,13 @@ bool SDLConsoleApp::Initialize()
 	if (win_state.valid) {
 		if (win_state.fullscreen) {
 			SDL_SetWindowFullscreen(_window, SDL_WINDOW_FULLSCREEN_DESKTOP);
-		} else if (win_state.maximized) {
+		} 
+		/* 
+		VK: actually we do not need this as we already have created window with last reminded size and position.
+
+		else if (win_state.maximized) {
 			SDL_MaximizeWindow(_window);
-		}
+		}*/
 	}
 
 	if (_arg.app_main) {


### PR DESCRIPTION
The problem: once the accelerated backend started, it asks KDE Plasma to switch off the kwin_x11 compositor. Result the display flickering at the start.

Actually, as there is no video player and no game, we do not need to turn off the Plasma compositing at the start.

So, I've added hint for SDL to not play with kwin.

In addition, I've disabled unexpected SDL_MaximizeWindow as we already creating the window with the appropriate size.