### PR TITLE
fix(console): prevent deadlock in console input queue on NOOP_EVENT

### DIFF
--- a/far2l/src/console/keyboard.cpp
+++ b/far2l/src/console/keyboard.cpp
@@ -34,6 +34,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "headers.hpp"
 
 #include <ctype.h>
+#include "InterThreadCall.hpp"
 #include "keyboard.hpp"
 #include "farqueue.hpp"
 #include "lang.hpp"
@@ -708,6 +709,11 @@ static DWORD GetInputRecordInner(INPUT_RECORD *rec, bool ExcludeMacro, bool Proc
 			}
 
 #endif
+			if (rec->EventType == NOOP_EVENT) {
+				Console.ReadInput(*rec);
+				DispatchInterThreadCalls();
+				continue;
+			}
 			break;
 		}
 


### PR DESCRIPTION
### Bug description

In TTY mode, when running a VT child process (e.g., `omp`) inside `far2l --tty`, mouse scroll events can cause the VT input reader thread to deadlock. The main thread enters an infinite spin loop in `GetInputRecordInner`, consuming 100% CPU and never making progress.

This bug was present in commits `ad576170c0f` (Fix broken and slow pasting in TTYX) and `987f93e96` ( Optimize bracketed paste performance), which both added synthetic `NOOP_EVENT` paths to `keyboard.cpp` without adding the corresponding dispatch handler for real `NOOP_EVENT` events written by `EnqueueInterThreadCallDelegate`.

### Root cause

`EnqueueInterThreadCallDelegate` writes a `NOOP_EVENT` into the console input queue to wake `WaitForNonEmptyWithTimeout` when a synchronous inter-thread call is pending. `GetInputRecordInner` peeks this event but previously discarded it without:

1. Reading it from the queue (leaving it there)
2. Dispatching the pending inter-thread call

This causes the main thread to spin forever — the `NOOP_EVENT` is always present, so `WaitForNonEmptyWithTimeout` returns immediately, but the loop body discards it without handling the pending call, and the cycle repeats.

### Fix

In `GetInputRecordInner`, after the `#endif` that closes the `FAR2L_TTY_INPUT_PROFILE` block, add a check for `NOOP_EVENT`:

```cpp
if (rec->EventType == NOOP_EVENT) {
    Console.ReadInput(*rec);          // remove from queue
    DispatchInterThreadCalls();       // handle pending calls
    continue;                         // keep draining
}
```

This mirrors the existing pattern for `BRACKETED_PASTE_EVENT` and other synthetic events: read the event, perform the associated side effect, and continue the drain loop.
