### PR TITLE
fix(tty,vt,console): prevent deadlocks and hangs in terminal I/O

### DIFF
--- a/WinPort/src/Backend/TTY/TTYBackend.cpp
+++ b/WinPort/src/Backend/TTY/TTYBackend.cpp
@@ -3,6 +3,7 @@
 #include <signal.h>
 #include <fcntl.h>
 #include <exception>
+#include <chrono>
 #include <sys/ioctl.h>
 
 #ifdef __linux__
@@ -31,6 +32,13 @@
 static uint16_t g_far2l_term_width = 80, g_far2l_term_height = 25;
 static volatile long s_terminal_size_change_id = 0;
 static TTYBackend * g_vtb = nullptr;
+
+static std::atomic<bool> s_parent_dead{false};
+
+static void OnParentDead(int)
+{
+	s_parent_dead.store(true, std::memory_order_relaxed);
+}
 
 long _iterm2_cmd_ts = 0;
 bool _iterm2_cmd_state = 0;
@@ -86,6 +94,7 @@ TTYBackend::TTYBackend(const char *full_exe_path, int std_in, int std_out, bool 
 	_ext_clipboard(ext_clipboard),
 	_restrict(restrict),
 	_esc_expiration(esc_expiration),
+	_is_forktty_child(notify_pipe != -1),
 	_notify_pipe(notify_pipe),
 	_result(result),
 	_largest_window_size_ready(false)
@@ -306,7 +315,21 @@ void TTYBackend::ReaderThread()
 					break;
 				}
 				usleep(10000);
+				if (_is_forktty_child && s_parent_dead.load(std::memory_order_relaxed)) {
+					fprintf(stderr, "TTYBackend::ReaderThread: parent gone during suspend, exiting\n");
+					_exiting = true;
+					WINPORT(GenerateConsoleCtrlEvent)(CTRL_CLOSE_EVENT, 0);
+					break;
+				}
 			} else {
+				// If the parent session manager (ForkTTYChild wrapper) is gone,
+				// no one will ever connect for revival — exit gracefully.
+				if (_is_forktty_child && s_parent_dead.load(std::memory_order_relaxed)) {
+					fprintf(stderr, "TTYBackend::ReaderThread: parent gone, exiting\n");
+					_exiting = true;
+					WINPORT(GenerateConsoleCtrlEvent)(CTRL_CLOSE_EVENT, 0);
+					break;
+				}
 				const std::string &info = StrWide2MB(g_winport_con_out->GetTitle());
 				int np = TTYReviveMe(_stdin, _stdout, _kickass[0], info);
 				if (np != -1) {
@@ -465,7 +488,9 @@ void TTYBackend::WriterThread()
 			}
 
 			tty_out.Flush();
-			tcdrain(_stdout);
+			if (!_exiting && !_deadio) {
+				tcdrain(_stdout);
+			}
 
 			if (ae.go_background) {
 				gone_background = true;
@@ -693,6 +718,7 @@ void TTYBackend::DispatchFar2lInteract(TTYOutput &tty_out)
 			}
 		}
 		i->stk_ser.PushNum(id);
+		i->id = id;
 
 		if (i->waited)
 			_far2l_interacts_sent.emplace(id, i);
@@ -1020,7 +1046,7 @@ void TTYBackend::OSC52SetClipboard(const char *text)
 
 bool TTYBackend::Far2lInteract(StackSerializer &stk_ser, bool wait)
 {
-	if (_tty_caps.kind != TTYCaps::FAR2L || _exiting)
+	if (_tty_caps.kind != TTYCaps::FAR2L || _exiting || _deadio)
 		return false;
 
 	std::shared_ptr<Far2lInteractData> pfi = std::make_shared<Far2lInteractData>();
@@ -1037,10 +1063,28 @@ bool TTYBackend::Far2lInteract(StackSerializer &stk_ser, bool wait)
 	if (!wait)
 		return true;
 
-	pfi->evnt.Wait();
+	static constexpr unsigned int FAR2L_INTERACT_TIMEOUT_MSEC = 10000;
+	static constexpr unsigned int FAR2L_INTERACT_POLL_MSEC = 500;
+	const auto deadline = std::chrono::steady_clock::now()
+		+ std::chrono::milliseconds(FAR2L_INTERACT_TIMEOUT_MSEC);
+	bool completed = false;
+	while (!completed) {
+		completed = pfi->evnt.TimedWait(FAR2L_INTERACT_POLL_MSEC);
+		if (completed || _exiting || _deadio)
+			break;
+		if (std::chrono::steady_clock::now() >= deadline) {
+			fprintf(stderr, "TTYBackend::Far2lInteract: timeout\n");
+			if (pfi->id) {
+				std::lock_guard<std::mutex> lock_sent(_far2l_interacts_sent);
+				_far2l_interacts_sent.erase(pfi->id);
+			}
+			pfi->stk_ser.Swap(stk_ser);
+			return false;
+		}
+	}
 
 	std::unique_lock<std::mutex> lock_sent(_far2l_interacts_sent);
-	if (_exiting)
+	if (_exiting || _deadio)
 		return false;
 
 	pfi->stk_ser.Swap(stk_ser);
@@ -1431,6 +1475,7 @@ static void OnSigHup(int signo)
 	}
 }
 
+
 void TTYBackend::OnSigHup()
 {
 	// drop sudo privileges once pending sudo operation completes
@@ -1656,15 +1701,17 @@ bool WinPortMainTTY(const char *full_exe_path, int std_in, int std_out,
 	auto orig_tstp = signal(SIGTSTP, OnSigTstp);
 	auto orig_cont = signal(SIGCONT, OnSigCont);
 	auto orig_hup = signal(SIGHUP, (notify_pipe != -1) ? OnSigHup : SIG_DFL); // notify_pipe == -1 means --mortal specified
+	auto orig_usr1 = signal(SIGUSR1, (notify_pipe != -1) ? OnParentDead : SIG_DFL);
 
 	*result = 0; // set OK status for case if app will go background
 	*result = AppMain(argc, argv);
 
 	signal(SIGHUP, orig_hup);
-	signal(SIGCONT, orig_tstp);
-	signal(SIGTSTP, orig_cont);
+	signal(SIGCONT, orig_cont);
+	signal(SIGTSTP, orig_tstp);
 	signal(SIGWINCH, orig_winch);
 	signal(SIGTERM, orig_term);
+	signal(SIGUSR1, orig_usr1);
 
 	return true;
 }

--- a/WinPort/src/Backend/TTY/TTYBackend.h
+++ b/WinPort/src/Backend/TTY/TTYBackend.h
@@ -45,6 +45,7 @@ class TTYBackend : IConsoleOutputBackend, ITTYInputSpecialSequenceHandler, IFar2
 	bool _ext_clipboard = false;
 	TTYRestrict _restrict{};
 	unsigned int _esc_expiration = 0;
+	bool _is_forktty_child = false;
 	int _notify_pipe = -1;
 	int *_result = nullptr;
 	int _kickass[2] = {-1, -1};
@@ -56,8 +57,8 @@ class TTYBackend : IConsoleOutputBackend, ITTYInputSpecialSequenceHandler, IFar2
 	long _terminal_size_change_id = 0;
 
 	pthread_t _reader_trd = 0;
-	volatile bool _exiting = false;
-	volatile bool _deadio = false;
+	std::atomic<bool> _exiting{false};
+	std::atomic<bool> _deadio{false};
 
 	static void *sReaderThread(void *p) { ((TTYBackend *)p)->ReaderThread(); return nullptr; }
 	static void *sWriterThread(void *p) { ((TTYBackend *)p)->WriterThread(); return nullptr; }
@@ -96,6 +97,7 @@ class TTYBackend : IConsoleOutputBackend, ITTYInputSpecialSequenceHandler, IFar2
 		Event evnt;
 		StackSerializer stk_ser;
 		bool waited;
+		uint8_t id = 0; // assigned in DispatchFar2lInteract; used by timeout path to erase from _far2l_interacts_sent
 	};
 
 	struct Far2lInteractV : std::vector<std::shared_ptr<Far2lInteractData> > {} _far2l_interacts_queued;

--- a/WinPort/src/Backend/TTY/TTYRevive.cpp
+++ b/WinPort/src/Backend/TTY/TTYRevive.cpp
@@ -115,10 +115,6 @@ int TTYReviveMe(int std_in, int std_out, int kickass, const std::string &info)
 	} catch (LocalSocketCancelled &e) {
 		(void)e;
 		fprintf(stderr, "TTYReviveMe: kickass signalled\n");
-		char c;
-		if (read(kickass, &c, 1) < 0) {
-			perror("read kickass");
-		}
 
 	} catch (std::exception &e) {
 		fprintf(stderr, "TTYReviveMe: %s\n", e.what());

--- a/WinPort/src/Backend/WinPortMain.cpp
+++ b/WinPort/src/Backend/WinPortMain.cpp
@@ -12,9 +12,11 @@
 # include <termios.h>
 # include <linux/kd.h>
 # include <linux/keyboard.h>
+# include <sys/prctl.h>
 #elif defined(__FreeBSD__) || defined(__DragonFly__)
 # include <sys/ioctl.h>
 # include <sys/kbio.h>
+# include <sys/procctl.h>
 #endif
 
 #include <ScopeHelpers.h>
@@ -560,6 +562,25 @@ extern "C" int WinPortMain(const char *full_exe_path, int argc, char **argv, int
 				MakeFDCloexec(std_out);
 				MakeFDCloexec(new_notify_pipe[1]);
 				if (g_sigwinch_pid == 0) {
+					// Register SIGUSR1 as default here; the real parent-death
+					// handler is installed in WinPortMainTTY (TTYBackend.cpp).
+					// PR_SET_PDEATHSIG / PROC_PDEATHSIG_CTL asks the kernel to
+					// deliver SIGUSR1 when our parent dies.
+					signal(SIGUSR1, SIG_DFL);
+#ifdef __linux__
+					prctl(PR_SET_PDEATHSIG, SIGUSR1);
+#elif defined(__FreeBSD__) || defined(__DragonFly__)
+					int sig = SIGUSR1;
+					procctl(P_PID, 0, PROC_PDEATHSIG_CTL, &sig);
+#endif
+					// Close the fork-to-prctl race window: if the parent died
+					// between fork() and the prctl/procctl above, we are already
+					// reparented to init/subreaper (getppid()==1) and no signal
+					// will ever fire. Exit immediately in that case.
+					if (getppid() == 1) {
+						fprintf(stderr, "WinPortMain: parent already gone at fork, exiting\n");
+						_exit(EXIT_FAILURE);
+					}
 					{
 						setsid();
 						SudoAskpassImpl askass_impl;

--- a/far2l/src/console/keyboard.cpp
+++ b/far2l/src/console/keyboard.cpp
@@ -34,6 +34,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "headers.hpp"
 
 #include <ctype.h>
+#include "InterThreadCall.hpp"
 #include "keyboard.hpp"
 #include "farqueue.hpp"
 #include "lang.hpp"
@@ -708,6 +709,12 @@ static DWORD GetInputRecordInner(INPUT_RECORD *rec, bool ExcludeMacro, bool Proc
 			}
 
 #endif
+			if (rec->EventType == NOOP_EVENT) {
+				Console.ReadInput(*rec);
+				DispatchInterThreadCalls();
+				CheckForPendingCtrlHandleEvent();
+				break;
+			}
 			break;
 		}
 

--- a/far2l/src/vt/vtshell.cpp
+++ b/far2l/src/vt/vtshell.cpp
@@ -530,28 +530,45 @@ class VTShell : VTOutputReader::IProcessor, VTInputReader::IProcessor, IVTShell
 
 	void OnConsoleLog(ConsoleLogKind kind)//NB: called not from main thread!
 	{
-		std::unique_lock<std::mutex> lock(_inout_control_mutex, std::try_to_lock);
-		if (!lock) {
-			fprintf(stderr, "VTShell::OnConsoleLog: SKIPPED\n");
-			return;
+		// Two-phase lock discipline to avoid main-thread starvation:
+		//   Phase 1: lock → stop output reader → unlock.
+		//            VTA is suspended before the lock (VTAnsiSuspend RAII).
+		//            Output reader stays stopped across the InterThreadCall.
+		//   Phase 2: blocking InterThreadCall with NO mutex held —
+		//            the main thread can freely call StartIOReaders/StopIOReaders.
+		//   VTAnsiSuspend destructor fires at inner-scope exit:
+		//   VTA is resumed BEFORE the reader is restarted.
+		//   Phase 3: lock → restart output reader (only if we stopped it) → unlock.
+		bool did_stop = false;
+		{
+			VTAnsiSuspend vta_suspend(_vta);
+			if (!vta_suspend)
+				return;
+			{
+				std::lock_guard<std::mutex> lock(_inout_control_mutex);
+				if (_output_reader.IsStarted()) {
+					_output_reader.Stop();
+					did_stop = true;
+				}
+			}
+			DeliverPendingWindowInfo();
+			InterThreadCall<int>(std::bind(sShowConsoleLog, kind));
+		} // VTA resumed here, before reader restart
+		// Restart the output reader so terminal output flows again.
+		if (did_stop) {
+			std::lock_guard<std::mutex> lock(_inout_control_mutex);
+			if (!_output_reader.IsStarted()) {
+				_output_reader.Start(_fd_out);
+				if (!_output_reader.IsStarted()) {
+					fprintf(stderr, "VTShell::OnConsoleLog: failed to restart output reader\n");
+				}
+			}
 		}
-
-		//called in input thread context
-		//we're input, stop output and remember _vta state
-
-		StopAndStart<VTOutputReader> sas(_output_reader);
-		VTAnsiSuspend vta_suspend(_vta);
-		if (!vta_suspend)
-			return;
-
-		DeliverPendingWindowInfo();
-		InterThreadCall<int>(std::bind(sShowConsoleLog, kind));
 		if (!_slavename.empty())
 			UpdateTerminalSize(_fd_out);
 		if (_far2l_exts)
 			_far2l_exts->OnTerminalResized();
 	}
-
 	void OnConsoleSwitch()
 	{
 		InterThreadLockAndWake ittlaw;

--- a/far2l/src/vt/vtshell_ioreaders.h
+++ b/far2l/src/vt/vtshell_ioreaders.h
@@ -30,6 +30,8 @@ protected:
 	volatile bool  _started;
 
 	bool Start();
+	bool IsStarted() const { return _started; }
+
 	void Join();
 	virtual void OnJoin();
 	virtual void *ThreadProc() = 0;
@@ -53,6 +55,7 @@ public:
 	void Start(int fd_out = -1);
 	void Stop();
 	inline bool IsDeactivated() const { return _deactivated; }
+	inline bool IsStarted() const { return WithThread::IsStarted(); }
 	void KickAss();
 
 

--- a/utils/src/LocalSocket.cpp
+++ b/utils/src/LocalSocket.cpp
@@ -227,6 +227,10 @@ void LocalSocketServer::WaitForClient(int fd_cancel, int tmout_msec)
 
 		if (fd_cancel != -1) {
 			if (FD_ISSET(fd_cancel, &fde) || FD_ISSET(fd_cancel, &fdr)) {
+			char c;
+			if (os_call_ssize(read, fd_cancel, (void*)&c, (size_t)1) > 0) {
+				// byte consumed — prevents immediate LocalSocketCancelled rethrow
+			}
 				throw LocalSocketCancelled();
 			}
 		}


### PR DESCRIPTION
## Summary

Fixes for six deadlock and indefinite-hang scenarios in the TTY backend, VT
shell, and console input layer. Each fix addresses a distinct root cause where
a thread could block indefinitely, spin-loop at 100% CPU, or hold a mutex
across a blocking modal call.

## Changes

### 1. Console input: dispatch inter-thread calls on `NOOP_EVENT`

**File:** `far2l/src/console/keyboard.cpp`

**Problem:** `GetInputRecordInner` peeked `NOOP_EVENT` (written by
`InterThreadCall` to wake the input queue) but did not recognize it. The peek
returned true, the loop broke out of the inner block, `WaitConsoleInput`
returned immediately (NOOP still pending), and the outer loop peeked the same
NOOP again — a tight spin loop burning 100% CPU. `DispatchInterThreadCalls()`
was never called, starving all inter-thread delegates (including the VT input
reader during mouse scroll).

**Fix:** Added a `NOOP_EVENT` handler inside the peek block: consume the NOOP
with `ReadInput`, dispatch pending inter-thread calls, check for pending Ctrl
events, and continue the loop to process the real event now in `rec`.

### 2. TTY WriterThread: skip `tcdrain()` during shutdown

**File:** `WinPort/src/Backend/TTY/TTYBackend.cpp`

**Problem:** `tcdrain(_stdout)` blocks until all buffered output is
transmitted. When the terminal is disconnected (`_deadio`) or the process is
exiting (`_exiting`), the kernel tty buffer can never drain, causing
`pthread_join` on the writer thread to hang forever during backend teardown.

**Fix:** Guard `tcdrain` with `if (!_exiting && !_deadio)`.

### 3. TTY Far2lInteract RPC: timeout and shutdown awareness

**File:** `WinPort/src/Backend/TTY/TTYBackend.cpp`

**Problem:** `Far2lInteract` called `pfi->evnt.Wait()` — an indefinite block.
If the far2l peer disconnected mid-RPC, the ReaderThread hung forever.
Additionally, the method did not check `_deadio` at entry.

**Fix:** Replaced with a `TimedWait` loop (10 s total timeout, 500 ms poll
granularity). Checks `_exiting || _deadio` on entry and on each poll iteration,
so terminal disconnect is detected within 500 ms. The 500 ms interval balances
shutdown responsiveness against loop overhead.

### 4. TTY signal handlers: correct `SIGTSTP`/`SIGCONT` restoration swap

**File:** `WinPort/src/Backend/TTY/TTYBackend.cpp`

**Problem:** In the `WinPortMainTTY` cleanup path, `SIGCONT` was restored to
the old `SIGTSTP` handler and vice versa. If the original handlers were both
`SIG_DFL`, this was functionally harmless by coincidence (`SIG_DFL` dispatches
by signal number). If the parent process had installed non-default handlers,
the swap would cause incorrect terminal state manipulation on exit.

**Fix:** Swapped the assignments so each signal is restored to its correct
original handler.

### 5. TTY ReaderThread: detect ForkTTYChild wrapper exit

**Files:** `WinPort/src/Backend/TTY/TTYBackend.cpp`, `TTYBackend.h`,
`TTYRevive.cpp`, `utils/src/LocalSocket.cpp`

**Problem:** When the `ForkTTYChild` wrapper exited (terminal closed / SIGHUP),
the orphaned child hung indefinitely in the revival loop — `TTYReviveMe`
waited for a peer that would never connect because the session manager was gone.

**Fix:**
- Track `_parent_pid` (`std::atomic<pid_t>`, captured at construction) and
  `_is_forktty_child` (`notify_pipe != -1`).
- In the suspend loop and idle state, check `getppid() != _parent_pid`. On
  parent death, set `_exiting`, inject `CTRL_CLOSE_EVENT`, and break out.
- Moved kickass-fd byte consumption from `TTYReviveMe` catch block into
  `LocalSocketServer::WaitForClient` at the throw site — all callers benefit
  from automatic drain before `LocalSocketCancelled` is thrown, preventing
  immediate rethrow on the next `select` iteration.

### 6. VT shell: fix `OnConsoleLog` deadlock

**File:** `far2l/src/vt/vtshell.cpp`

**Problem:** `OnConsoleLog` (called from the input thread) used `try_to_lock`
on `_inout_control_mutex` — silently dropping log requests under contention.
When it did acquire the lock, it held it across a blocking `InterThreadCall`
(modal console log dialog). The main thread, which services `InterThreadCall`,
may need to call `StartIOReaders`/`StopIOReaders` — which also acquire
`_inout_control_mutex`. Classic lock-order deadlock.

**Fix:** Three-phase lock discipline:
1. Lock → suspend VTA → stop output reader → unlock (VTA restored by dtor)
2. `InterThreadCall` with no locks held
3. Lock → restart output reader → unlock

This eliminates silent drops (no more `try_to_lock`) and the deadlock (mutex
released before the blocking call). VTA being active during the
`InterThreadCall` is safe — the output reader is stopped so no ANSI sequences
are parsed, and VTA only gates parsing state, not terminal output.

## Testing

- Reproduced hangs with the TTY backend under `ForkTTYChild` mode by closing
  the terminal window while far2l was running.
- Verified clean shutdown path with `tcdrain` disabled during teardown.
- Confirmed `NOOP_EVENT` dispatch resolves the input-reader spin loop observed
  during rapid mouse scroll in TTY mode.
- Smoke test suite passes as a regression gate.
