### PR TITLE
fix(multiarc/targz): handle GNUTYPE_LONGLINK for hard links with long…

### DIFF
--- a/multiarc/src/formats/targz/targz.cpp
+++ b/multiarc/src/formats/targz/targz.cpp
@@ -319,6 +319,7 @@ static int GetArcItemTAR(struct ArcItemInfo *Info)
 	DWORD ReadSize;
 	BOOL SkipItem = FALSE;
 	std::vector<char> LongName;
+	std::vector<char> LongLink;
 	do {
 		NextPosition.Part.LowPart = WINPORT(SetFilePointer)(ArcHandle, NextPosition.Part.LowPart,
 				&NextPosition.Part.HighPart, FILE_BEGIN);
@@ -340,11 +341,11 @@ static int GetArcItemTAR(struct ArcItemInfo *Info)
 				|| TAR_hdr.header.typeflag == GNUTYPE_PAXHDR) {
 			SkipItem = TRUE;
 		} else {
-			// TODO: GNUTYPE_LONGLINK
 			DWORD dwUnixMode = 0;
 			SkipItem = FALSE;
 			if (!LongName.empty()) {
 				Info->PathName = LongName.data();
+				LongName.clear();
 			} else {
 				Info->PathName.clear();
 				if (TAR_hdr.header.prefix[0]) {
@@ -387,7 +388,12 @@ static int GetArcItemTAR(struct ArcItemInfo *Info)
 
 			if ((dwUnixMode & S_IFMT) == S_IFLNK)		// TAR_hdr.header.typeflag == SYMTYPE || TAR_hdr.header.typeflag == LNKTYPE
 			{
-				Info->LinkName.reset(new std::string(TAR_hdr.header.linkname));
+				if (!LongLink.empty()) {
+					Info->LinkName.reset(new std::string(LongLink.data()));
+					LongLink.clear();
+				} else {
+					Info->LinkName.reset(new std::string(TAR_hdr.header.linkname));
+				}
 				if (TAR_hdr.header.typeflag == LNKTYPE)
 					Info->LinkName->insert(0, "/");
 			}
@@ -426,38 +432,57 @@ static int GetArcItemTAR(struct ArcItemInfo *Info)
 			PrevPosition.i64+= (int64_t)sizeof(TAR_hdr);
 			WINPORT(SetFilePointer)
 			(ArcHandle, PrevPosition.Part.LowPart, &PrevPosition.Part.HighPart, FILE_BEGIN);
-			// we can't have two LONGNAME records in a row without a file between them
-			if (!LongName.empty())
-				return GETARC_BROKEN;
-			LongName.resize(Info->nPhysicalSize + 1);
-			DWORD BytesRead;
-			WINPORT(ReadFile)(ArcHandle, LongName.data(), Info->nPhysicalSize, &BytesRead, NULL);
-			if (BytesRead != Info->nPhysicalSize)
-				return GETARC_BROKEN;
 
-			if (TAR_hdr.header.typeflag == GNUTYPE_PAXHDR) {	// pax extended header: consists of sequence of "len key=value\n" strings
-				// currently using only "path" key - its a modern way to specify long file path
-				std::vector<char> PathRecord;
-				for (DWORD i = 0; i < BytesRead;) {
-					int len = atoi(&LongName[i]);
-					if (len <= 0 || (DWORD)len > BytesRead - i) {
-						fprintf(stderr, "%s: ext record bad len=%d at %x\n", __FUNCTION__, len, i);
-						break;
-					}
+			if (TAR_hdr.header.typeflag == GNUTYPE_LONGLINK) {
+				// Long linkname for the next entry
+				if (!LongLink.empty())
+					return GETARC_BROKEN;
+				LongLink.resize(Info->nPhysicalSize + 1);
+				LongLink.back() = 0;
+				DWORD BytesRead;
+				WINPORT(ReadFile)(ArcHandle, LongLink.data(), Info->nPhysicalSize, &BytesRead, NULL);
+				if (BytesRead != Info->nPhysicalSize)
+					return GETARC_BROKEN;
+			} else {
+				// we can't have two LONGNAME/PAXHDR records in a row without a file between them
+				if (!LongName.empty())
+					return GETARC_BROKEN;
+				LongName.resize(Info->nPhysicalSize + 1);
+				DWORD BytesRead;
+				WINPORT(ReadFile)(ArcHandle, LongName.data(), Info->nPhysicalSize, &BytesRead, NULL);
+				if (BytesRead != Info->nPhysicalSize)
+					return GETARC_BROKEN;
 
-					char *spc = strchr(&LongName[i], ' ');
-					char *eq = strchr(&LongName[i], '=');
-					if (!spc || !eq || eq < spc || LongName[i + len - 1] != '\n') {
-						fprintf(stderr, "%s: ext record bad at %x\n", __FUNCTION__, i);
-						break;
+				if (TAR_hdr.header.typeflag == GNUTYPE_PAXHDR) {	// pax extended header: consists of sequence of "len key=value\n" strings
+					// using "path" and "linkpath" keys
+					std::vector<char> PathRecord;
+					std::vector<char> LinkRecord;
+					for (DWORD i = 0; i < BytesRead;) {
+						int len = atoi(&LongName[i]);
+						if (len <= 0 || (DWORD)len > BytesRead - i) {
+							fprintf(stderr, "%s: ext record bad len=%d at %x\n", __FUNCTION__, len, i);
+							break;
+						}
+
+						char *spc = strchr(&LongName[i], ' ');
+						char *eq = strchr(&LongName[i], '=');
+						if (!spc || !eq || eq < spc || LongName[i + len - 1] != '\n') {
+							fprintf(stderr, "%s: ext record bad at %x\n", __FUNCTION__, i);
+							break;
+						}
+						if (strncmp(spc, " path=", 6) == 0) {
+							PathRecord.assign(eq + 1, &LongName[i + len - 1]);
+							PathRecord.emplace_back(0);
+						} else if (strncmp(spc, " linkpath=", 10) == 0) {
+							LinkRecord.assign(eq + 1, &LongName[i + len - 1]);
+							LinkRecord.emplace_back(0);
+						}
+						i+= len;
 					}
-					if (strncmp(spc, " path=", 6) == 0) {
-						PathRecord.assign(eq + 1, &LongName[i + len - 1]);
-						PathRecord.emplace_back(0);
-					}
-					i+= len;
+					LongName.swap(PathRecord);
+					if (!LinkRecord.empty())
+						LongLink.swap(LinkRecord);
 				}
-				LongName.swap(PathRecord);
 			}
 		}
 


### PR DESCRIPTION
fix(multiarc/targz): handle GNUTYPE_LONGLINK for hard links with long paths

TAR archives with hard links whose target path exceeds 100 characters
use a GNUTYPE_LONGLINK ('K') header block to store the full link name.
Previously this data was incorrectly stored in LongName (shared with
GNUTYPE_LONGNAME) and then applied to PathName instead of LinkName,
causing far2l to return GETARC_BROKEN when browsing such archives.

Note: this fix applies to the built-in TAR parser in targz.cpp, which
is used when libarchive is unavailable. When libarchive is present,
far2l delegates TAR parsing to it and this code path is not used.

Changes:
- Add separate LongLink vector to store GNUTYPE_LONGLINK data
- Route GNUTYPE_LONGLINK records into LongLink instead of LongName
- Apply LongLink to Info->LinkName when present
- Clear LongName after use to prevent stale data leaking to next entry
- Handle PAX extended header 'linkpath' key alongside existing 'path'
- Remove TODO: GNUTYPE_LONGLINK comment

Fixes opening TAR archives containing hard links with paths > 100 chars.

---

TAR-архивы, содержащие жёсткие ссылки (hard links) с длиной пути цели более 100 символов, использует специальный блок GNUTYPE_LONGLINK ('K') для хранения полного пути. Ранее этот блок обрабатывался так же, как GNUTYPE_LONGNAME — данные записывались в общую переменную LongName и затем применялись к PathName вместо LinkName. В результате при попытке открыть такой архив в far2l возвращался GETARC_BROKEN.

Примечание: исправление относится к встроенному парсеру TAR в targz.cpp, который используется когда libarchive недоступна. При наличии libarchive far2l делегирует разбор TAR этой библиотеке, и данный код не задействуется.

Изменения:
- Добавлена отдельная переменная LongLink для хранения данных GNUTYPE_LONGLINK
- Записи GNUTYPE_LONGLINK теперь направляются в LongLink, а не в LongName
- LongLink применяется к Info->LinkName при наличии данных
- Исправлена утечка данных: LongName теперь очищается после использования, иначе устаревшие данные попадали в следующую запись
- В обработке PAX extended header добавлена поддержка ключа 'linkpath' наряду с уже существующим 'path'
- Удалён комментарий TODO: GNUTYPE_LONGLINK

Проверено: архивы с жёсткими ссылками с длиной пути более 100 символов теперь корректно открываются в far2l.