### PR TITLE
SDL font picker now saves font path instead of FC descriptor

### DIFF
--- a/WinPort/src/Backend/SDL/SDLFontDialog.cpp
+++ b/WinPort/src/Backend/SDL/SDLFontDialog.cpp
@@ -1,5 +1,7 @@
 #include "SDLFontDialog.h"
 
+#include "SDLBackendUtils.h"
+
 #include <SDL.h>
 #include <fontconfig/fontconfig.h>
 #include <ft2build.h>
@@ -8,6 +10,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <cstdio>
+#include <cctype>
 #include <string>
 #include <unordered_set>
 #include <vector>
@@ -21,7 +24,6 @@ struct FontEntry {
     std::string path;
     int face_index{-1};
     std::string label;
-    std::string fc_name;
 };
 
 struct Color {
@@ -227,30 +229,6 @@ static std::vector<FontEntry> CollectFonts()
         entry.path = reinterpret_cast<const char *>(file);
         entry.face_index = index;
         entry.label = std::move(label);
-        if (family) {
-            std::string desc = std::string("fc:") + reinterpret_cast<const char *>(family);
-            if (style) {
-                desc += ":style=";
-                desc += reinterpret_cast<const char *>(style);
-            }
-            int slant = 0;
-            if (FcPatternGetInteger(font, FC_SLANT, 0, &slant) == FcResultMatch) {
-                desc += ":slant=" + std::to_string(slant);
-            }
-            int weight = 0;
-            if (FcPatternGetInteger(font, FC_WEIGHT, 0, &weight) == FcResultMatch) {
-                desc += ":weight=" + std::to_string(weight);
-            }
-            int width = 0;
-            if (FcPatternGetInteger(font, FC_WIDTH, 0, &width) == FcResultMatch) {
-                desc += ":width=" + std::to_string(width);
-            }
-            int spacing = 0;
-            if (FcPatternGetInteger(font, FC_SPACING, 0, &spacing) == FcResultMatch) {
-                desc += ":spacing=" + std::to_string(spacing);
-            }
-            entry.fc_name = std::move(desc);
-        }
         fonts.push_back(std::move(entry));
     }
 
@@ -280,6 +258,44 @@ static int ClampPointSize(int size)
     return size;
 }
 
+static std::string FoldAscii(std::string value)
+{
+    std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) {
+        return static_cast<char>(std::tolower(c));
+    });
+    return value;
+}
+
+static void SortFontsByLabel(std::vector<FontEntry> &fonts)
+{
+    std::stable_sort(fonts.begin(), fonts.end(), [](const FontEntry &a, const FontEntry &b) {
+        const std::string a_label = FoldAscii(a.label);
+        const std::string b_label = FoldAscii(b.label);
+        if (a_label != b_label) {
+            return a_label < b_label;
+        }
+        if (a.path != b.path) {
+            return a.path < b.path;
+        }
+        return a.face_index < b.face_index;
+    });
+}
+
+static int FindFontEntry(const std::vector<FontEntry> &fonts, const std::string &path, int face_index)
+{
+    if (path.empty()) {
+        return -1;
+    }
+    const std::string expanded_path = ExpandUserPath(path);
+    const std::string &match_path = expanded_path.empty() ? path : expanded_path;
+    for (size_t i = 0; i < fonts.size(); ++i) {
+        if (fonts[i].path == match_path && (face_index < 0 || fonts[i].face_index == face_index)) {
+            return static_cast<int>(i);
+        }
+    }
+    return -1;
+}
+
 } // namespace
 
 SDLFontDialogStatus SDLShowFontPicker(SDLFontSelection &selection)
@@ -288,6 +304,7 @@ SDLFontDialogStatus SDLShowFontPicker(SDLFontSelection &selection)
     if (fonts.empty()) {
         return SDLFontDialogStatus::Failed;
     }
+    SortFontsByLabel(fonts);
 
     const int win_w = 720;
     const int win_h = 540;
@@ -320,7 +337,8 @@ SDLFontDialogStatus SDLShowFontPicker(SDLFontSelection &selection)
     }
 
     int point_size = ClampPointSize(static_cast<int>(selection.point_size > 0.0f ? selection.point_size : 18));
-    int selected = 0;
+    const int current = FindFontEntry(fonts, selection.path, selection.face_index);
+    int selected = current >= 0 ? current : 0;
     int scroll = 0;
 
     const int pad = 12;
@@ -486,8 +504,14 @@ SDLFontDialogStatus SDLShowFontPicker(SDLFontSelection &selection)
             const int y = list_y + i * line_h;
             if (idx == selected) {
                 FillRect(surface, 0, y, win_w, line_h, Color{60, 80, 120, 255});
+            } else if (idx == current) {
+                FillRect(surface, 0, y, win_w, line_h, Color{42, 48, 58, 255});
             }
-            RenderText(surface, ui_face, list_x, y, fonts[idx].label, Color{240, 240, 240, 255});
+            std::string label = fonts[idx].label;
+            if (idx == current) {
+                label += "  [current]";
+            }
+            RenderText(surface, ui_face, list_x, y, label, Color{240, 240, 240, 255});
         }
 
         RenderText(surface, ui_face, pad, win_h - footer_h + 10,
@@ -513,9 +537,6 @@ SDLFontDialogStatus SDLShowFontPicker(SDLFontSelection &selection)
     if (status == SDLFontDialogStatus::Chosen) {
         selection.path = fonts[selected].path;
         selection.face_index = fonts[selected].face_index;
-        if (!fonts[selected].fc_name.empty()) {
-            selection.fc_name = fonts[selected].fc_name;
-        }
         selection.point_size = static_cast<float>(point_size);
     }
 

--- a/WinPort/src/Backend/SDL/SDLFontDialog.h
+++ b/WinPort/src/Backend/SDL/SDLFontDialog.h
@@ -12,7 +12,6 @@ enum class SDLFontDialogStatus
 struct SDLFontSelection
 {
     std::string path;
-    std::string fc_name;
     float point_size{0.0f};
     int face_index{-1};
 };

--- a/WinPort/src/Backend/SDL/SDLFontManager.cpp
+++ b/WinPort/src/Backend/SDL/SDLFontManager.cpp
@@ -10,18 +10,11 @@
 #include <cctype>
 #include <cmath>
 #include <cstdlib>
-#include <cstring>
 #include <fstream>
 #include <limits>
-#include <limits.h>
 
 #if !defined(__APPLE__)
 #include <fontconfig/fontconfig.h>
-#endif
-
-#if defined(__APPLE__)
-#include <CoreText/CoreText.h>
-#include <CoreGraphics/CoreGraphics.h>
 #endif
 
 namespace
@@ -132,39 +125,6 @@ static bool ClusterPrefersEmojiPresentation(const std::u32string &cluster)
 }
 
 #if !defined(__APPLE__)
-static bool AppendFontPathFromFontconfigDescriptor(std::vector<std::string> &out, const std::string &descriptor)
-{
-	if (descriptor.empty()) {
-		return false;
-	}
-	FcPattern *pattern = FcNameParse(reinterpret_cast<const FcChar8 *>(descriptor.c_str()));
-	if (!pattern) {
-		return false;
-	}
-	FcConfigSubstitute(nullptr, pattern, FcMatchPattern);
-	FcDefaultSubstitute(pattern);
-	FcResult res = FcResultMatch;
-	FcPattern *font = FcFontMatch(nullptr, pattern, &res);
-	FcPatternDestroy(pattern);
-	if (!font || res != FcResultMatch) {
-		if (font) {
-			FcPatternDestroy(font);
-		}
-		return false;
-	}
-	FcChar8 *file = nullptr;
-	int index = 0;
-	if (FcPatternGetString(font, FC_FILE, 0, &file) != FcResultMatch) {
-		FcPatternDestroy(font);
-		return false;
-	}
-	FcPatternGetInteger(font, FC_INDEX, 0, &index);
-	const std::string descriptor_out = BuildFontPathDescriptor(reinterpret_cast<const char *>(file), index);
-	FcPatternDestroy(font);
-	out.emplace_back(descriptor_out);
-	return true;
-}
-
 static void AppendFontPathFromFontconfigFamily(std::vector<std::string> &out, const std::string &family, bool require_fixed)
 {
 	if (family.empty()) {
@@ -176,7 +136,7 @@ static void AppendFontPathFromFontconfigFamily(std::vector<std::string> &out, co
 	}
 	FcPatternAddString(pattern, FC_FAMILY, reinterpret_cast<const FcChar8 *>(family.c_str()));
 	if (require_fixed) {
-		FcPatternAddBool(pattern, FC_SPACING, FC_MONO);
+		FcPatternAddInteger(pattern, FC_SPACING, FC_MONO);
 	}
 	FcConfigSubstitute(nullptr, pattern, FcMatchPattern);
 	FcDefaultSubstitute(pattern);
@@ -332,83 +292,6 @@ static std::vector<std::string> DefaultFallbackFontCandidates()
 	return out;
 }
 
-static std::vector<std::string> ExtractFontNamesFromDescriptor(const std::string &descriptor)
-{
-	std::vector<std::string> names;
-	std::string trimmed = TrimString(descriptor);
-	if (trimmed.empty()) {
-		return names;
-	}
-	const size_t colon = trimmed.find(':');
-	if (colon != std::string::npos) {
-		const std::string prefix = trimmed.substr(0, colon);
-		if (!prefix.empty()) {
-			names.emplace_back(prefix);
-		}
-		const std::string tail = trimmed.substr(colon + 1);
-		trimmed = TrimString(tail);
-		if (trimmed.empty()) {
-			return names;
-		}
-	}
-
-	const char *face_key = "face=";
-	const size_t face_pos = trimmed.find(face_key);
-	if (face_pos != std::string::npos) {
-		size_t value_start = face_pos + strlen(face_key);
-		size_t value_end = trimmed.find_first_of(",;", value_start);
-		const std::string face = TrimString(trimmed.substr(value_start, value_end - value_start));
-		if (!face.empty()) {
-			names.emplace_back(face);
-			return names;
-		}
-	}
-
-	const size_t last_semicolon = trimmed.find_last_of(';');
-	if (last_semicolon != std::string::npos && last_semicolon + 1 < trimmed.size()) {
-		const std::string tail = TrimString(trimmed.substr(last_semicolon + 1));
-		if (!tail.empty()) {
-			names.emplace_back(tail);
-			return names;
-		}
-	}
-
-	if (!trimmed.empty()) {
-		names.emplace_back(trimmed);
-	}
-	return names;
-}
-
-#if defined(__APPLE__)
-static void AppendFontPathForName(const std::string &name, std::vector<std::string> &out)
-{
-	if (name.empty()) {
-		return;
-	}
-	CFStringRef cf_name = CFStringCreateWithCString(kCFAllocatorDefault, name.c_str(), kCFStringEncodingUTF8);
-	if (!cf_name) {
-		return;
-	}
-	CTFontDescriptorRef desc = CTFontDescriptorCreateWithNameAndSize(cf_name, 0.0);
-	CFRelease(cf_name);
-	if (!desc) {
-		return;
-	}
-	CFURLRef url = static_cast<CFURLRef>(CTFontDescriptorCopyAttribute(desc, kCTFontURLAttribute));
-	CFRelease(desc);
-	if (!url) {
-		return;
-	}
-	char buffer[PATH_MAX];
-	if (CFURLGetFileSystemRepresentation(url, true, reinterpret_cast<UInt8 *>(buffer), sizeof(buffer))) {
-		AppendFontPathIfReadable(out, buffer);
-	}
-	CFRelease(url);
-}
-#else
-static void AppendFontPathForName(const std::string &, std::vector<std::string> &) {}
-#endif
-
 static void AppendFontPathsFromConfig(std::vector<std::string> &out)
 {
 	const std::string config_path = InMyConfig("sdl_font", false);
@@ -433,20 +316,7 @@ static void AppendFontPathsFromConfig(std::vector<std::string> &out)
 			continue;
 		}
 
-#if !defined(__APPLE__)
-		if (AppendFontPathFromFontconfigDescriptor(out, trimmed)) {
-			continue;
-		}
-#endif
-
-		if (AppendFontPathIfReadable(out, trimmed)) {
-			continue;
-		}
-
-		const auto names = ExtractFontNamesFromDescriptor(trimmed);
-		for (const auto &name : names) {
-			AppendFontPathForName(name, out);
-		}
+		AppendFontPathIfReadable(out, trimmed);
 	}
 }
 
@@ -1195,6 +1065,46 @@ bool SaveFontPreference(const std::string &path, int face_index, int point_size)
 	return true;
 }
 
+bool LoadFontPreferenceFromConfig(SDLFontSelection &selection)
+{
+	const std::string config_path = InMyConfig("sdl_font", false);
+	if (config_path.empty()) {
+		return false;
+	}
+
+	std::ifstream file(config_path);
+	if (!file.is_open()) {
+		return false;
+	}
+
+	bool found_font = false;
+	bool found_size = false;
+	std::string line;
+	while (std::getline(file, line)) {
+		const std::string trimmed = TrimString(line);
+		if (trimmed.empty()) {
+			continue;
+		}
+
+		int point_size = 0;
+		if (ExtractFontPointSizeFromLine(trimmed, point_size)) {
+			selection.point_size = static_cast<float>(point_size);
+			found_size = true;
+			continue;
+		}
+
+		if (!found_font) {
+			const FontPathDescriptor desc = ParseFontPathDescriptor(trimmed);
+			if (!desc.path.empty()) {
+				selection.path = ExpandUserPath(desc.path);
+				selection.face_index = desc.face_index;
+				found_font = !selection.path.empty();
+			}
+		}
+	}
+	return found_font || found_size;
+}
+
 bool EnsureFontPreferenceSelected()
 {
 	const std::string config_path = InMyConfig("sdl_font", false);
@@ -1206,15 +1116,13 @@ bool EnsureFontPreferenceSelected()
 	if (status != SDLFontDialogStatus::Chosen) {
 		return false;
 	}
-	const std::string descriptor = selection.fc_name.empty() ? selection.path : selection.fc_name;
-	const int descriptor_face = selection.fc_name.empty() ? selection.face_index : -1;
-	if (descriptor.empty()) {
+	if (selection.path.empty()) {
 		return false;
 	}
 	const int chosen_size = (selection.point_size > 0.0f)
 		? NormalizeFontPointSize(selection.point_size)
 		: kDefaultFontPointSize;
-	return SaveFontPreference(descriptor, descriptor_face, chosen_size);
+	return SaveFontPreference(selection.path, selection.face_index, chosen_size);
 }
 
 int LoadFontPointSizeFromConfig()

--- a/WinPort/src/Backend/SDL/SDLFontManager.h
+++ b/WinPort/src/Backend/SDL/SDLFontManager.h
@@ -20,6 +20,8 @@
 
 #include "SDLShared.h"
 
+struct SDLFontSelection;
+
 class SDLFontManager
 {
 public:
@@ -105,5 +107,6 @@ int ClampFontPointSize(int pt);
 int NormalizeFontPointSize(float pt);
 bool ExtractFontPointSizeFromLine(const std::string &line, int &out_pt);
 bool SaveFontPreference(const std::string &path, int face_index, int point_size);
+bool LoadFontPreferenceFromConfig(SDLFontSelection &selection);
 bool EnsureFontPreferenceSelected();
 int LoadFontPointSizeFromConfig();

--- a/WinPort/src/Backend/SDL/SDLMain.cpp
+++ b/WinPort/src/Backend/SDL/SDLMain.cpp
@@ -773,6 +773,7 @@ private:
 	SHORT ClampColumn(int pixel_x) const;
 	SHORT ClampRow(int pixel_y) const;
 	static WORD SDLKeycodeToVK(SDL_Keycode key);
+	static WORD SDLScancodeToLayoutIndependentVK(SDL_Scancode scancode);
 	static int IsEnhancedKey(SDL_Keycode key, SDL_Scancode scancode);
 	static DWORD ModifiersToControlState(Uint16 mod);
 	void DamageAreaBetween(COORD c1, COORD c2);
@@ -1974,6 +1975,14 @@ WORD SDLConsoleBackend::SDLKeycodeToVK(SDL_Keycode key)
 	}
 }
 
+WORD SDLConsoleBackend::SDLScancodeToLayoutIndependentVK(SDL_Scancode scancode)
+{
+	if (scancode >= SDL_SCANCODE_A && scancode <= SDL_SCANCODE_Z) {
+		return static_cast<WORD>('A' + (scancode - SDL_SCANCODE_A));
+	}
+	return 0;
+}
+
 DWORD SDLConsoleBackend::ModifiersToControlState(Uint16 mod)
 {
 	DWORD state = 0;
@@ -2042,6 +2051,9 @@ void SDLConsoleBackend::HandleKeyEvent(const SDL_KeyboardEvent &key)
 	ir.Event.KeyEvent.bKeyDown = (key.type == SDL_KEYDOWN);
 	ir.Event.KeyEvent.wRepeatCount = key.repeat ? key.repeat : 1;
 	ir.Event.KeyEvent.wVirtualKeyCode = SDLKeycodeToVK(key.keysym.sym);
+	if (!ir.Event.KeyEvent.wVirtualKeyCode && (key.keysym.mod & (KMOD_CTRL | KMOD_ALT | KMOD_GUI)) != 0) {
+		ir.Event.KeyEvent.wVirtualKeyCode = SDLScancodeToLayoutIndependentVK(key.keysym.scancode);
+	}
 	ir.Event.KeyEvent.wVirtualScanCode = key.keysym.scancode;
 	ir.Event.KeyEvent.uChar.UnicodeChar = 0;
 	ir.Event.KeyEvent.dwControlKeyState = ModifiersToControlState(key.keysym.mod);

--- a/WinPort/src/Backend/SDL/SDLMain.cpp
+++ b/WinPort/src/Backend/SDL/SDLMain.cpp
@@ -2338,6 +2338,7 @@ void SDLConsoleBackend::RequestFontDialog()
 void SDLConsoleBackend::ChangeFontInteractive()
 {
 	SDLFontSelection selection;
+	LoadFontPreferenceFromConfig(selection);
 	const SDLFontDialogStatus status = SDLShowFontPicker(selection);
 	if (_window) {
 		SDL_ShowWindow(_window);
@@ -2361,10 +2362,7 @@ void SDLConsoleBackend::ChangeFontInteractive()
 		return;
 	}
 
-	const std::string descriptor = selection.fc_name.empty() ? selection.path : selection.fc_name;
-	const int descriptor_face = selection.fc_name.empty() ? selection.face_index : -1;
-
-	if (descriptor.empty()) {
+	if (selection.path.empty()) {
 		SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "far2l", "Selected font did not provide a path.", _window);
 		return;
 	}
@@ -2373,7 +2371,7 @@ void SDLConsoleBackend::ChangeFontInteractive()
 		? NormalizeFontPointSize(selection.point_size)
 		: LoadFontPointSizeFromConfig();
 
-	if (!SaveFontPreference(descriptor, descriptor_face, chosen_size)) {
+	if (!SaveFontPreference(selection.path, selection.face_index, chosen_size)) {
 		SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "far2l", "Unable to save selected font.", _window);
 		return;
 	}


### PR DESCRIPTION
for exact matching on load, to avoid non monospaced version to be chosen 

Also layout independent shortcuts are added