### PR TITLE
Some editor fixes

### DIFF
--- a/far2l/src/edit.cpp
+++ b/far2l/src/edit.cpp
@@ -1631,6 +1631,18 @@ int Edit::GetVisualLineCount() const
 	return m_WrapBreaks.size();
 }
 
+int Edit::FindVisualLine(int Pos) const
+{
+	if (!m_bWordWrapState || m_WrapBreaks.empty())
+		return 0;
+
+	if (Pos <= 0)
+		return 0;
+
+	const auto it = std::upper_bound(m_WrapBreaks.begin(), m_WrapBreaks.end(), Pos);
+	return std::max(0, static_cast<int>(it - m_WrapBreaks.begin()) - 1);
+}
+
 void Edit::GetVisualLine(int line, int& start, int& end) const
 {
 	if (!m_bWordWrapState || m_WrapBreaks.empty() || line < 0)

--- a/far2l/src/edit.cpp
+++ b/far2l/src/edit.cpp
@@ -859,7 +859,9 @@ int Edit::ProcessKey(FarKey Key)
 		return TRUE;
 	}
 
-	if (Key != KEY_NONE && Key != KEY_IDLE && Key != KEY_SHIFTINS && Key != KEY_SHIFTNUMPAD0 && Key != KEY_CTRLINS
+	if (Flags.Check(FEDITLINE_CLEARFLAG)
+			&& Key != KEY_NONE && Key != KEY_IDLE && Key != KEY_SHIFTINS && Key != KEY_SHIFTNUMPAD0
+			&& Key != KEY_CTRLINS
 			&& ((unsigned int)Key < KEY_F1 || (unsigned int)Key > KEY_F12) && Key != KEY_ALT && Key != KEY_SHIFT
 			&& Key != KEY_CTRL && Key != KEY_RALT && Key != KEY_RCTRL && (Key < KEY_ALT_BASE || Key > KEY_ALT_BASE + 0xFFFF)
 			&& !( Key & (KEY_ALT | KEY_RALT) )

--- a/far2l/src/edit.hpp
+++ b/far2l/src/edit.hpp
@@ -211,6 +211,7 @@ protected:
 	inline int CalcPosFwd(int LimitPos = -1) const { return CalcPosFwdTo(CurPos, LimitPos); }
 	inline int CalcPosBwd() const { return CalcPosBwdTo(CurPos); }
 
+	int FindVisualLine(int Pos) const;
 	int GetVisualLineCount() const;
 	void GetVisualLine(int line, int& start, int& end) const;
 public:

--- a/far2l/src/editor.cpp
+++ b/far2l/src/editor.cpp
@@ -190,12 +190,9 @@ Editor::Editor(ScreenObject *pOwner, bool DialogUsed)
 {
 	_KEYMACRO(SysLog(L"Editor::Editor()"));
 	_KEYMACRO(SysLog(1));
-	m_TopScreenLogicalLine = nullptr;
 	m_TopScreenVisualLine = 0;
-	m_CurVisualLineInLogicalLine = 0;
 	EdOpt = Opt.EdOpt;
 	m_bWordWrap = EdOpt.WordWrap;
-	m_WrapMaxVisibleLineLength = 0;
 	SetOwner(pOwner);
 
 	if (DialogUsed)
@@ -236,11 +233,11 @@ void Editor::AdjustScreenPosition()
 	if (!m_bWordWrap)
 		return;
 
-	SyncWordWrapVisualLine();
+	const int cur_visual_line = GetCurVisualLine();
 
 	// First, place the current visual line at the top of the screen
-	m_TopScreenLogicalLine = CurLine;
-	m_TopScreenVisualLine = m_CurVisualLineInLogicalLine;
+	TopScreen = CurLine;
+	m_TopScreenVisualLine = cur_visual_line;
 
 	// Then, scroll up by half the screen height to center it
 	int HalfScreen = (Y2 - Y1 + 1) / 2;
@@ -253,45 +250,14 @@ void Editor::AdjustScreenPosition()
 	}
 }
 
-int Editor::FindVisualLine(Edit* line, int Pos)
+int Editor::FindVisualLine(Edit* line, int Pos) const
 {
-	if (!m_bWordWrap || !line) return 0;
-
-	for (int i = 0; i < line->GetVisualLineCount(); ++i) {
-		int start, end;
-		line->GetVisualLine(i, start, end);
-		if (Pos >= start && Pos < end) {
-			return i;
-		}
-	}
-
-	if (Pos == line->GetLength()) {
-		int last_line = std::max(0, line->GetVisualLineCount() - 1);
-		return last_line;
-	}
-
-	return std::max(0, line->GetVisualLineCount() - 1);
+	return line ? line->FindVisualLine(Pos) : 0;
 }
 
-void Editor::SyncWordWrapVisualLine()
+int Editor::GetCurVisualLine() const
 {
-	if (!m_bWordWrap || !CurLine)
-		return;
-
-	const int visual_line_count = CurLine->GetVisualLineCount();
-	if (m_CurVisualLineInLogicalLine >= 0 && m_CurVisualLineInLogicalLine < visual_line_count)
-	{
-		int start, end;
-		CurLine->GetVisualLine(m_CurVisualLineInLogicalLine, start, end);
-		const int cur_pos = CurLine->GetCurPos();
-		if ((cur_pos >= start && cur_pos < end)
-			|| (cur_pos == CurLine->GetLength() && end == CurLine->GetLength()))
-		{
-			return;
-		}
-	}
-
-	m_CurVisualLineInLogicalLine = FindVisualLine(CurLine, CurLine->GetCurPos());
+	return (m_bWordWrap && CurLine) ? CurLine->FindVisualLine(CurLine->GetCurPos()) : 0;
 }
 
 void Editor::RememberWordWrapPreferredCellPos()
@@ -299,18 +265,16 @@ void Editor::RememberWordWrapPreferredCellPos()
 	if (!m_bWordWrap || !CurLine)
 		return;
 
-	SyncWordWrapVisualLine();
-
-	int visual_line_start, visual_line_end;
-	CurLine->GetVisualLine(m_CurVisualLineInLogicalLine, visual_line_start, visual_line_end);
-	(void)visual_line_end;
+	const int cur_visual_line = GetCurVisualLine();
+	int visual_line_start, ignored_end;
+	CurLine->GetVisualLine(cur_visual_line, visual_line_start, ignored_end);
 	m_WordWrapPreferredCellPos = CurLine->GetCellCurPos() - CurLine->RealPosToCell(visual_line_start);
 }
 
-void Editor::SetCursorByVisualLineCellOffset(int horizontal_cell_pos)
+void Editor::SetCursorByVisualLineCellOffset(int VisualLine, int horizontal_cell_pos)
 {
 	int new_start, new_end;
-	CurLine->GetVisualLine(m_CurVisualLineInLogicalLine, new_start, new_end);
+	CurLine->GetVisualLine(VisualLine, new_start, new_end);
 
 	int new_cell_pos = CurLine->RealPosToCell(new_start) + horizontal_cell_pos;
 	int new_pos = CurLine->CellPosToReal(new_cell_pos);
@@ -328,6 +292,43 @@ void Editor::SetCursorByVisualLineCellOffset(int horizontal_cell_pos)
 	}
 
 	CurLine->SetCurPos(new_pos);
+}
+
+void Editor::RestoreWordWrapPreferredCellPos()
+{
+	if (!m_bWordWrap || !CurLine)
+		return;
+
+	SetCursorByVisualLineCellOffset(GetCurVisualLine(), m_WordWrapPreferredCellPos);
+}
+
+void Editor::SetWordWrapCursorPosition(int NewPos)
+{
+	if (!CurLine)
+		return;
+
+	CurLine->SetCurPos(NewPos);
+	RememberWordWrapPreferredCellPos();
+}
+
+void Editor::SetWordWrapCursorPosition(int NewPos, int VisualLine)
+{
+	if (!CurLine)
+		return;
+
+	CurLine->SetCurPos(NewPos);
+
+	if (!m_bWordWrap)
+		return;
+
+	int visual_line_start, visual_line_end;
+	CurLine->GetVisualLine(VisualLine, visual_line_start, visual_line_end);
+
+	if (visual_line_end < CurLine->GetLength() && CurLine->GetCurPos() >= visual_line_end) {
+		CurLine->SetCurPos(CurLine->CalcPosBwdTo(visual_line_end));
+	}
+
+	m_WordWrapPreferredCellPos = CurLine->GetCellCurPos() - CurLine->RealPosToCell(visual_line_start);
 }
 
 // Helper function to count total lines in the editor
@@ -413,9 +414,7 @@ void Editor::FreeAllocatedData(bool FreeUndo)
 	UndoSavePos = nullptr;
 	UndoPos = nullptr;
 	UndoSkipLevel = 0;
-	m_TopScreenLogicalLine = nullptr;
 	m_TopScreenVisualLine = 0;
-	m_CurVisualLineInLogicalLine = 0;
 	m_LineCountDirty = true;  // Invalidate line number cache
 	ClearStackBookmarks();
 	TopList = EndList = CurLine = nullptr;
@@ -520,9 +519,7 @@ int Editor::SetRawData(const wchar_t *SrcBuf, int SizeSrcBuf, int TextFormat)
 	CurLine = TopList;
 	TopScreen = TopList;
 	NumLine = 0;
-	m_TopScreenLogicalLine = TopScreen;
 	m_TopScreenVisualLine = 0;
-	m_CurVisualLineInLogicalLine = 0;
 	TextChanged(1);
 	return TRUE;
 }
@@ -603,12 +600,12 @@ void Editor::DisplayObject()
 
 void Editor::ShowEditor(int CurLineOnly)
 {
+	const int cur_visual_line = (m_bWordWrap && CurLine) ? GetCurVisualLine() : 0;
+
 	if (m_bWordWrap && CurLine)
 	{
-		SyncWordWrapVisualLine();
-
 		EnsureTopScreenVisual();
-		const int off = VisualOffsetFromTop(CurLine, m_CurVisualLineInLogicalLine);
+		const int off = VisualOffsetFromTop(CurLine, cur_visual_line);
 		if (off < 0 || off >= (Y2 - Y1 + 1)) {
 			AdjustScreenPosition();
 		}
@@ -622,7 +619,7 @@ void Editor::ShowEditor(int CurLineOnly)
 
 		// Centralized correction logic to prevent scrolling past the end of the file.
 		int ScreenHeight = Y2 - Y1 + 1;
-		int LinesBelow = GetVisualLinesBelow(m_TopScreenLogicalLine, m_TopScreenVisualLine, ScreenHeight);
+		int LinesBelow = GetVisualLinesBelow(TopScreen, m_TopScreenVisualLine, ScreenHeight);
 
 		if (LinesBelow < ScreenHeight)
 		{
@@ -641,25 +638,6 @@ void Editor::ShowEditor(int CurLineOnly)
 		// Ensure TopScreen pointers are initialized
 		EnsureTopScreenVisual();
 
-		// In Word Wrap mode, we need to calculate the maximum length of all lines
-		// that will be visible on the screen. This value is then reported to plugins
-		// via ECTL_GETINFO as WindowSizeX.
-		// This "tricks" plugins (like Colorer) into thinking the window is wide enough
-		// to hold the longest visible line, thus preventing them from prematurely
-		// stopping their parsing and ensuring that entire wrapped lines are highlighted correctly.
-		m_WrapMaxVisibleLineLength = 0;
-		Edit *ScanPtr = m_TopScreenLogicalLine;
-		int LinesToScan = Y2 - Y1 + 1;
-		while (ScanPtr && LinesToScan > 0)
-		{
-			if (ScanPtr->GetLength() > m_WrapMaxVisibleLineLength)
-			{
-				m_WrapMaxVisibleLineLength = ScanPtr->GetLength();
-			}
-			LinesToScan -= ScanPtr->GetVisualLineCount();
-			ScanPtr = ScanPtr->m_next;
-		}
-
 		if (!ScrBuf.GetLockCount()) {
 			if (Flags.Check(FEDITOR_JUSTMODIFIED)) {
 				Flags.Clear(FEDITOR_JUSTMODIFIED);
@@ -677,7 +655,7 @@ void Editor::ShowEditor(int CurLineOnly)
 
 		DrawScrollbar();
 
-		Edit *CurLogicalLine = m_TopScreenLogicalLine;
+		Edit *CurLogicalLine = TopScreen;
 		int CurVisualLine = m_TopScreenVisualLine;
 
 		// Calculate line number width if needed
@@ -817,7 +795,7 @@ void Editor::ShowEditor(int CurLineOnly)
 				}
 			}
 
-			if (CurLogicalLine == CurLine && CurVisualLine == m_CurVisualLineInLogicalLine)
+			if (CurLogicalLine == CurLine && CurVisualLine == cur_visual_line)
 			{
 				int CurPos = CurLine->GetCurPos();
 				int VisualCurPos = CurPos - VisualLineStart;
@@ -1674,8 +1652,9 @@ int Editor::ProcessKey(FarKey Key)
 
 			if (m_bWordWrap)
 			{
+				const int cur_visual_line = GetCurVisualLine();
 				int start, end;
-				CurLine->GetVisualLine(m_CurVisualLineInLogicalLine, start, end);
+				CurLine->GetVisualLine(cur_visual_line, start, end);
 
 				Pasting++;
 				Lock();
@@ -1717,8 +1696,9 @@ int Editor::ProcessKey(FarKey Key)
 			{
 				if (m_bWordWrap)
 				{
+					const int cur_visual_line = GetCurVisualLine();
 					int start, end;
-					CurLine->GetVisualLine(m_CurVisualLineInLogicalLine, start, end);
+					CurLine->GetVisualLine(cur_visual_line, start, end);
 
 					Pasting++;
 					Lock();
@@ -1964,7 +1944,8 @@ int Editor::ProcessKey(FarKey Key)
 		case KEY_SHIFTNUMPAD2: {
 			if (m_bWordWrap)
 			{
-				if (!CurLine->m_next && (m_CurVisualLineInLogicalLine + 1 >= CurLine->GetVisualLineCount()))
+				const int cur_visual_line = GetCurVisualLine();
+				if (!CurLine->m_next && (cur_visual_line + 1 >= CurLine->GetVisualLineCount()))
 				{
 					Show();
 					return TRUE;
@@ -1976,7 +1957,7 @@ int Editor::ProcessKey(FarKey Key)
 				OldLine->GetRealSelection(OldSelStart, OldSelEnd);
 
 				Down();
-				SetCursorByVisualLineCellOffset(m_WordWrapPreferredCellPos);
+				RestoreWordWrapPreferredCellPos();
 
 				if (OldLine == CurLine)
 				{
@@ -2113,7 +2094,7 @@ int Editor::ProcessKey(FarKey Key)
 		case KEY_SHIFTNUMPAD8: {
 			if (m_bWordWrap)
 			{
-				if (!CurLine->m_prev && m_CurVisualLineInLogicalLine == 0)
+				if (!CurLine->m_prev && GetCurVisualLine() == 0)
 				{
 					Show();
 					return TRUE;
@@ -2125,7 +2106,7 @@ int Editor::ProcessKey(FarKey Key)
 				OldLine->GetRealSelection(OldSelStart, OldSelEnd);
 
 				Up();
-				SetCursorByVisualLineCellOffset(m_WordWrapPreferredCellPos);
+				RestoreWordWrapPreferredCellPos();
 
 				if (OldLine == CurLine)
 				{
@@ -2348,14 +2329,11 @@ int Editor::ProcessKey(FarKey Key)
 			if (m_bWordWrap) {
 				int current_pos = CurLine->GetCurPos();
 				if (current_pos > 0) {
-					int new_pos = CurLine->CalcPosBwdTo(current_pos);
-					CurLine->SetCurPos(new_pos);
+					SetWordWrapCursorPosition(CurLine->CalcPosBwdTo(current_pos));
 				} else if (CurLine->m_prev) {
-					Up(); // This moves to CurLine->m_prev and sets visual line
-					int new_pos = CurLine->GetLength();
-					CurLine->SetCurPos(new_pos);
+					Up();
+					SetWordWrapCursorPosition(CurLine->GetLength());
 				}
-				RememberWordWrapPreferredCellPos();
 				Show();
 
 			} else { // Original logic
@@ -2378,13 +2356,11 @@ int Editor::ProcessKey(FarKey Key)
 			if (m_bWordWrap) {
 				int current_pos = CurLine->GetCurPos();
 				if (current_pos < CurLine->GetLength()) {
-					int new_pos = CurLine->CalcPosFwdTo(current_pos);
-					CurLine->SetCurPos(new_pos);
+					SetWordWrapCursorPosition(CurLine->CalcPosFwdTo(current_pos));
 				} else if (CurLine->m_next) {
-					Down(); // Moves to next logical line's first visual line.
-					CurLine->SetCurPos(0);
+					Down();
+					SetWordWrapCursorPosition(0);
 				}
-				RememberWordWrapPreferredCellPos();
 				Show();
 
 			} else {
@@ -2540,7 +2516,7 @@ int Editor::ProcessKey(FarKey Key)
 				Flags.Set(FEDITOR_NEWUNDO);
 				if (m_bWordWrap) {
 					Up();
-					SetCursorByVisualLineCellOffset(m_WordWrapPreferredCellPos);
+					RestoreWordWrapPreferredCellPos();
 					Show();
 				} else {
 					int PrevMaxPos = MaxRightPos;
@@ -2568,7 +2544,7 @@ int Editor::ProcessKey(FarKey Key)
 				Flags.Set(FEDITOR_NEWUNDO);
 				if (m_bWordWrap) {
 					Down();
-					SetCursorByVisualLineCellOffset(m_WordWrapPreferredCellPos);
+					RestoreWordWrapPreferredCellPos();
 					Show();
 				} else {
 					int PrevMaxPos = MaxRightPos;
@@ -2670,8 +2646,6 @@ case KEY_CTRLNUMPAD9: {
 		CurLine = TopList;
 		TopScreen = CurLine;
 		if (m_bWordWrap) {
-			m_CurVisualLineInLogicalLine = 0;
-			m_TopScreenLogicalLine = TopScreen;
 			m_TopScreenVisualLine = 0;
 		}
 
@@ -2703,9 +2677,9 @@ case KEY_CTRLNUMPAD3: {
 		}
 
 		if (m_bWordWrap) {
-			m_CurVisualLineInLogicalLine = std::max(0, CurLine->GetVisualLineCount() - 1);
-			m_TopScreenLogicalLine = CurLine;
-			m_TopScreenVisualLine = m_CurVisualLineInLogicalLine;
+			const int last_visual_line = std::max(0, CurLine->GetVisualLineCount() - 1);
+			TopScreen = CurLine;
+			m_TopScreenVisualLine = last_visual_line;
 			for (int i = 0; i < Y2 - Y1; ++i) {
 				if (!DecTopVisualLine()) {
 					break;
@@ -3391,10 +3365,10 @@ case KEY_CTRLNUMPAD3: {
 		{
 			if (m_bWordWrap)
 			{
+				const int cur_visual_line = GetCurVisualLine();
 				int start, end;
-				CurLine->GetVisualLine(m_CurVisualLineInLogicalLine, start, end);
-				CurLine->SetCurPos(start);
-				RememberWordWrapPreferredCellPos();
+				CurLine->GetVisualLine(cur_visual_line, start, end);
+				SetWordWrapCursorPosition(start);
 				Show();
 				return TRUE;
 			}
@@ -3405,8 +3379,9 @@ case KEY_CTRLNUMPAD3: {
 		{
 			if (m_bWordWrap)
 			{
+				const int cur_visual_line = GetCurVisualLine();
 				int start, end;
-				CurLine->GetVisualLine(m_CurVisualLineInLogicalLine, start, end);
+				CurLine->GetVisualLine(cur_visual_line, start, end);
 
 				int targetPos = end;
 				// Если мы не в конце логической строки, и символ перед точкой переноса - пробел,
@@ -3415,8 +3390,7 @@ case KEY_CTRLNUMPAD3: {
 				{
 				    targetPos--;
 				}
-				CurLine->SetCurPos(targetPos);
-				RememberWordWrapPreferredCellPos();
+				SetWordWrapCursorPosition(targetPos);
 
 				Show();
 
@@ -3796,7 +3770,7 @@ int Editor::ProcessMouse(MOUSE_EVENT_RECORD *MouseEvent)
 		MouseTarget cur{};
 		cur.line = CurLine;
 		cur.pos = CurLine ? CurLine->GetCurPos() : 0;
-		cur.visual_line = m_CurVisualLineInLogicalLine;
+		cur.visual_line = GetCurVisualLine();
 		ApplyMouseTarget(cur, false, right_down || AltDown(MouseEvent), allow_selection);
 	};
 
@@ -3930,7 +3904,7 @@ bool Editor::ComputeMouseTarget(int mouse_x, int mouse_y, MouseTarget& target)
 	{
 		EnsureTopScreenVisual();
 
-		Edit* line = m_TopScreenLogicalLine;
+		Edit* line = TopScreen;
 		int visual = m_TopScreenVisualLine;
 		int y = Y1;
 
@@ -4005,14 +3979,12 @@ void Editor::ApplyMouseTarget(const MouseTarget& target, bool initial_click, boo
 	if (m_bWordWrap)
 	{
 		int t = VisualOffsetFromTop(target.line, target.visual_line);
-		int c = VisualOffsetFromTop(CurLine, m_CurVisualLineInLogicalLine);
+		int c = VisualOffsetFromTop(CurLine, GetCurVisualLine());
 
 		if (t != -1 && c != -1)
 			moveByDelta(t - c);
 		else
-			fallbackSetCurLine(m_TopScreenLogicalLine ? m_TopScreenLogicalLine : TopScreen);
-
-		m_CurVisualLineInLogicalLine = target.visual_line;
+			fallbackSetCurLine(TopScreen);
 	}
 	else
 	{
@@ -4037,10 +4009,10 @@ void Editor::ApplyMouseTarget(const MouseTarget& target, bool initial_click, boo
 	if (initial_click)
 		UnmarkBlockAndShowIt();
 
-	CurLine->SetCurPos(target.pos);
-
 	if (m_bWordWrap)
-		RememberWordWrapPreferredCellPos();
+		SetWordWrapCursorPosition(target.pos, target.visual_line);
+	else
+		CurLine->SetCurPos(target.pos);
 
 	if (allow_selection) {
 		if (MouseSelStartingLine == -1)
@@ -4155,11 +4127,11 @@ void Editor::GoToVisualLine(int VisualLine)
 		if (visual_lines_so_far + visual_lines_in_current > VisualLine)
 		{
 			// The target is in this logical line
+			const int target_visual_line = VisualLine - visual_lines_so_far;
 			CurLine = target_logical;
 			NumLine = logical_line_num;
-			m_CurVisualLineInLogicalLine = VisualLine - visual_lines_so_far;
 			CurLine->SetCurPos(0); // Move to start of logical line first
-			SetCursorByVisualLineCellOffset(0); // Then to start of visual line
+			SetCursorByVisualLineCellOffset(target_visual_line, 0); // Then to start of visual line
 			RememberWordWrapPreferredCellPos();
 			AdjustScreenPosition(); // Center the view
 			return;
@@ -4186,7 +4158,7 @@ int Editor::GetTopVisualLine()
 	int top_pos = 0;
 	// This can be slow for large files, but it's the simplest correct implementation.
 	// We can optimize with caching later if needed.
-	for (Edit* line = TopList; line && line != m_TopScreenLogicalLine; line = line->m_next) {
+	for (Edit* line = TopList; line && line != TopScreen; line = line->m_next) {
 		top_pos += line->GetVisualLineCount();
 	}
 	top_pos += m_TopScreenVisualLine;
@@ -4205,14 +4177,36 @@ int Editor::GetVisualLinesBelow(Edit* startLine, int startVisual, int limit)
 	return std::min(count, limit);
 }
 
+int Editor::GetWordWrapVisibleMaxLineLength() const
+{
+	if (!m_bWordWrap)
+		return ObjWidth;
+
+	Edit* scan_ptr = TopScreen ? TopScreen : (CurLine ? CurLine : TopList);
+	if (!scan_ptr)
+		return 0;
+
+	int scan_visual = TopScreen ? m_TopScreenVisualLine : 0;
+	int lines_to_scan = Y2 - Y1 + 1;
+	int max_visible_line_length = 0;
+
+	while (scan_ptr && lines_to_scan > 0)
+	{
+		max_visible_line_length = std::max(max_visible_line_length, scan_ptr->GetLength());
+		lines_to_scan -= std::max(1, scan_ptr->GetVisualLineCount() - scan_visual);
+		scan_ptr = scan_ptr->m_next;
+		scan_visual = 0;
+	}
+
+	return max_visible_line_length;
+}
+
 int Editor::GetTopScreenLineNumber()
 {
 	if (!CurLine)
 		return 1;
 
-	Edit* topLinePtr = m_bWordWrap 
-						? (m_TopScreenLogicalLine ? m_TopScreenLogicalLine : TopScreen) 
-						: TopScreen;
+	Edit* topLinePtr = TopScreen;
 	if (!topLinePtr)
 		topLinePtr = TopList ? TopList : CurLine;
 
@@ -4222,8 +4216,8 @@ int Editor::GetTopScreenLineNumber()
 
 void Editor::EnsureTopScreenVisual()
 {
-	if (!m_TopScreenLogicalLine) {
-		m_TopScreenLogicalLine = TopScreen;
+	if (!TopScreen) {
+		TopScreen = CurLine ? CurLine : TopList;
 		m_TopScreenVisualLine = 0;
 	}
 }
@@ -4231,16 +4225,16 @@ void Editor::EnsureTopScreenVisual()
 bool Editor::DecTopVisualLine()
 {
 	EnsureTopScreenVisual();
-	if (!m_TopScreenLogicalLine) {
+	if (!TopScreen) {
 		return false;
 	}
 	if (m_TopScreenVisualLine > 0) {
 		--m_TopScreenVisualLine;
 		return true;
 	}
-	if (m_TopScreenLogicalLine->m_prev) {
-		m_TopScreenLogicalLine = m_TopScreenLogicalLine->m_prev;
-		m_TopScreenVisualLine = std::max(0, m_TopScreenLogicalLine->GetVisualLineCount() - 1);
+	if (TopScreen->m_prev) {
+		TopScreen = TopScreen->m_prev;
+		m_TopScreenVisualLine = std::max(0, TopScreen->GetVisualLineCount() - 1);
 		return true;
 	}
 	return false;
@@ -4249,17 +4243,17 @@ bool Editor::DecTopVisualLine()
 bool Editor::IncTopVisualLine()
 {
 	EnsureTopScreenVisual();
-	if (!m_TopScreenLogicalLine) {
+	if (!TopScreen) {
 		return false;
 	}
 	++m_TopScreenVisualLine;
-	if (m_TopScreenVisualLine >= m_TopScreenLogicalLine->GetVisualLineCount()) {
-		if (m_TopScreenLogicalLine->m_next) {
-			m_TopScreenLogicalLine = m_TopScreenLogicalLine->m_next;
+	if (m_TopScreenVisualLine >= TopScreen->GetVisualLineCount()) {
+		if (TopScreen->m_next) {
+			TopScreen = TopScreen->m_next;
 			m_TopScreenVisualLine = 0;
 			return true;
 		}
-		m_TopScreenVisualLine = std::max(0, m_TopScreenLogicalLine->GetVisualLineCount() - 1);
+		m_TopScreenVisualLine = std::max(0, TopScreen->GetVisualLineCount() - 1);
 		return false;
 	}
 	return true;
@@ -4267,12 +4261,12 @@ bool Editor::IncTopVisualLine()
 
 int Editor::VisualOffsetFromTop(Edit* line, int vline) const
 {
-	if (!line || !m_TopScreenLogicalLine) {
+	if (!line || !TopScreen) {
 		return -1;
 	}
 	int off = 0;
 	int vis = m_TopScreenVisualLine;
-	for (Edit* p = m_TopScreenLogicalLine; p && off <= (Y2 - Y1); p = p->m_next, vis = 0) {
+	for (Edit* p = TopScreen; p && off <= (Y2 - Y1); p = p->m_next, vis = 0) {
 		if (p == line) {
 			return off + (vline - vis);
 		}
@@ -4382,12 +4376,7 @@ void Editor::DeleteString(Edit *DelPtr, int LineNumber, int DeleteLast, int Undo
 			TopScreen = TopScreen->m_prev;
 	}
 
-	if (m_bWordWrap && DelPtr == m_TopScreenLogicalLine) {
-		if (m_TopScreenLogicalLine->m_next) {
-			m_TopScreenLogicalLine = m_TopScreenLogicalLine->m_next;
-		} else {
-			m_TopScreenLogicalLine = m_TopScreenLogicalLine->m_prev;
-		}
+	if (m_bWordWrap && DelPtr == TopScreen) {
 		m_TopScreenVisualLine = 0;
 	}
 
@@ -4579,7 +4568,6 @@ void Editor::InsertString()
 		// We need the simple logical "move to next line" behavior.
 		CurLine = CurLine->m_next;
 		NumLine++;
-		m_CurVisualLineInLogicalLine = 0;
 		// The auto-indent logic below will handle setting the correct CurPos,
 		// but we must start at 0 before that.
 		CurLine->SetCurPos(0);
@@ -4669,27 +4657,27 @@ void Editor::Down()
 {
  	if (m_bWordWrap)
 	{
-		SyncWordWrapVisualLine();
-
+		const int cur_visual_line = GetCurVisualLine();
 		int start, end;
-		CurLine->GetVisualLine(m_CurVisualLineInLogicalLine, start, end);
+		CurLine->GetVisualLine(cur_visual_line, start, end);
 		int cur_cell_pos = CurLine->RealPosToCell(CurLine->GetCurPos());
 		int start_cell_pos = CurLine->RealPosToCell(start);
 		int horizontal_cell_pos = cur_cell_pos - start_cell_pos;
+		int target_visual_line = cur_visual_line;
 
-		if (m_CurVisualLineInLogicalLine + 1 < CurLine->GetVisualLineCount()) {
-			m_CurVisualLineInLogicalLine++;
+		if (cur_visual_line + 1 < CurLine->GetVisualLineCount()) {
+			target_visual_line = cur_visual_line + 1;
 		} else if (CurLine->m_next) {
 			CurLine = CurLine->m_next;
 			NumLine++;
-			m_CurVisualLineInLogicalLine = 0;
+			target_visual_line = 0;
 		} else {
 			return;
 		}
 
-		SetCursorByVisualLineCellOffset(horizontal_cell_pos);
+		SetCursorByVisualLineCellOffset(target_visual_line, horizontal_cell_pos);
 
-		int visual_lines_from_top = VisualOffsetFromTop(CurLine, m_CurVisualLineInLogicalLine);
+		int visual_lines_from_top = VisualOffsetFromTop(CurLine, target_visual_line);
 		if (visual_lines_from_top < 0) {
 			visual_lines_from_top = Y2 - Y1 + 2;
 		}
@@ -4728,7 +4716,7 @@ void Editor::ScrollDown()
 	{
 		IncTopVisualLine();
 		Down();
-		SetCursorByVisualLineCellOffset(m_WordWrapPreferredCellPos);
+		RestoreWordWrapPreferredCellPos();
 		return;
 	}
 
@@ -4756,28 +4744,28 @@ void Editor::Up()
 {
 	if (m_bWordWrap)
 	{
-		SyncWordWrapVisualLine();
-
+		const int cur_visual_line = GetCurVisualLine();
 		int start, end;
-		CurLine->GetVisualLine(m_CurVisualLineInLogicalLine, start, end);
+		CurLine->GetVisualLine(cur_visual_line, start, end);
 		int cur_cell_pos = CurLine->RealPosToCell(CurLine->GetCurPos());
 		int start_cell_pos = CurLine->RealPosToCell(start);
 		int horizontal_cell_pos = cur_cell_pos - start_cell_pos;
+		int target_visual_line = cur_visual_line;
 
-		if (m_CurVisualLineInLogicalLine > 0) {
-			m_CurVisualLineInLogicalLine--;
+		if (cur_visual_line > 0) {
+			target_visual_line = cur_visual_line - 1;
 		} else if (CurLine->m_prev) {
 			CurLine = CurLine->m_prev;
 			NumLine--;
-			m_CurVisualLineInLogicalLine = CurLine->GetVisualLineCount() - 1;
+			target_visual_line = CurLine->GetVisualLineCount() - 1;
 		} else {
 			return;
 		}
 
-		SetCursorByVisualLineCellOffset(horizontal_cell_pos);
+		SetCursorByVisualLineCellOffset(target_visual_line, horizontal_cell_pos);
 
 		EnsureTopScreenVisual();
-		const int off = VisualOffsetFromTop(CurLine, m_CurVisualLineInLogicalLine);
+		const int off = VisualOffsetFromTop(CurLine, target_visual_line);
 		if (off < 0) {
 			DecTopVisualLine();
 		}
@@ -4806,7 +4794,7 @@ void Editor::ScrollUp()
 	{
 		DecTopVisualLine();
 		Up();
-		SetCursorByVisualLineCellOffset(m_WordWrapPreferredCellPos);
+		RestoreWordWrapPreferredCellPos();
 		return;
 	}
 
@@ -5001,7 +4989,7 @@ BOOL Editor::Search(int Next)
 						}
 					}
 
-					m_TopScreenLogicalLine = newTopLogical;
+					TopScreen = newTopLogical;
 					m_TopScreenVisualLine = newTopVisual;
 					CurLine = CurPtr;
 					NumLine = NewNumLine;
@@ -6796,7 +6784,7 @@ int Editor::EditorControl(int Command, void *Param)
 					// away the analysis of the "unseen" part of the line, which in word-wrap mode
 					// is actually visible on subsequent visual lines.
 					// We add a small margin just in case.
-					Info->WindowSizeX = m_WrapMaxVisibleLineLength + 32;
+					Info->WindowSizeX = GetWordWrapVisibleMaxLineLength() + 32;
 				}
 
 				return TRUE;
@@ -7204,11 +7192,11 @@ int Editor::GotoBookmark(DWORD Pos)
 	if (Pos < POSCACHE_BOOKMARK_COUNT) {
 		if (SavePos.Line[Pos] != POS_NONE) {
 			GoToLine(static_cast<int>(SavePos.Line[Pos]));
-			CurLine->SetCurPos(static_cast<int>(SavePos.Cursor[Pos]));
-			CurLine->SetLeftPos(static_cast<int>(SavePos.LeftPos[Pos]));
-
 			if (m_bWordWrap)
-				RememberWordWrapPreferredCellPos();
+				SetWordWrapCursorPosition(static_cast<int>(SavePos.Cursor[Pos]));
+			else
+				CurLine->SetCurPos(static_cast<int>(SavePos.Cursor[Pos]));
+			CurLine->SetLeftPos(static_cast<int>(SavePos.LeftPos[Pos]));
 
 			TopScreen = CurLine;
 
@@ -7279,11 +7267,11 @@ int Editor::RestoreStackBookmark()
 
 	if (StackPos && ((int)StackPos->Line != NumLine || (int)StackPos->Cursor != CurLine->GetCurPos())) {
 		GoToLine(StackPos->Line);
-		CurLine->SetCurPos(StackPos->Cursor);
-		CurLine->SetLeftPos(StackPos->LeftPos);
-
 		if (m_bWordWrap)
-			RememberWordWrapPreferredCellPos();
+			SetWordWrapCursorPosition(StackPos->Cursor);
+		else
+			CurLine->SetCurPos(StackPos->Cursor);
+		CurLine->SetLeftPos(StackPos->LeftPos);
 
 		TopScreen = CurLine;
 
@@ -7772,12 +7760,10 @@ void Editor::SetWordWrap(int NewMode)
 
 		if (m_bWordWrap) // Turning ON
 		{
-			m_TopScreenLogicalLine = TopScreen;
 			m_TopScreenVisualLine = 0;
 		}
 		else // Turning OFF
 		{
-			TopScreen = m_TopScreenLogicalLine;
 			m_WordWrapPreferredCellPos = 0;
 
 			if (CurLine && ObjWidth > 0)
@@ -8085,7 +8071,6 @@ void Editor::SetCacheParams(EditorCacheParams *pp)
 
 	if (StartLine == -2)	// from Viewer!
 	{
-		m_TopScreenLogicalLine = TopScreen;
 		m_TopScreenVisualLine = 0;
 		Edit *CurPtr = TopList;
 		long TotalSize = 0;
@@ -8148,8 +8133,8 @@ void Editor::SetCacheParams(EditorCacheParams *pp)
 
 					RememberWordWrapPreferredCellPos();
 
-					m_TopScreenLogicalLine = CurLine;
-					m_TopScreenVisualLine = m_CurVisualLineInLogicalLine;
+					TopScreen = CurLine;
+					m_TopScreenVisualLine = GetCurVisualLine();
 
 					for (int i = 0; i < pp->ScreenLine; i++) {
 						if (!DecTopVisualLine()) {

--- a/far2l/src/editor.cpp
+++ b/far2l/src/editor.cpp
@@ -66,6 +66,78 @@ static int ReplaceMode, ReplaceAll;
 
 static int EditorID = 0;
 
+static DWORD64 MakeWordWrapTailFillColor(DWORD64 color)
+{
+	return color & ~(IMPORTANT_LINE_CHAR | EXPLICIT_LINE_BREAK | COMMON_LVB_STRIKEOUT | COMMON_LVB_UNDERSCORE);
+}
+
+static bool TryGetWordWrapEmptyVisualLineFillColor(Edit *line, DWORD64 &fill_color)
+{
+	ColorItem ci;
+	for (size_t i = 0; line->GetColor(&ci, i); ++i)
+	{
+		if ((ci.StartPos <= 0 && ci.EndPos >= line->GetLength() - 1)
+			|| (ci.StartPos == -1 && ci.EndPos == -1))
+		{
+			fill_color = MakeWordWrapTailFillColor(ci.Color);
+			return true;
+		}
+	}
+
+	return false;
+}
+
+static void GetWordWrapLogicalColorRange(const ColorItem &ci, int xoff, int &logical_start, int &logical_end)
+{
+	logical_start = ci.StartPos;
+	logical_end = ci.EndPos;
+
+	if (ci.StartPos != -1 && ci.EndPos != -1) {
+		logical_start -= xoff;
+		logical_end -= xoff;
+	}
+}
+
+static bool ColorCoversWordWrapVisualLine(
+	const ColorItem &ci,
+	int logical_start,
+	int logical_end,
+	int visual_line_start,
+	int visual_line_end)
+{
+	return (ci.StartPos == -1 && ci.EndPos == -1)
+		|| (logical_start <= visual_line_start && logical_end >= visual_line_end - 1);
+}
+
+static bool TryMapColorToWordWrapVisualLine(
+	const ColorItem &ci,
+	int logical_start,
+	int logical_end,
+	int visual_line_start,
+	int visual_line_end,
+	ColorItem &mapped_ci)
+{
+	const int visual_line_length = visual_line_end - visual_line_start;
+	if (visual_line_length <= 0)
+		return false;
+
+	mapped_ci = ci;
+
+	if (ci.StartPos == -1 && ci.EndPos == -1)
+	{
+		mapped_ci.StartPos = 0;
+		mapped_ci.EndPos = visual_line_length - 1;
+		return true;
+	}
+
+	if (logical_start >= visual_line_end || logical_end < visual_line_start)
+		return false;
+
+	mapped_ci.StartPos = std::max(logical_start, visual_line_start) - visual_line_start;
+	mapped_ci.EndPos = std::min(logical_end, visual_line_end - 1) - visual_line_start;
+	return mapped_ci.StartPos <= mapped_ci.EndPos;
+}
+
 // EditorUndoData
 enum
 {
@@ -94,7 +166,7 @@ Editor::Editor(ScreenObject *pOwner, bool DialogUsed)
 	LastSearchReverse(GlobalSearchReverse),
 	LastSearchSelFound(Opt.EdOpt.SearchSelFound),
 	LastSearchRegexp(Opt.EdOpt.SearchRegexp),
-	m_WordWrapMaxRightPos(0),
+	m_WordWrapPreferredCellPos(0),
 	m_codepage(CP_OEMCP),
 	StartLine(-1),
 	StartChar(-1),
@@ -164,8 +236,7 @@ void Editor::AdjustScreenPosition()
 	if (!m_bWordWrap)
 		return;
 
-	// Ensure m_CurVisualLineInLogicalLine is up to date
-	m_CurVisualLineInLogicalLine = FindVisualLine(CurLine, CurLine->GetCurPos());
+	SyncWordWrapVisualLine();
 
 	// First, place the current visual line at the top of the screen
 	m_TopScreenLogicalLine = CurLine;
@@ -202,22 +273,58 @@ int Editor::FindVisualLine(Edit* line, int Pos)
 	return std::max(0, line->GetVisualLineCount() - 1);
 }
 
-void Editor::UpdateCursorPosition(int horizontal_cell_pos)
+void Editor::SyncWordWrapVisualLine()
+{
+	if (!m_bWordWrap || !CurLine)
+		return;
+
+	const int visual_line_count = CurLine->GetVisualLineCount();
+	if (m_CurVisualLineInLogicalLine >= 0 && m_CurVisualLineInLogicalLine < visual_line_count)
+	{
+		int start, end;
+		CurLine->GetVisualLine(m_CurVisualLineInLogicalLine, start, end);
+		const int cur_pos = CurLine->GetCurPos();
+		if ((cur_pos >= start && cur_pos < end)
+			|| (cur_pos == CurLine->GetLength() && end == CurLine->GetLength()))
+		{
+			return;
+		}
+	}
+
+	m_CurVisualLineInLogicalLine = FindVisualLine(CurLine, CurLine->GetCurPos());
+}
+
+void Editor::RememberWordWrapPreferredCellPos()
+{
+	if (!m_bWordWrap || !CurLine)
+		return;
+
+	SyncWordWrapVisualLine();
+
+	int visual_line_start, visual_line_end;
+	CurLine->GetVisualLine(m_CurVisualLineInLogicalLine, visual_line_start, visual_line_end);
+	(void)visual_line_end;
+	m_WordWrapPreferredCellPos = CurLine->GetCellCurPos() - CurLine->RealPosToCell(visual_line_start);
+}
+
+void Editor::SetCursorByVisualLineCellOffset(int horizontal_cell_pos)
 {
 	int new_start, new_end;
 	CurLine->GetVisualLine(m_CurVisualLineInLogicalLine, new_start, new_end);
 
 	int new_cell_pos = CurLine->RealPosToCell(new_start) + horizontal_cell_pos;
 	int new_pos = CurLine->CellPosToReal(new_cell_pos);
+	const int line_length = CurLine->GetLength();
 
-	// Clamp to the new visual line's boundaries.
-	// If new_pos is past the end of the visual line, move it to the end of the visual line.
-	if (new_pos > new_end) {
-		new_pos = new_end;
+	// For wrapped sub-lines, the [start, end) boundary belongs to the next visual line.
+	// If the preferred x lands on or beyond that boundary, keep the cursor on the last
+	// position that still belongs to the current visual line.
+	if (new_end < line_length && new_pos >= new_end) {
+		new_pos = CurLine->CalcPosBwdTo(new_end);
 	}
 	// A safety clamp to ensure we don't go past the actual end of the string data.
-	if (new_pos > CurLine->GetLength()) {
-		new_pos = CurLine->GetLength();
+	if (new_pos > line_length) {
+		new_pos = line_length;
 	}
 
 	CurLine->SetCurPos(new_pos);
@@ -275,7 +382,23 @@ int Editor::CalculateTextAreaWidth(int BaseWidth, bool ReserveScrollBar)
 	}
 
 	Width -= CalculateLineNumberWidth();
-	return Width;
+	return std::max(Width, 1);
+}
+
+void Editor::RecalculateAllWordWraps(bool SyncWordWrapState)
+{
+	int Width = 0;
+	if (ObjWidth > 0) {
+		Width = CalculateTextAreaWidth(ObjWidth, EdOpt.ShowScrollBar);
+	}
+	for (Edit *CurPtr = TopList; CurPtr; CurPtr = CurPtr->m_next)
+	{
+		if (SyncWordWrapState) {
+			CurPtr->SetWordWrap(m_bWordWrap);
+		}
+		CurPtr->ObjWidth = Width;
+		CurPtr->RecalculateWordWrap(Width, EdOpt.TabSize);
+	}
 }
 
 void Editor::FreeAllocatedData(bool FreeUndo)
@@ -482,26 +605,13 @@ void Editor::ShowEditor(int CurLineOnly)
 {
 	if (m_bWordWrap && CurLine)
 	{
-		m_CurVisualLineInLogicalLine = FindVisualLine(CurLine, CurLine->GetCurPos());
+		SyncWordWrapVisualLine();
 
 		EnsureTopScreenVisual();
 		const int off = VisualOffsetFromTop(CurLine, m_CurVisualLineInLogicalLine);
 		if (off < 0 || off >= (Y2 - Y1 + 1)) {
 			AdjustScreenPosition();
 		}
-	}
-	// Re-assign to member XX2 to see what's going on before the loop
-	if (m_bWordWrap)
-	{
-		// In word wrap mode, the scrollbar makes no sense for now.
-		XX2 = X2;
-	}
-	else
-	{
-		if (NumLastLine > (Y2 - Y1) + 1)
-			XX2 = X2 - (EdOpt.ShowScrollBar ? 1 : 0);
-		else
-			XX2 = X2;
 	}
 	if (Locked() || !TopList)
 		return;
@@ -525,17 +635,8 @@ void Editor::ShowEditor(int CurLineOnly)
 				}
 			}
 		}
-	}
 
-	if (m_bWordWrap)
-	{
 		CurLine->SetLeftPos(0);
-		MaxRightPos = CurLine->GetCellCurPos();
-
-		int v_start, v_end;
-		CurLine->GetVisualLine(m_CurVisualLineInLogicalLine, v_start, v_end);
-		int visual_line_start_cell = CurLine->RealPosToCell(v_start);
-		m_WordWrapMaxRightPos = CurLine->GetCellCurPos() - visual_line_start_cell;
 
 		// Ensure TopScreen pointers are initialized
 		EnsureTopScreenVisual();
@@ -630,210 +731,117 @@ void Editor::ShowEditor(int CurLineOnly)
 
 			if (SelStart != -1)
 			{
-				int StringLength = VisualLineEnd - VisualLineStart;
+				bool HasOverlap = false;
+				int TargetSelStart = -1, TargetSelEnd = 0;
 
-				// 1. Calculate selection range relative to ShowString's internal string (0 to StringLength)
-				int ShowSelStart = SelStart - VisualLineStart;
-				int ShowSelEnd = (SelEnd == -1) ? -1 : SelEnd - VisualLineStart;
-
-				// 2. Clamp Start & End
-				if (ShowSelStart < 0) ShowSelStart = 0;
-				if (ShowSelEnd != -1 && ShowSelEnd > StringLength) ShowSelEnd = StringLength;
-
-				// 4. Set selection on ShowString if there is an overlap
-				if (ShowSelStart < StringLength || SelEnd == -1 || (SelStart == SelEnd && CurLogicalLine->GetLength() == 0))
+				if (SelStart == SelEnd && CurLogicalLine->GetLength() == 0)
 				{
-					int TargetSelStart = -1, TargetSelEnd = 0;
-
-					if (SelEnd == -1)
+					HasOverlap = true;
+					TargetSelStart = 0;
+					TargetSelEnd = -1;
+				}
+				else if (SelEnd == -1)
+				{
+					const int ClippedSelStart = std::max(SelStart, VisualLineStart);
+					if (ClippedSelStart < VisualLineEnd)
 					{
-						TargetSelStart = ShowSelStart;
+						HasOverlap = true;
+						TargetSelStart = ClippedSelStart - VisualLineStart;
 						TargetSelEnd = -1;
-					}
-					else if (ShowSelEnd > ShowSelStart)
-					{
-						TargetSelStart = ShowSelStart;
-						TargetSelEnd = ShowSelEnd;
-					}
-					else if (SelStart == SelEnd && CurLogicalLine->GetLength() == 0)
-					{
-						TargetSelStart = 0;
-						TargetSelEnd = -1;
-					}
-
-					if (TargetSelStart != -1)
-					{
-						ShowString.Select(TargetSelStart, TargetSelEnd);
-
-						int DbgGetSelStart, DbgGetSelEnd;
-						ShowString.GetSelection(DbgGetSelStart, DbgGetSelEnd);
 					}
 				}
-			}
-			// Debugging log for selection state
-			int dbg_s, db_e;
-			ShowString.GetSelection(dbg_s, db_e);
+				else
+				{
+					const int ClippedSelStart = std::max(SelStart, VisualLineStart);
+					const int ClippedSelEnd = std::min(SelEnd, VisualLineEnd);
+					if (ClippedSelStart < ClippedSelEnd)
+					{
+						HasOverlap = true;
+						TargetSelStart = ClippedSelStart - VisualLineStart;
+						TargetSelEnd = ClippedSelEnd - VisualLineStart;
+					}
+				}
 
-			// --- Специальная отрисовка для выделенных пустых строк ---
+				if (HasOverlap)
+				{
+					ShowString.Select(TargetSelStart, TargetSelEnd);
+				}
+			}
+
+			bool is_selected_empty_logical_line = false;
 			if (CurLogicalLine->GetLength() == 0)
 			{
 				int RealSelStart, RealSelEnd;
 				CurLogicalLine->GetRealSelection(RealSelStart, RealSelEnd);
 
-				// Условие, что строка "полностью выделена" (т.е. выделение перешло на следующую строку)
-				if (RealSelStart == 0 && RealSelEnd == -1)
+				// A fully selected empty logical line is rendered as a single selected cell.
+				is_selected_empty_logical_line = (RealSelStart == 0 && RealSelEnd == -1);
+				if (is_selected_empty_logical_line)
 				{
-					ShowString.SetString(L" ");
-					ShowString.Select(0, -1);
+					ShowString.Select(0, 1);
 				}
 			}
 
-			bool background_filled = false;
-			// Special handling for syntax highlighting on empty visual lines
-			if (VisualLineStart == VisualLineEnd)
-			{
-				ColorItem current_ci;
-
-				// Check for an encompassing color item, typically the background color specified by the plugin
-				for (size_t i = 0; CurLogicalLine->GetColor(&current_ci, i); ++i)
-				{
-					// If a large covering item is found (StartPos <= 0 AND EndPos covers the whole logical line, OR the {-1, -1} marker is used)
-					if ((current_ci.StartPos <= 0 && current_ci.EndPos >= CurLogicalLine->GetLength() - 1)
-						|| (current_ci.StartPos == -1 && current_ci.EndPos == -1) )
-					{
-						// Apply background coloring directly to the screen buffer, but preserve line number area
-						SetScreen(EdOpt.ShowLineNumbers ? LineNumX1 : X1, Y, XX2, Y, L' ', current_ci.Color);
-						background_filled = true;
-						break;
-					}
-				}
+			const bool IsEmptyVisualLine = VisualLineStart == VisualLineEnd;
+			bool has_tail_fill_color = false;
+			DWORD64 tail_fill_color = 0;
+			if (IsEmptyVisualLine) {
+				has_tail_fill_color = TryGetWordWrapEmptyVisualLineFillColor(CurLogicalLine, tail_fill_color);
 			}
 
-			// Copy color info
+			const int xoff = Flags.Check(FEDITOR_DIALOGMEMOEDIT) ? 0 : X1;
 			ColorItem ci;
-			// We use a large relative index hint to force Edit::ApplyColor to fill up to XX2.
-			const int FULL_LINE_END_POS_HINT = 10000;
-
 			for (size_t i = 0; CurLogicalLine->GetColor(&ci, i); ++i)
 			{
-				// Convert stored coordinates back to logical string positions for processing
-				// Colors are stored with line number offset added (see ECTL_ADDCOLOR),
-				// so we need to subtract it to get original logical positions
-				int LogicalStartPos = ci.StartPos;
-				int LogicalEndPos = ci.EndPos;
+				int logical_start, logical_end;
+				GetWordWrapLogicalColorRange(ci, xoff, logical_start, logical_end);
+				const bool covers_visual_line =
+					ColorCoversWordWrapVisualLine(ci, logical_start, logical_end, VisualLineStart, VisualLineEnd);
 
-				if (ci.StartPos != -1 && ci.EndPos != -1) {
-					int xoff = Flags.Check(FEDITOR_DIALOGMEMOEDIT) ? 0 : X1;
-					LogicalStartPos = ci.StartPos - xoff;
-					LogicalEndPos = ci.EndPos - xoff;
+				if (!IsEmptyVisualLine
+					&& covers_visual_line)
+				{
+					has_tail_fill_color = true;
+					tail_fill_color = MakeWordWrapTailFillColor(ci.Color);
 				}
 
-				if ((ci.StartPos == -1 && ci.EndPos == -1) || (LogicalStartPos < VisualLineEnd && LogicalEndPos >= VisualLineStart))
+				ColorItem mapped_ci;
+				if (TryMapColorToWordWrapVisualLine(
+						ci, logical_start, logical_end, VisualLineStart, VisualLineEnd, mapped_ci))
 				{
-					ColorItem new_ci = ci;
-
-					bool is_full_visual_line_coverage = false;
-
-					if (ci.StartPos != -1 || ci.EndPos != -1) // Standard color item
-					{
-						// Heuristic: if the color covers the entire content of the visible portion, assume it's a background fill.
-						if (LogicalStartPos <= VisualLineStart && LogicalEndPos >= VisualLineEnd - 1)
-						{
-							is_full_visual_line_coverage = true;
-						}
-
-						// Clip logical positions to current visual line and convert to coordinate system
-						// expected by Edit::ApplyColor
-						int ClippedLogicalStart = LogicalStartPos;
-						int ClippedLogicalEnd = LogicalEndPos;
-
-						// Clip to current visual line boundaries in logical coordinates
-						if (ClippedLogicalStart < VisualLineStart) ClippedLogicalStart = VisualLineStart;
-						if (ClippedLogicalEnd >= VisualLineEnd) ClippedLogicalEnd = VisualLineEnd - 1;
-
-						new_ci.StartPos = ClippedLogicalStart - VisualLineStart;
-						new_ci.EndPos = ClippedLogicalEnd - VisualLineStart;
-
-						// Apply boundary adjustments
-						if (is_full_visual_line_coverage)
-						{
-							// Force EndPos large to cause DrawColor/ApplyColor to fill to the screen edge
-							new_ci.EndPos = FULL_LINE_END_POS_HINT;
-						}
-						else if (new_ci.EndPos >= (VisualLineEnd - VisualLineStart))
-						{
-							new_ci.EndPos = (VisualLineEnd - VisualLineStart) - 1;
-						}
+					// In WW mode a full-line background item must still cover the full visual tab width.
+					if (covers_visual_line) {
+						mapped_ci.Color &= ~ECF_TAB1;
 					}
-					else // Special case for {-1, -1} background element
-					{
-						new_ci.EndPos = FULL_LINE_END_POS_HINT;
-					}
-
-					if (new_ci.StartPos <= new_ci.EndPos)
-					{
-						ShowString.AddColor(&new_ci);
-					}
-					else if (new_ci.StartPos == -1 && new_ci.EndPos == -1) // Note: this case should now be covered by the {-1, -1} block above, but keep redundant logging check
-					{
-						ShowString.AddColor(&new_ci);
-					}
+					ShowString.AddColor(&mapped_ci);
 				}
 			}
 
-			if (!background_filled) // Only draw normally if we didn't manually fill the background
+			if (CurLogicalLine == CurLine && CurVisualLine == m_CurVisualLineInLogicalLine)
 			{
-				int final_sel_start, final_sel_end;
-				ShowString.GetRealSelection(final_sel_start, final_sel_end);
+				int CurPos = CurLine->GetCurPos();
+				int VisualCurPos = CurPos - VisualLineStart;
+				if (VisualCurPos < 0) VisualCurPos = 0;
+				if (VisualCurPos > (VisualLineEnd - VisualLineStart)) VisualCurPos = (VisualLineEnd - VisualLineStart);
 
-				if (CurLogicalLine == CurLine && CurVisualLine == m_CurVisualLineInLogicalLine)
-				{
-					int CurPos = CurLine->GetCurPos();
-					int VisualCurPos = CurPos - VisualLineStart;
-					if (VisualCurPos < 0) VisualCurPos = 0;
-					if (VisualCurPos > (VisualLineEnd - VisualLineStart)) VisualCurPos = (VisualLineEnd - VisualLineStart);
-
-					ShowString.SetCurPos(VisualCurPos);
-					ShowString.SetCursorVisibleFlag(m_showCursor);
-					ShowString.Show();
-				}
-				else
-				{
-					ShowString.FastShow();
-				}
+				ShowString.SetCurPos(VisualCurPos);
+				ShowString.SetCursorVisibleFlag(m_showCursor);
+				ShowString.Show();
 			}
-			else // This 'else' corresponds to 'if (!background_filled)'
+			else
 			{
-				// Even if background was filled, we might need to draw our fake selection cursor on top of it.
-				if (CurLogicalLine->GetLength() == 0)
-				{
-					int RealSelStart, RealSelEnd;
-					CurLogicalLine->GetRealSelection(RealSelStart, RealSelEnd);
-					if (RealSelStart == 0 && RealSelEnd == -1)
-					{
-						// Draw a single selected space directly to the screen buffer (after line numbers)
-						int SelX = EdOpt.ShowLineNumbers ? LineNumX1 : X1;
-						SetScreen(SelX, Y, SelX, Y, L' ', FarColorToReal(COL_EDITORSELECTEDTEXT));
-					}
-				}
+				ShowString.FastShow();
+			}
 
-				if (m_showCursor && CurLogicalLine == CurLine && CurVisualLine == m_CurVisualLineInLogicalLine)
+			if (has_tail_fill_color)
+			{
+				int tail_fill_x = ShowString.X1 + ShowString.RealPosToCell(ShowString.GetLength());
+				if (is_selected_empty_logical_line) {
+					tail_fill_x = std::max(tail_fill_x, ShowString.X1 + 1);
+				}
+				if (tail_fill_x <= XX2)
 				{
-					// This is the cursor line, but it was empty and the background was drawn by SetScreen.
-					// The regular Show()/FastShow() path was skipped, so we need to position the cursor manually.
-					ShowString.SetOvertypeMode(Flags.Check(FEDITOR_OVERTYPE));
-					bool CursorVisible = true;
-					DWORD CursorSize = 0;
-					ShowString.GetCursorType(CursorVisible, CursorSize);
-					if (!CursorVisible) {
-						::SetCursorType(0, CursorSize);
-					} else if (ShowString.Flags.Check(FEDITLINE_OVERTYPE)) {
-						::SetCursorType(1, Opt.CursorSize[2] ? Opt.CursorSize[2] : 99);
-					} else {
-						::SetCursorType(1, Opt.CursorSize[0] ? Opt.CursorSize[0] : 10);
-					}
-					// For an empty line, cursor is always at the beginning.
-					MoveCursor(EdOpt.ShowLineNumbers ? LineNumX1 : X1, Y);
+					ScrBuf.ApplyColor(tail_fill_x, Y, XX2, Y, tail_fill_color, CurLogicalLine->SelColor);
 				}
 			}
 			if (CurVisualLine < CurLogicalLine->GetVisualLineCount() - 1)
@@ -1676,7 +1684,7 @@ int Editor::ProcessKey(FarKey Key)
 					int oldPos = CurLine->GetCurPos();
 					ProcessKey(KEY_SHIFTLEFT);
 					if (oldPos == CurLine->GetCurPos()) {
-						 break;
+						break;
 					}
 				}
 				Pasting--;
@@ -1968,7 +1976,7 @@ int Editor::ProcessKey(FarKey Key)
 				OldLine->GetRealSelection(OldSelStart, OldSelEnd);
 
 				Down();
-				UpdateCursorPosition(m_WordWrapMaxRightPos);
+				SetCursorByVisualLineCellOffset(m_WordWrapPreferredCellPos);
 
 				if (OldLine == CurLine)
 				{
@@ -2117,7 +2125,7 @@ int Editor::ProcessKey(FarKey Key)
 				OldLine->GetRealSelection(OldSelStart, OldSelEnd);
 
 				Up();
-				UpdateCursorPosition(m_WordWrapMaxRightPos);
+				SetCursorByVisualLineCellOffset(m_WordWrapPreferredCellPos);
 
 				if (OldLine == CurLine)
 				{
@@ -2342,18 +2350,13 @@ int Editor::ProcessKey(FarKey Key)
 				if (current_pos > 0) {
 					int new_pos = CurLine->CalcPosBwdTo(current_pos);
 					CurLine->SetCurPos(new_pos);
-					m_CurVisualLineInLogicalLine = FindVisualLine(CurLine, new_pos);
 				} else if (CurLine->m_prev) {
 					Up(); // This moves to CurLine->m_prev and sets visual line
 					int new_pos = CurLine->GetLength();
 					CurLine->SetCurPos(new_pos);
 				}
+				RememberWordWrapPreferredCellPos();
 				Show();
-
-				int v_start_pos, v_end_pos;
-				CurLine->GetVisualLine(m_CurVisualLineInLogicalLine, v_start_pos, v_end_pos);
-				int visual_line_start_cell = CurLine->RealPosToCell(v_start_pos);
-				m_WordWrapMaxRightPos = CurLine->GetCellCurPos() - visual_line_start_cell;
 
 			} else { // Original logic
 				if (!CurPos && CurLine->m_prev) {
@@ -2377,18 +2380,12 @@ int Editor::ProcessKey(FarKey Key)
 				if (current_pos < CurLine->GetLength()) {
 					int new_pos = CurLine->CalcPosFwdTo(current_pos);
 					CurLine->SetCurPos(new_pos);
-					m_CurVisualLineInLogicalLine = FindVisualLine(CurLine, new_pos);
 				} else if (CurLine->m_next) {
 					Down(); // Moves to next logical line's first visual line.
 					CurLine->SetCurPos(0);
-					m_CurVisualLineInLogicalLine = 0;
 				}
+				RememberWordWrapPreferredCellPos();
 				Show();
-
-				int v_start_pos, v_end_pos;
-				CurLine->GetVisualLine(m_CurVisualLineInLogicalLine, v_start_pos, v_end_pos);
-				int visual_line_start_cell = CurLine->RealPosToCell(v_start_pos);
-				m_WordWrapMaxRightPos = CurLine->GetCellCurPos() - visual_line_start_cell;
 
 			} else {
 				// Original logic for non-word-wrap
@@ -2543,7 +2540,7 @@ int Editor::ProcessKey(FarKey Key)
 				Flags.Set(FEDITOR_NEWUNDO);
 				if (m_bWordWrap) {
 					Up();
-					UpdateCursorPosition(m_WordWrapMaxRightPos);
+					SetCursorByVisualLineCellOffset(m_WordWrapPreferredCellPos);
 					Show();
 				} else {
 					int PrevMaxPos = MaxRightPos;
@@ -2571,7 +2568,7 @@ int Editor::ProcessKey(FarKey Key)
 				Flags.Set(FEDITOR_NEWUNDO);
 				if (m_bWordWrap) {
 					Down();
-					UpdateCursorPosition(m_WordWrapMaxRightPos);
+					SetCursorByVisualLineCellOffset(m_WordWrapPreferredCellPos);
 					Show();
 				} else {
 					int PrevMaxPos = MaxRightPos;
@@ -3397,8 +3394,8 @@ case KEY_CTRLNUMPAD3: {
 				int start, end;
 				CurLine->GetVisualLine(m_CurVisualLineInLogicalLine, start, end);
 				CurLine->SetCurPos(start);
+				RememberWordWrapPreferredCellPos();
 				Show();
-				m_WordWrapMaxRightPos = 0;
 				return TRUE;
 			}
 		}
@@ -3419,13 +3416,9 @@ case KEY_CTRLNUMPAD3: {
 				    targetPos--;
 				}
 				CurLine->SetCurPos(targetPos);
+				RememberWordWrapPreferredCellPos();
 
 				Show();
-
-				int v_start_pos, v_end_pos;
-				CurLine->GetVisualLine(m_CurVisualLineInLogicalLine, v_start_pos, v_end_pos);
-				int visual_line_start_cell = CurLine->RealPosToCell(v_start_pos);
-				m_WordWrapMaxRightPos = CurLine->GetCellCurPos() - visual_line_start_cell;
 
 				return TRUE;
 			}
@@ -3628,14 +3621,13 @@ case KEY_CTRLNUMPAD3: {
 				CurLine->GetSelection(PreSelStart, PreSelEnd);
 				// </comment>
 				// AY: Это что бы при FastShow LeftPos не становился в конец строки.
-				CurLine->ObjWidth = XX2 - X1 + 1;
+				if (m_bWordWrap) {
+					CurLine->ObjWidth = ObjWidth > 0 ? CalculateTextAreaWidth(ObjWidth, EdOpt.ShowScrollBar) : 0;
+				} else {
+					CurLine->ObjWidth = XX2 - X1 + 1;
+				}
 
 				if (CurLine->ProcessKey(Key)) {
-					if (m_bWordWrap)
-					{
-						m_CurVisualLineInLogicalLine = FindVisualLine(CurLine, CurLine->GetCurPos());
-					}
-
 					int SelStart, SelEnd;
 
 					/*
@@ -3647,8 +3639,9 @@ case KEY_CTRLNUMPAD3: {
 
 					if (m_bWordWrap)
 					{
-						int Width = CalculateTextAreaWidth(X2 - X1 + 1, EdOpt.ShowScrollBar);
+						int Width = ObjWidth > 0 ? CalculateTextAreaWidth(ObjWidth, EdOpt.ShowScrollBar) : 0;
 						CurLine->RecalculateWordWrap(Width, EdOpt.TabSize);
+						RememberWordWrapPreferredCellPos();
 					}
 
 					if (Key == KEY_TAB && CurLine->GetConvertTabs() && BlockStart && BlockStart != CurLine) {
@@ -4046,6 +4039,9 @@ void Editor::ApplyMouseTarget(const MouseTarget& target, bool initial_click, boo
 
 	CurLine->SetCurPos(target.pos);
 
+	if (m_bWordWrap)
+		RememberWordWrapPreferredCellPos();
+
 	if (allow_selection) {
 		if (MouseSelStartingLine == -1)
 		{
@@ -4163,7 +4159,8 @@ void Editor::GoToVisualLine(int VisualLine)
 			NumLine = logical_line_num;
 			m_CurVisualLineInLogicalLine = VisualLine - visual_lines_so_far;
 			CurLine->SetCurPos(0); // Move to start of logical line first
-			UpdateCursorPosition(0); // Then to start of visual line
+			SetCursorByVisualLineCellOffset(0); // Then to start of visual line
+			RememberWordWrapPreferredCellPos();
 			AdjustScreenPosition(); // Center the view
 			return;
 		}
@@ -4672,11 +4669,7 @@ void Editor::Down()
 {
  	if (m_bWordWrap)
 	{
-		// Defensively re-synchronize the current visual line with the cursor's actual position.
-		int synced_visual_line = FindVisualLine(CurLine, CurLine->GetCurPos());
-		if (synced_visual_line != m_CurVisualLineInLogicalLine) {
-			m_CurVisualLineInLogicalLine = synced_visual_line;
-		}
+		SyncWordWrapVisualLine();
 
 		int start, end;
 		CurLine->GetVisualLine(m_CurVisualLineInLogicalLine, start, end);
@@ -4694,7 +4687,7 @@ void Editor::Down()
 			return;
 		}
 
-		UpdateCursorPosition(horizontal_cell_pos);
+		SetCursorByVisualLineCellOffset(horizontal_cell_pos);
 
 		int visual_lines_from_top = VisualOffsetFromTop(CurLine, m_CurVisualLineInLogicalLine);
 		if (visual_lines_from_top < 0) {
@@ -4735,6 +4728,7 @@ void Editor::ScrollDown()
 	{
 		IncTopVisualLine();
 		Down();
+		SetCursorByVisualLineCellOffset(m_WordWrapPreferredCellPos);
 		return;
 	}
 
@@ -4762,11 +4756,7 @@ void Editor::Up()
 {
 	if (m_bWordWrap)
 	{
-		// Defensively re-synchronize the current visual line with the cursor's actual position.
-		int synced_visual_line = FindVisualLine(CurLine, CurLine->GetCurPos());
-		if (synced_visual_line != m_CurVisualLineInLogicalLine) {
-			m_CurVisualLineInLogicalLine = synced_visual_line;
-		}
+		SyncWordWrapVisualLine();
 
 		int start, end;
 		CurLine->GetVisualLine(m_CurVisualLineInLogicalLine, start, end);
@@ -4784,7 +4774,7 @@ void Editor::Up()
 			return;
 		}
 
-		UpdateCursorPosition(horizontal_cell_pos);
+		SetCursorByVisualLineCellOffset(horizontal_cell_pos);
 
 		EnsureTopScreenVisual();
 		const int off = VisualOffsetFromTop(CurLine, m_CurVisualLineInLogicalLine);
@@ -4816,6 +4806,7 @@ void Editor::ScrollUp()
 	{
 		DecTopVisualLine();
 		Up();
+		SetCursorByVisualLineCellOffset(m_WordWrapPreferredCellPos);
 		return;
 	}
 
@@ -5343,8 +5334,7 @@ void Editor::Paste(const wchar_t *Src)
 
 
 	if (m_bWordWrap) {
-		// Пересчитываем визуальную линию курсора на основе реальной позиции
-		m_CurVisualLineInLogicalLine = FindVisualLine(CurLine, CurLine->GetCurPos());
+		RememberWordWrapPreferredCellPos();
 
 		// Полная перерисовка редактора для обновления отображения
 		Show();
@@ -5588,7 +5578,7 @@ void Editor::DeleteBlock()
 
 	if (m_bWordWrap)
 	{
-		m_CurVisualLineInLogicalLine = FindVisualLine(CurLine, CurLine->GetCurPos());
+		RememberWordWrapPreferredCellPos();
 	}
 	AddUndoData(UNDO_END);
 	BlockStart = nullptr;
@@ -5817,6 +5807,10 @@ void Editor::GoToPosition()
 		} else {
 			CurLine->SetCellCurPos(NewCol);
 		}
+
+		if (m_bWordWrap)
+			RememberWordWrapPreferredCellPos();
+
 		Show();
 	}
 }
@@ -6329,7 +6323,7 @@ void Editor::DeleteVBlock()
 
 	if (m_bWordWrap)
 	{
-		m_CurVisualLineInLogicalLine = FindVisualLine(CurLine, CurLine->GetCurPos());
+		RememberWordWrapPreferredCellPos();
 	}
 	AddUndoData(UNDO_END);
 	VBlockStart = nullptr;
@@ -6877,6 +6871,9 @@ int Editor::EditorControl(int Command, void *Param)
 					CurLine->SetOvertypeMode(Flags.Check(FEDITOR_OVERTYPE));
 				}
 
+				if (m_bWordWrap)
+					RememberWordWrapPreferredCellPos();
+
 				Unlock();
 				return TRUE;
 			}
@@ -7209,6 +7206,10 @@ int Editor::GotoBookmark(DWORD Pos)
 			GoToLine(static_cast<int>(SavePos.Line[Pos]));
 			CurLine->SetCurPos(static_cast<int>(SavePos.Cursor[Pos]));
 			CurLine->SetLeftPos(static_cast<int>(SavePos.LeftPos[Pos]));
+
+			if (m_bWordWrap)
+				RememberWordWrapPreferredCellPos();
+
 			TopScreen = CurLine;
 
 			for (DWORD I = 0; I < SavePos.ScreenLine[Pos] && TopScreen->m_prev; I++)
@@ -7280,6 +7281,10 @@ int Editor::RestoreStackBookmark()
 		GoToLine(StackPos->Line);
 		CurLine->SetCurPos(StackPos->Cursor);
 		CurLine->SetLeftPos(StackPos->LeftPos);
+
+		if (m_bWordWrap)
+			RememberWordWrapPreferredCellPos();
+
 		TopScreen = CurLine;
 
 		for (DWORD I = 0; I < StackPos->ScreenLine && TopScreen->m_prev; I++)
@@ -7773,15 +7778,12 @@ void Editor::SetWordWrap(int NewMode)
 		else // Turning OFF
 		{
 			TopScreen = m_TopScreenLogicalLine;
-			m_WordWrapMaxRightPos = 0;
+			m_WordWrapPreferredCellPos = 0;
 
 			if (CurLine && ObjWidth > 0)
 			{
 				int VisibleWidth = CalculateTextAreaWidth(ObjWidth,
 						NumLastLine > (Y2 - Y1) + 1 && EdOpt.ShowScrollBar);
-
-				if (VisibleWidth < 1)
-					VisibleWidth = 1;
 
 				int CurPos = CurLine->GetCellCurPos();
 				int NewLeftPos = CurLine->GetLeftPos();
@@ -7802,15 +7804,10 @@ void Editor::SetWordWrap(int NewMode)
 			}
 		}
 
-		int Width = CalculateTextAreaWidth(ObjWidth, EdOpt.ShowScrollBar);
+		RecalculateAllWordWraps(true);
 
-		Edit *CurPtr = TopList;
-		while (CurPtr)
-		{
-			CurPtr->SetWordWrap(m_bWordWrap);
-			CurPtr->RecalculateWordWrap(Width, EdOpt.TabSize);
-			CurPtr = CurPtr->m_next;
-		}
+		if (m_bWordWrap)
+			RememberWordWrapPreferredCellPos();
 	}
 }
 
@@ -7875,13 +7872,7 @@ void Editor::SetShowLineNumbers(int NewMode)
 
 		// If word wrap is enabled, recalculate wrap positions for all lines
 		if (m_bWordWrap) {
-			int Width = CalculateTextAreaWidth(X2 - X1 + 1, EdOpt.ShowScrollBar);
-
-			CurPtr = TopList;
-			while (CurPtr) {
-				CurPtr->RecalculateWordWrap(Width, EdOpt.TabSize);
-				CurPtr = CurPtr->m_next;
-			}
+			RecalculateAllWordWraps(false);
 		}
 
 		// Trigger plugin event to reapply syntax highlighting
@@ -7989,6 +7980,9 @@ Edit *Editor::CreateString(const wchar_t *lpwszStr, int nLength)
 	if (pEdit) {
 		pEdit->SetPosition(X1, Y1, X2, Y2);
 		pEdit->SetWordWrap(m_bWordWrap);
+		if (m_bWordWrap) {
+			pEdit->ObjWidth = ObjWidth > 0 ? CalculateTextAreaWidth(ObjWidth, EdOpt.ShowScrollBar) : 0;
+		}
 
 		pEdit->m_next = nullptr;
 		pEdit->m_prev = nullptr;
@@ -8152,7 +8146,7 @@ void Editor::SetCacheParams(EditorCacheParams *pp)
 					else
 						CurLine->SetCellCurPos(pp->LinePos);
 
-					m_CurVisualLineInLogicalLine = FindVisualLine(CurLine, CurLine->GetCurPos());
+					RememberWordWrapPreferredCellPos();
 
 					m_TopScreenLogicalLine = CurLine;
 					m_TopScreenVisualLine = m_CurVisualLineInLogicalLine;
@@ -8248,12 +8242,7 @@ void Editor::SetPosition(int X1, int Y1, int X2, int Y2)
 
 	if (m_bWordWrap)
 	{
-		int RecalcWidth = CalculateTextAreaWidth(X2 - X1 + 1, EdOpt.ShowScrollBar);
-
-		for(Edit *CurPtr=TopList; CurPtr; CurPtr=CurPtr->m_next)
-		{
-			CurPtr->RecalculateWordWrap(RecalcWidth, EdOpt.TabSize);
-		}
+		RecalculateAllWordWraps(false);
 	}
 }
 
@@ -8283,6 +8272,8 @@ void Editor::SetCurPos(int NewCol, int NewRow)
 	Lock();
 	GoToLine(NewRow);
 	CurLine->SetCellCurPos(NewCol);
+	if (m_bWordWrap)
+		RememberWordWrapPreferredCellPos();
 	// CurLine->SetLeftPos(LeftPos); ???
 	Unlock();
 }

--- a/far2l/src/editor.cpp
+++ b/far2l/src/editor.cpp
@@ -5564,10 +5564,7 @@ void Editor::DeleteBlock()
 		}
 	}
 
-	if (m_bWordWrap)
-	{
-		RememberWordWrapPreferredCellPos();
-	}
+	RememberWordWrapPreferredCellPos();
 	AddUndoData(UNDO_END);
 	BlockStart = nullptr;
 }
@@ -5796,8 +5793,7 @@ void Editor::GoToPosition()
 			CurLine->SetCellCurPos(NewCol);
 		}
 
-		if (m_bWordWrap)
-			RememberWordWrapPreferredCellPos();
+		RememberWordWrapPreferredCellPos();
 
 		Show();
 	}
@@ -6859,8 +6855,7 @@ int Editor::EditorControl(int Command, void *Param)
 					CurLine->SetOvertypeMode(Flags.Check(FEDITOR_OVERTYPE));
 				}
 
-				if (m_bWordWrap)
-					RememberWordWrapPreferredCellPos();
+				RememberWordWrapPreferredCellPos();
 
 				Unlock();
 				return TRUE;
@@ -7192,10 +7187,7 @@ int Editor::GotoBookmark(DWORD Pos)
 	if (Pos < POSCACHE_BOOKMARK_COUNT) {
 		if (SavePos.Line[Pos] != POS_NONE) {
 			GoToLine(static_cast<int>(SavePos.Line[Pos]));
-			if (m_bWordWrap)
-				SetWordWrapCursorPosition(static_cast<int>(SavePos.Cursor[Pos]));
-			else
-				CurLine->SetCurPos(static_cast<int>(SavePos.Cursor[Pos]));
+			SetWordWrapCursorPosition(static_cast<int>(SavePos.Cursor[Pos]));
 			CurLine->SetLeftPos(static_cast<int>(SavePos.LeftPos[Pos]));
 
 			TopScreen = CurLine;
@@ -7267,10 +7259,7 @@ int Editor::RestoreStackBookmark()
 
 	if (StackPos && ((int)StackPos->Line != NumLine || (int)StackPos->Cursor != CurLine->GetCurPos())) {
 		GoToLine(StackPos->Line);
-		if (m_bWordWrap)
-			SetWordWrapCursorPosition(StackPos->Cursor);
-		else
-			CurLine->SetCurPos(StackPos->Cursor);
+		SetWordWrapCursorPosition(StackPos->Cursor);
 		CurLine->SetLeftPos(StackPos->LeftPos);
 
 		TopScreen = CurLine;
@@ -7792,8 +7781,7 @@ void Editor::SetWordWrap(int NewMode)
 
 		RecalculateAllWordWraps(true);
 
-		if (m_bWordWrap)
-			RememberWordWrapPreferredCellPos();
+		RememberWordWrapPreferredCellPos();
 	}
 }
 
@@ -8257,8 +8245,7 @@ void Editor::SetCurPos(int NewCol, int NewRow)
 	Lock();
 	GoToLine(NewRow);
 	CurLine->SetCellCurPos(NewCol);
-	if (m_bWordWrap)
-		RememberWordWrapPreferredCellPos();
+	RememberWordWrapPreferredCellPos();
 	// CurLine->SetLeftPos(LeftPos); ???
 	Unlock();
 }

--- a/far2l/src/editor.cpp
+++ b/far2l/src/editor.cpp
@@ -266,6 +266,18 @@ int Editor::CalculateLineNumberWidth()
 	return LineNumWidth;
 }
 
+int Editor::CalculateTextAreaWidth(int BaseWidth, bool ReserveScrollBar)
+{
+	int Width = BaseWidth;
+
+	if (ReserveScrollBar) {
+		Width--;
+	}
+
+	Width -= CalculateLineNumberWidth();
+	return Width;
+}
+
 void Editor::FreeAllocatedData(bool FreeUndo)
 {
 	while (EndList) {
@@ -2174,7 +2186,7 @@ int Editor::ProcessKey(FarKey Key)
 			if (SelAtBeginning || SelFirst)
 			{
 				CurLine->Select(0, SelEnd);
-				SelStart = CurLine->RealPosToCell(CurPos);
+				SelStart = CurPos;
 
 				if (!EdOpt.CursorBeyondEOL
 						&& CurLine->m_prev->CellPosToReal(SelStart) > CurLine->m_prev->GetLength()) {
@@ -2336,7 +2348,6 @@ int Editor::ProcessKey(FarKey Key)
 					int new_pos = CurLine->GetLength();
 					CurLine->SetCurPos(new_pos);
 				}
-				MaxRightPos = CurLine->GetCellCurPos();
 				Show();
 
 				int v_start_pos, v_end_pos;
@@ -2372,7 +2383,6 @@ int Editor::ProcessKey(FarKey Key)
 					CurLine->SetCurPos(0);
 					m_CurVisualLineInLogicalLine = 0;
 				}
-				MaxRightPos = CurLine->GetCellCurPos();
 				Show();
 
 				int v_start_pos, v_end_pos;
@@ -3637,8 +3647,7 @@ case KEY_CTRLNUMPAD3: {
 
 					if (m_bWordWrap)
 					{
-						int Width = X2 - X1 + 1;
-						if (EdOpt.ShowScrollBar) Width--;
+						int Width = CalculateTextAreaWidth(X2 - X1 + 1, EdOpt.ShowScrollBar);
 						CurLine->RecalculateWordWrap(Width, EdOpt.TabSize);
 					}
 
@@ -4056,14 +4065,6 @@ void Editor::ApplyMouseTarget(const MouseTarget& target, bool initial_click, boo
 				MouseSelStartingPos - target.pos,
 				MouseSelStartingLine + 1 - NumLine);
 		}
-	}
-
-	if (m_bWordWrap)
-	{
-		int v_start, v_end;
-		CurLine->GetVisualLine(m_CurVisualLineInLogicalLine, v_start, v_end);
-		m_WordWrapMaxRightPos = CurLine->GetCellCurPos() - CurLine->RealPosToCell(v_start);
-		MaxRightPos = CurLine->GetCellCurPos();
 	}
 
 	Show();
@@ -7772,28 +7773,36 @@ void Editor::SetWordWrap(int NewMode)
 		else // Turning OFF
 		{
 			TopScreen = m_TopScreenLogicalLine;
+			m_WordWrapMaxRightPos = 0;
+
+			if (CurLine && ObjWidth > 0)
+			{
+				int VisibleWidth = CalculateTextAreaWidth(ObjWidth,
+						NumLastLine > (Y2 - Y1) + 1 && EdOpt.ShowScrollBar);
+
+				if (VisibleWidth < 1)
+					VisibleWidth = 1;
+
+				int CurPos = CurLine->GetCellCurPos();
+				int NewLeftPos = CurLine->GetLeftPos();
+				if (CurPos - NewLeftPos > VisibleWidth - 1) {
+					for (int ShiftBy = 1; ShiftBy <= std::max(EdOpt.TabSize, 2); ++ShiftBy) {
+						int RealLeftPos = CurLine->CellPosToReal(CurPos - VisibleWidth + ShiftBy);
+						int CandidateLeftPos = CurLine->RealPosToCell(RealLeftPos);
+						if (CandidateLeftPos != NewLeftPos) {
+							NewLeftPos = CandidateLeftPos;
+							break;
+						}
+					}
+				}
+
+				if (CurPos < NewLeftPos)
+					NewLeftPos = CurPos;
+				CurLine->SetLeftPos(NewLeftPos);
+			}
 		}
 
-		int Width = ObjWidth;
-		if (EdOpt.ShowScrollBar)
-			Width--;
-
-		// Account for line numbers if enabled
-		if (EdOpt.ShowLineNumbers) {
-			int TotalLines = 0;
-			for (Edit *CountPtr = TopList; CountPtr; CountPtr = CountPtr->m_next) {
-				TotalLines++;
-			}
-			int LineNumWidth = 1;
-			int temp = TotalLines;
-			while (temp >= 10) {
-				LineNumWidth++;
-				temp /= 10;
-			}
-			if (LineNumWidth < 4) LineNumWidth = 4;
-			LineNumWidth += 1;
-			Width -= LineNumWidth;
-		}
+		int Width = CalculateTextAreaWidth(ObjWidth, EdOpt.ShowScrollBar);
 
 		Edit *CurPtr = TopList;
 		while (CurPtr)
@@ -7866,14 +7875,7 @@ void Editor::SetShowLineNumbers(int NewMode)
 
 		// If word wrap is enabled, recalculate wrap positions for all lines
 		if (m_bWordWrap) {
-			// Calculate line number width
-			int LineNumWidth = CalculateLineNumberWidth();
-
-			// Recalculate word wrap with adjusted width
-			int Width = X2 - X1 + 1;
-			if (EdOpt.ShowScrollBar)
-				Width--;
-			Width -= LineNumWidth;
+			int Width = CalculateTextAreaWidth(X2 - X1 + 1, EdOpt.ShowScrollBar);
 
 			CurPtr = TopList;
 			while (CurPtr) {
@@ -8246,12 +8248,7 @@ void Editor::SetPosition(int X1, int Y1, int X2, int Y2)
 
 	if (m_bWordWrap)
 	{
-		int RecalcWidth = X2 - X1 + 1;
-		if (EdOpt.ShowScrollBar) // Consistent with ShowEditor logic
-			RecalcWidth--;
-
-		// Account for line numbers if enabled
-		RecalcWidth -= CalculateLineNumberWidth();
+		int RecalcWidth = CalculateTextAreaWidth(X2 - X1 + 1, EdOpt.ShowScrollBar);
 
 		for(Edit *CurPtr=TopList; CurPtr; CurPtr=CurPtr->m_next)
 		{

--- a/far2l/src/editor.cpp
+++ b/far2l/src/editor.cpp
@@ -250,11 +250,6 @@ void Editor::AdjustScreenPosition()
 	}
 }
 
-int Editor::FindVisualLine(Edit* line, int Pos) const
-{
-	return line ? line->FindVisualLine(Pos) : 0;
-}
-
 int Editor::GetCurVisualLine() const
 {
 	return (m_bWordWrap && CurLine) ? CurLine->FindVisualLine(CurLine->GetCurPos()) : 0;
@@ -4971,7 +4966,7 @@ BOOL Editor::Search(int Next)
 				*/
 				if (m_bWordWrap)
 				{
-					int foundVisualLine = FindVisualLine(CurPtr, CurPtr->GetCurPos());
+					int foundVisualLine = CurPtr->FindVisualLine(CurPtr->GetCurPos());
 
 					int FromTop = (Y2 - Y1 + 1) / 4;
 

--- a/far2l/src/editor.hpp
+++ b/far2l/src/editor.hpp
@@ -314,6 +314,7 @@ void GoToVisualLine(int VisualLine);
 	void HighlightAsWrapped(int Y, Edit &ShowString); // new helper function
 	int CalculateTotalLines();  // Helper to count total lines
 	int CalculateLineNumberWidth();  // Helper to calculate line number display width
+	int CalculateTextAreaWidth(int BaseWidth, bool ReserveScrollBar);  // Helper for text viewport width
 	// void SetStringsTable();
 	void BlockLeft();
 	void BlockRight();

--- a/far2l/src/editor.hpp
+++ b/far2l/src/editor.hpp
@@ -220,7 +220,7 @@ private:
 		Новая переменная для поиска "Whole words"
 	*/
 	int LastSearchCase, LastSearchWholeWords, LastSearchReverse, LastSearchSelFound, LastSearchRegexp;
-	int m_WordWrapMaxRightPos;
+	int m_WordWrapPreferredCellPos;
 
 	UINT m_codepage;	// BUGBUG
 
@@ -278,7 +278,7 @@ private:
 	bool ComputeMouseTarget(int mouse_x, int mouse_y, MouseTarget& target);
 	void ApplyMouseTarget(const MouseTarget& target, bool initial_click, bool vblock, bool allow_selection);
 	virtual void DisplayObject();
-	void UpdateCursorPosition(int horizontal_cell_pos);
+	void SetCursorByVisualLineCellOffset(int horizontal_cell_pos);
 	void ShowEditor(int CurLineOnly);
 	void DeleteString(Edit *DelPtr, int LineNumber, int DeleteLast, int UndoLine);
 	void InsertString();
@@ -315,6 +315,9 @@ void GoToVisualLine(int VisualLine);
 	int CalculateTotalLines();  // Helper to count total lines
 	int CalculateLineNumberWidth();  // Helper to calculate line number display width
 	int CalculateTextAreaWidth(int BaseWidth, bool ReserveScrollBar);  // Helper for text viewport width
+	void RecalculateAllWordWraps(bool SyncWordWrapState);
+	void SyncWordWrapVisualLine();
+	void RememberWordWrapPreferredCellPos();
 	// void SetStringsTable();
 	void BlockLeft();
 	void BlockRight();

--- a/far2l/src/editor.hpp
+++ b/far2l/src/editor.hpp
@@ -238,8 +238,6 @@ private:
 	Edit *TopList;
 	Edit *EndList;
 	Edit *TopScreen;
-	int m_CurVisualLineInLogicalLine;
-	Edit *m_TopScreenLogicalLine;
 	int m_TopScreenVisualLine;
 	Edit *CurLine;
 	Edit *LastGetLine;
@@ -247,7 +245,6 @@ private:
 	int LastGetLineNumber;
 	bool SaveTabSettings;
 	bool m_bWordWrap;
-	int m_WrapMaxVisibleLineLength;
 	bool m_MouseButtonIsHeld;
 	
 	// Line number caching for performance
@@ -266,10 +263,12 @@ private:
 		int visual_line{0};
 	};
 
-	int FindVisualLine(Edit* line, int Pos);
+	int FindVisualLine(Edit* line, int Pos) const;
+	int GetCurVisualLine() const;
 	int GetTotalVisualLines();
 	int GetTopVisualLine();
 	int GetVisualLinesBelow(Edit* startLine, int startVisual, int limit);
+	int GetWordWrapVisibleMaxLineLength() const;
 	int GetTopScreenLineNumber();
 	void EnsureTopScreenVisual();
 	bool DecTopVisualLine();
@@ -278,7 +277,10 @@ private:
 	bool ComputeMouseTarget(int mouse_x, int mouse_y, MouseTarget& target);
 	void ApplyMouseTarget(const MouseTarget& target, bool initial_click, bool vblock, bool allow_selection);
 	virtual void DisplayObject();
-	void SetCursorByVisualLineCellOffset(int horizontal_cell_pos);
+	void SetCursorByVisualLineCellOffset(int VisualLine, int horizontal_cell_pos);
+	void RestoreWordWrapPreferredCellPos();
+	void SetWordWrapCursorPosition(int NewPos);
+	void SetWordWrapCursorPosition(int NewPos, int VisualLine);
 	void ShowEditor(int CurLineOnly);
 	void DeleteString(Edit *DelPtr, int LineNumber, int DeleteLast, int UndoLine);
 	void InsertString();
@@ -316,7 +318,6 @@ void GoToVisualLine(int VisualLine);
 	int CalculateLineNumberWidth();  // Helper to calculate line number display width
 	int CalculateTextAreaWidth(int BaseWidth, bool ReserveScrollBar);  // Helper for text viewport width
 	void RecalculateAllWordWraps(bool SyncWordWrapState);
-	void SyncWordWrapVisualLine();
 	void RememberWordWrapPreferredCellPos();
 	// void SetStringsTable();
 	void BlockLeft();

--- a/far2l/src/editor.hpp
+++ b/far2l/src/editor.hpp
@@ -263,7 +263,6 @@ private:
 		int visual_line{0};
 	};
 
-	int FindVisualLine(Edit* line, int Pos) const;
 	int GetCurVisualLine() const;
 	int GetTotalVisualLines();
 	int GetTopVisualLine();


### PR DESCRIPTION
1. Fixed selection with Shift+Up, Shift+PgUp after 03bb65fc 
<img width="763" height="385" alt="image" src="https://github.com/user-attachments/assets/fd9c797b-f2d2-4432-a041-9a65f3bc705d" />

2. Stale LeftPos=0 before redraw on Wrap->Unwrap causing coloring issues beyond EOL (Fix #3327, see screenshot there) 
3. Screen width calculation code cleanup
4. Avoid sudden cursor/screen jumps to the right on vertical navigation after unwrap. Steps to reproduce on current master: wrap, put cursor to a wrapped line past the wrap mark, unwrap, click Home, then arrow Up and see the jump
5. Keep stable X offset for WW vertical navigation and selection. Steps to reproduce: move cursor vertically with or without shift pressed when WW is active
6. Recalculate word wrap against the real text area width during edits, new line creation etc to avoid text past the right edge. Steps to reproduce: start typing on empty line some text with no spaces while WW and line numbers are activated together and see it going beyond the right edge. Fix #3369
7. Fill background color in WW mode without propagating underline or strikeout to the padded area. Issue can be seen when opening README.md in WW mode
<img width="944" height="718" alt="image" src="https://github.com/user-attachments/assets/3a967909-ae62-43ec-a03a-2c1bbd2de5b4" />

8. Refactoring of WW path in ShowEditor for simplification and readability
9. Refactoring of WW state handling to avoid continuous resync
10. Fix #3149. Steps to reproduce: ctrl+shift+m in the middle of a large file in WW mode

