### PR TITLE
Fix regressions with Del and NumPad arrow keys in TTY and WX backends related to the new Kitty keyboard protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,10 @@ docker run -it far2l
 
 or simply on **Debian/Ubuntu** (without SDL-dependencies):
 ``` sh
+# For Debian 13+ / Ubuntu 23.04+ (using wxWidgets 3.2):
+apt-get install libwxgtk3.2-dev libx11-dev libxi-dev libxml2-dev libuchardet-dev libssh-dev libssl-dev libsmbclient-dev libnfs-dev libneon27-dev libarchive-dev cmake pkg-config g++ git
+
+# For older distributions (using wxWidgets 3.0):
 apt-get install libwxgtk3.0-gtk3-dev libx11-dev libxi-dev libxml2-dev libuchardet-dev libssh-dev libssl-dev libsmbclient-dev libnfs-dev libneon27-dev libarchive-dev cmake pkg-config g++ git
 ```
 

--- a/WinPort/src/Backend/TTY/TTYBackend.cpp
+++ b/WinPort/src/Backend/TTY/TTYBackend.cpp
@@ -38,7 +38,8 @@ bool _iterm2_cmd_state = 0;
 static bool IsEnhancedKey(WORD code)
 {
 	return (code==VK_LEFT || code==VK_RIGHT || code==VK_UP || code==VK_DOWN
-		|| code==VK_HOME || code==VK_END || code==VK_NEXT || code==VK_PRIOR );
+		|| code==VK_HOME || code==VK_END || code==VK_NEXT || code==VK_PRIOR
+		|| code==VK_INSERT || code==VK_DELETE );
 }
 
 static WORD WChar2WinVKeyCode(WCHAR wc)

--- a/far2l/src/vt/vtshell_translation_kitty.cpp
+++ b/far2l/src/vt/vtshell_translation_kitty.cpp
@@ -224,13 +224,15 @@ std::string VT_TranslateKeyToKitty(const KEY_EVENT_RECORD &KeyEvent, int flags, 
 	if (ctrl)  modifiers |= 4;
 	modifiers++; // bit mask + 1 as spec requres
 
-	if (KeyEvent.dwControlKeyState & CAPSLOCK_ON) {
-		modifiers |= 64;
-		nolegacy = true;
-	}
-	if (KeyEvent.dwControlKeyState & NUMLOCK_ON) {
-		modifiers |= 128;
-		nolegacy = true;
+	if (flags & (4 | 8)) {
+		if (KeyEvent.dwControlKeyState & CAPSLOCK_ON) {
+			modifiers |= 64;
+			nolegacy = true;
+		}
+		if (KeyEvent.dwControlKeyState & NUMLOCK_ON) {
+			modifiers |= 128;
+			nolegacy = true;
+		}
 	}
 
 	setlocale(LC_CTYPE, "");
@@ -321,47 +323,47 @@ std::string VT_TranslateKeyToKitty(const KEY_EVENT_RECORD &KeyEvent, int flags, 
 		// non-CSIu keys: keycode is not an unicode code point
 
 		case VK_INSERT:
-			if (enhanced) { keycode = 2; suffix = '~'; }
-			else          { keycode = 57425; suffix = 'u'; }
+			if (enhanced || !(flags & 8)) { keycode = 2; suffix = '~'; }
+			else                          { keycode = 57425; suffix = 'u'; }
 			break;
 		case VK_DELETE:
-			if (enhanced) { keycode = 3; suffix = '~'; }
-			else          { keycode = 57426; suffix = 'u'; }
+			if (enhanced || !(flags & 8)) { keycode = 3; suffix = '~'; }
+			else                          { keycode = 57426; suffix = 'u'; }
 			break;
 
 		case VK_LEFT:
-			if (enhanced) { keycode = 1; suffix = 'D'; }
-			else          { keycode = 57417; suffix = 'u'; }
+			if (enhanced || !(flags & 8)) { keycode = 1; suffix = 'D'; }
+			else                          { keycode = 57417; suffix = 'u'; }
 			break;
 		case VK_RIGHT:
-			if (enhanced) { keycode = 1; suffix = 'C'; }
-			else          { keycode = 57418; suffix = 'u'; }
+			if (enhanced || !(flags & 8)) { keycode = 1; suffix = 'C'; }
+			else                          { keycode = 57418; suffix = 'u'; }
 			break;
 		case VK_UP:
-			if (enhanced) { keycode = 1; suffix = 'A'; }
-			else          { keycode = 57419; suffix = 'u'; }
+			if (enhanced || !(flags & 8)) { keycode = 1; suffix = 'A'; }
+			else                          { keycode = 57419; suffix = 'u'; }
 			break;
 		case VK_DOWN:
-			if (enhanced) { keycode = 1; suffix = 'B'; }
-			else          { keycode = 57420; suffix = 'u'; }
+			if (enhanced || !(flags & 8)) { keycode = 1; suffix = 'B'; }
+			else                          { keycode = 57420; suffix = 'u'; }
 			break;
 
 		case VK_PRIOR: // Page Up
-			if (enhanced) { keycode = 5; suffix = '~'; }
-			else          { keycode = 57421; suffix = 'u'; }
+			if (enhanced || !(flags & 8)) { keycode = 5; suffix = '~'; }
+			else                          { keycode = 57421; suffix = 'u'; }
 			break;
 		case VK_NEXT:  // Page Down
-			if (enhanced) { keycode = 6; suffix = '~'; }
-			else          { keycode = 57422; suffix = 'u'; }
+			if (enhanced || !(flags & 8)) { keycode = 6; suffix = '~'; }
+			else                          { keycode = 57422; suffix = 'u'; }
 			break;
 
 		case VK_HOME:
-			if (enhanced) { keycode = 1; suffix = 'H'; }
-			else          { keycode = 57423; suffix = 'u'; }
+			if (enhanced || !(flags & 8)) { keycode = 1; suffix = 'H'; }
+			else                          { keycode = 57423; suffix = 'u'; }
 			break;
 		case VK_END:
-			if (enhanced) { keycode = 1; suffix = 'F'; }
-			else          { keycode = 57424; suffix = 'u'; }
+			if (enhanced || !(flags & 8)) { keycode = 1; suffix = 'F'; }
+			else                          { keycode = 57424; suffix = 'u'; }
 			break;
 
 		case VK_F1:


### PR DESCRIPTION
1. Update `IsEnhancedKey` in `TTYBackend.cpp` to include `VK_INSERT` and `VK_DELETE` so they receive the `ENHANCED_KEY` flag, fixing TTY Del translation.
2. Modify `VT_TranslateKeyToKitty` to avoid appending `CAPSLOCK_ON` and `NUMLOCK_ON` modifiers to sequences unless alternate keys or full reporting is requested (`flags & (4 | 8)`). This prevents `nolegacy` from being spuriously activated when NumLock is on, allowing proper fallback to legacy sequences.
3. `VT_TranslateKeyToKitty` to fall back to legacy sequence behavior for NumPad navigation keys unless full reporting mode (`flags & 8`) is requested, ensuring compatibility with applications that do not support the full Kitty protocol.

Fixes #3409