### PR TITLE
fix(vt): suppress key-up events for plain-text chars to prevent doubling chars

### DIFF
--- a/far2l/src/hmenu.cpp
+++ b/far2l/src/hmenu.cpp
@@ -172,12 +172,18 @@ int HMenu::ProcessKey(FarKey Key)
 			FrameManager->ProcessKey(KEY_ALTF9);
 			break;
 		case KEY_OP_PLAINTEXT: {
-			const wchar_t *str = eStackAsString();
+			FARString strText;
+			if (!GPastedText.IsEmpty()) {
+				strText = GPastedText;
+				GPastedText.Clear();
+			} else {
+				strText = eStackAsString();
+			}
 
-			if (!*str)
+			if (strText.IsEmpty())
 				return FALSE;
 
-			Key = *str;
+			Key = strText[0];
 			break;
 		}
 		case KEY_NONE:

--- a/far2l/src/vt/vtshell.cpp
+++ b/far2l/src/vt/vtshell.cpp
@@ -900,6 +900,11 @@ class VTShell : VTOutputReader::IProcessor, VTInputReader::IProcessor, IVTShell
 			if (spec)
 				return spec;
 		}
+		// For plain text characters (VK==0) there is no terminal-level key-release
+		// representation. Writing the same raw char on UP would double every character
+		// in bracketed paste and in any mode that forwards key-up events (win32/kitty).
+		if (!KeyEvent.bKeyDown)
+			return std::string();
 
 		wchar_t wz[3] = {KeyEvent.uChar.UnicodeChar, 0};
 		if (_slavename.empty() && wz[0] == '\r') //pipes fallback


### PR DESCRIPTION
### Bug description

When pasting text from the clipboard into a VT child process (e.g., `omp`, `bash`, or any other interactive shell) running inside `far2l --tty`, every pasted character appears twice.

**Example:** pasting `lmv/dev-restructured` into a VT child results in `llmmvv//ddeevv--rreessttrruuccttuurreedd`.

This only happens when the outer terminal supports and enables bracketed paste (most modern terminals: GNOME Terminal 3.48+, iTerm2 3.5+, Windows Terminal 1.21+, etc.) **and** the VT child requests a key-reporting mode that forwards key-release events, such as:

* **win32-input-mode** (`CSI ? 9001 h`) — used by PowerShell, Windows-era tools
* **Kitty keyboard protocol** with key-release reporting (`CSI > 1 u` or `CSI > 2 u`) — used by modern editors

### Root cause

`VTShell::TranslateKeyEvent()` in `vtshell.cpp` translates `INPUT_RECORD` key events into terminal escape sequences or raw bytes. For plain-text characters (letters, digits, punctuation), the `INPUT_RECORD` has `wVirtualKeyCode == 0`. `TranslateKeyEvent` converts `uChar.UnicodeChar` to a multibyte string and returns it **for both `KEY_DOWN` and `KEY_UP` events**.

Bracketed paste injects plain-text characters as `KEY_EVENT` records with `VK == 0`. When the VT child has requested key-release reporting, far2l forwards the `KEY_UP` events too. Since `TranslateKeyEvent` returns the same raw byte sequence for UP as for DOWN, every pasted character is written to the child PTY **twice**.

This does **not** affect far2l's own internal editor, command line, or menus — those consumers correctly deduplicate bracketed paste via `GPastedText`. It only affects VT child processes that receive the raw translated bytes.

### Fix

**`vtshell.cpp`**: In `TranslateKeyEvent`, after the special-key handling block and before converting `uChar.UnicodeChar` to raw bytes, return an empty string for `KEY_UP` events when `wVirtualKeyCode == 0`. There is no terminal-level key-release representation for plain text characters, so emitting nothing on UP is the correct behavior and matches the existing suppression for special-key UP events (see the `if (!KeyEvent.bKeyDown ...)` guard a few lines earlier).

**`hmenu.cpp`** (drive-by fix): `HMenu::ProcessKey` handles `KEY_OP_PLAINTEXT` by calling `eStackAsString()`, which discards any bracketed-paste content already accumulated in `GPastedText`. Added a `GPastedText` check so the horizontal menu consumes bracketed-paste text when available, falling back to `eStackAsString()` only when empty.

### How to verify

1. Run `far2l --tty` inside a bracketed-paste-aware terminal.
2. Start a VT child that requests key-release reporting (e.g., `omp`, or any shell after running `printf '\e[?9001h'` for win32-input-mode).
3. Paste `lmv/dev-restructured`.
4. **Before fix:** `llmmvv//ddeevv--rreessttrruuccttuurreedd`
5. **After fix:** `lmv/dev-restructured` (exactly one instance)

Also verified:
* Build compiles with zero errors.
* Unit tests: 43 passed, 1 skipped (`Daemonize`).
* Normal typing in VT child is unaffected — alphanumeric keys still appear once.
