### PR TITLE
Fix crash on F12 when a dialog is open

### DIFF
--- a/far2l/src/manager.cpp
+++ b/far2l/src/manager.cpp
@@ -933,10 +933,9 @@ int Manager::ProcessKey(DWORD Key)
 					if ((TypeFrame != MODALTYPE_HELP && TypeFrame != MODALTYPE_DIALOG) || CurFrame->GetCanLoseFocus())
 					{
 						DeactivateFrame(FrameMenu(),0);
-						return TRUE;
 					}
 
-					break;	// отдадим F12 дальше по цепочке
+					return TRUE; // the current modal dialog/help cannot lose focus, so F12 is a no-op
 				}
 
 				case KEY_CTRLALTSHIFTPRESS:


### PR DESCRIPTION
Steps to reproduce: open any dialog (Make folder, File search) and press F12