### PR TITLE
DI_MEMOEDIT improvements and corrections

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -82,6 +82,8 @@ Fills up to specified count handles, but returns background terminal session cou
 
 * added sort mode option "executables first", that works with the file panel by `FILE_ATTRIBUTE_EXECUTABLE` option. It is available for plug-ins in the same manner as "directories first" option so plug-ins are able to handle it as they need.
 
+* new "`IsMemoEdit`" member in `struct EditorInfo`.
+
 ### Added following commands into FILE_CONTROL_COMMANDS:
 * `FCTL_GETPANELPLUGINHANDLE`
 Can be used to interact with plugin that renders other panel.

--- a/HACKING.md
+++ b/HACKING.md
@@ -82,8 +82,6 @@ Fills up to specified count handles, but returns background terminal session cou
 
 * added sort mode option "executables first", that works with the file panel by `FILE_ATTRIBUTE_EXECUTABLE` option. It is available for plug-ins in the same manner as "directories first" option so plug-ins are able to handle it as they need.
 
-* new "`IsMemoEdit`" member in `struct EditorInfo`.
-
 ### Added following commands into FILE_CONTROL_COMMANDS:
 * `FCTL_GETPANELPLUGINHANDLE`
 Can be used to interact with plugin that renders other panel.
@@ -130,6 +128,9 @@ Size of colors array is `DLG_ITEM_MAX_CUST_COLORS` which is currently 5.
     - `LIFIND_KEEPAMPERSAND` (in `enum FARLISTFINDFLAGS`);
 * Flags in `enum PROCESSNAME_FLAGS` (added in #2452):
     - `PN_GENERATENAME`, `PN_CHECKMASK`, `PN_SHOWERRORMESSAGE`, `PN_RESERVED1`, `PN_CASESENSITIVE`, `PN_NONE`
+* Flags in `enum EDITOR_OPTIONS` (used in `struct EditorInfo.Options`, added in #3248 and #3449):
+    - `EOPT_SHOWNUMBERS`, `EOPT_SHOWGUTTER`. `EOPT_MEMOEDIT`
+
 
 ### Non-modal dialogs:
  `FDLG_NONMODAL` is now available (see https://github.com/elfmz/far2l/issues/2867#issuecomment-3368134072).

--- a/far2l/far2sdk/farplug-mb.h
+++ b/far2l/far2sdk/farplug-mb.h
@@ -1359,6 +1359,7 @@ namespace oldfar
 		DWORD CurState;
 		int WindowX;
 		int WindowY;
+		int IsMemoEdit;
 		DWORD Reserved[4];
 	};
 

--- a/far2l/far2sdk/farplug-mb.h
+++ b/far2l/far2sdk/farplug-mb.h
@@ -1318,6 +1318,7 @@ namespace oldfar
 		EOPT_BOM               = 0x00000200,
 		EOPT_SHOWNUMBERS       = 0x00000400,
 		EOPT_SHOWGUTTER        = 0x00000800,
+		EOPT_MEMOEDIT          = 0x00001000,
 	};
 
 
@@ -1359,7 +1360,6 @@ namespace oldfar
 		DWORD CurState;
 		int WindowX;
 		int WindowY;
-		int IsMemoEdit;
 		DWORD Reserved[4];
 	};
 

--- a/far2l/far2sdk/farplug-wide.h
+++ b/far2l/far2sdk/farplug-wide.h
@@ -1771,6 +1771,7 @@ struct EditorInfo
 	UINT CodePage;
 	int WindowX;
 	int WindowY;
+	int IsMemoEdit;
 	DWORD Reserved[3];
 };
 

--- a/far2l/far2sdk/farplug-wide.h
+++ b/far2l/far2sdk/farplug-wide.h
@@ -1732,6 +1732,7 @@ enum EDITOR_OPTIONS
 	EOPT_BOM               = 0x00000200,
 	EOPT_SHOWNUMBERS       = 0x00000400,
 	EOPT_SHOWGUTTER        = 0x00000800,
+	EOPT_MEMOEDIT          = 0x00001000,
 };
 
 
@@ -1771,7 +1772,6 @@ struct EditorInfo
 	UINT CodePage;
 	int WindowX;
 	int WindowY;
-	int IsMemoEdit;
 	DWORD Reserved[3];
 };
 

--- a/far2l/src/dialog.cpp
+++ b/far2l/src/dialog.cpp
@@ -5911,7 +5911,7 @@ LONG_PTR SendDlgMessageSynched(HANDLE hDlg, int Msg, int Param1, LONG_PTR Param2
 								did->PtrData[Len - 1] = 0;
 							}
 						}
-						break;
+						return Len;
 					case DI_COMBOBOX:
 					case DI_EDIT:
 					case DI_PSWEDIT:

--- a/far2l/src/dlgedit.cpp
+++ b/far2l/src/dlgedit.cpp
@@ -388,7 +388,7 @@ void DlgEdit::GetString(wchar_t *Str, int MaxSize, int Row)
 		} else {
 			wchar_t *buf = nullptr;
 			int size = 0;
-			if (!multiEdit->GetRawData(&buf, size, 1) || !buf) {
+			if (!multiEdit->GetRawData(&buf, size, 0) || !buf) {
 				*Str = 0;
 				return;
 			}
@@ -419,7 +419,7 @@ void DlgEdit::GetString(FARString &strStr, int Row)
 		} else {
 			wchar_t *buf = nullptr;
 			int size = 0;
-			if (!multiEdit->GetRawData(&buf, size, 1) || !buf) {
+			if (!multiEdit->GetRawData(&buf, size, 0) || !buf) {
 				strStr.Clear();
 				return;
 			}
@@ -599,7 +599,7 @@ int DlgEdit::GetLength()
 			return 0;
 		wchar_t *buf = nullptr;
 		int size = 0;
-		if (!multiEdit->GetRawData(&buf, size, 1) || !buf) {
+		if (!multiEdit->GetRawData(&buf, size, 0) || !buf) {
 			fprintf(stderr, "DlgEdit::GetLength multiline getraw failed\n");
 			return 0;
 		}

--- a/far2l/src/dlgedit.cpp
+++ b/far2l/src/dlgedit.cpp
@@ -168,6 +168,8 @@ int DlgEdit::ProcessKey(FarKey Key)
 
 	if (Type == DLGEDIT_MULTILINE) {
 		DialogEditorPluginScope scope(multiEdit);
+		if (CtrlObject->Plugins.ProcessEditorInput(FrameManager->GetLastInputRecord()))
+			return TRUE;
 		return multiEdit->ProcessKey(Key);
 	} else
 		return lineEdit->ProcessKey(Key);

--- a/far2l/src/editor.cpp
+++ b/far2l/src/editor.cpp
@@ -1494,6 +1494,11 @@ int Editor::ProcessKey(FarKey Key)
 	if (Key == KEY_NONE)
 		return TRUE;
 
+	if (Flags.Check(FEDITOR_DIALOGMEMOEDIT)) {
+		if (CtrlObject->Plugins.ProcessEditorInput(FrameManager->GetLastInputRecord()))
+			return TRUE;
+	}
+
 	_KEYMACRO(CleverSysLog SL(L"Editor::ProcessKey()"));
 	_KEYMACRO(SysLog(L"Key=%ls", _FARKEY_ToName(Key)));
 	int CurPos, CurVisPos, I;
@@ -6855,6 +6860,7 @@ int Editor::EditorControl(int Command, void *Param)
 				Info->CodePage = m_codepage;
 				Info->WindowX = X1;
 				Info->WindowY = Y1;
+				Info->IsMemoEdit = Flags.Check(FEDITOR_DIALOGMEMOEDIT) ? 1 : 0;
 				if (m_bWordWrap)
 				{
 					// For plugins (e.g., Colorer) to correctly process long lines that are wrapped,
@@ -7120,6 +7126,21 @@ int Editor::EditorControl(int Command, void *Param)
 				}
 			}
 			return TRUE;
+		}
+		case ECTL_PROCESSINPUT: {
+			if (Param) {
+				INPUT_RECORD *rec = (INPUT_RECORD *)Param;
+				if (CtrlObject->Plugins.ProcessEditorInput(rec))
+					return TRUE;
+				if (rec->EventType == MOUSE_EVENT)
+					ProcessMouse(&rec->Event.MouseEvent);
+				else {
+					FarKey Key = CalcKeyCode(rec, false);
+					ProcessKey(Key);
+				}
+				return TRUE;
+			}
+			return FALSE;
 		}
 		// должно выполняется в FileEditor::EditorControl()
 		case ECTL_PROCESSKEY: {

--- a/far2l/src/editor.cpp
+++ b/far2l/src/editor.cpp
@@ -1494,11 +1494,6 @@ int Editor::ProcessKey(FarKey Key)
 	if (Key == KEY_NONE)
 		return TRUE;
 
-	if (Flags.Check(FEDITOR_DIALOGMEMOEDIT)) {
-		if (CtrlObject->Plugins.ProcessEditorInput(FrameManager->GetLastInputRecord()))
-			return TRUE;
-	}
-
 	_KEYMACRO(CleverSysLog SL(L"Editor::ProcessKey()"));
 	_KEYMACRO(SysLog(L"Key=%ls", _FARKEY_ToName(Key)));
 	int CurPos, CurVisPos, I;
@@ -6852,6 +6847,9 @@ int Editor::EditorControl(int Command, void *Param)
 				if (EdOpt.ShowGutterMarks)
 					Info->Options|= EOPT_SHOWGUTTER;
 
+				if (Flags.Check(FEDITOR_DIALOGMEMOEDIT))
+					Info->Options|= EOPT_MEMOEDIT;
+
 				Info->TabSize = EdOpt.TabSize;
 				Info->BookMarkCount = POSCACHE_BOOKMARK_COUNT;
 				Info->CurState = Flags.Check(FEDITOR_LOCKMODE) ? ECSTATE_LOCKED : 0;
@@ -6860,7 +6858,6 @@ int Editor::EditorControl(int Command, void *Param)
 				Info->CodePage = m_codepage;
 				Info->WindowX = X1;
 				Info->WindowY = Y1;
-				Info->IsMemoEdit = Flags.Check(FEDITOR_DIALOGMEMOEDIT) ? 1 : 0;
 				if (m_bWordWrap)
 				{
 					// For plugins (e.g., Colorer) to correctly process long lines that are wrapped,

--- a/far2l/src/fileedit.cpp
+++ b/far2l/src/fileedit.cpp
@@ -785,7 +785,7 @@ int FileEditor::ReProcessKey(FarKey Key, int CalledFromControl)
 	}
 
 	/*
-		Все сотальные необработанные клавиши пустим далее
+		Все остальные необработанные клавиши пустим далее
 		$ 28.04.2001 DJ
 		не передаем KEY_MACRO* плагину - поскольку ReadRec в этом случае
 		никак не соответствует обрабатываемой клавише, возникают разномастные
@@ -2178,10 +2178,8 @@ void FileEditor::ResizeConsole()
 
 int FileEditor::ProcessEditorInput(INPUT_RECORD *Rec)
 {
-	int RetCode;
 	CtrlObject->Plugins.CurEditor = this;
-	RetCode = CtrlObject->Plugins.ProcessEditorInput(Rec);
-	return RetCode;
+	return CtrlObject->Plugins.ProcessEditorInput(Rec);
 }
 
 

--- a/far2l/src/macro/macrobrowser.cpp
+++ b/far2l/src/macro/macrobrowser.cpp
@@ -148,23 +148,6 @@ inline static bool IsEditChanged(HANDLE hDlg, int EditControl, const wchar_t *Or
 	return 0 != StrCmp(Cur, Original);
 }
 
-static bool IsMemoEditChanged(HANDLE hDlg, int EditControl, const wchar_t *Original)
-{
-	const wchar_t *Cur = reinterpret_cast<LPCWSTR>(SendDlgMessage(hDlg, DM_GETCONSTTEXTPTR, EditControl, 0));
-	if (!Cur && !Original)
-		return false;
-	if (!Cur || !Original)
-		return true;
-	FARString strCur = Cur; // DI_MEMOEDIT always add trailing newline
-	size_t last = strCur.GetLength();
-	if (last > 0) {
-		last--;
-		if (strCur[last] == '\n')
-			strCur.Truncate(last);
-	}
-	return 0 != StrCmp(strCur, Original);
-}
-
 inline static void DlgDefaultMark(HANDLE hDlg, int id, bool nodefault)
 {
 	// id - id of DI_TEXT for non-default marker
@@ -292,7 +275,7 @@ static LONG_PTR WINAPI MacroEditDlgProc(HANDLE hDlg, int Msg, int Param1, LONG_P
 						break;
 					case ME_MEMOEDIT_SEQUENCE:
 						DlgDefaultMark(hDlg, ME_MEMOEDIT_SEQUENCE-1, // mark (un)changed
-							IsMemoEditChanged(hDlg, ME_MEMOEDIT_SEQUENCE, MEParam->mr->Src) );
+							IsEditChanged(hDlg, ME_MEMOEDIT_SEQUENCE, MEParam->mr->Src) );
 						break;
 				}
 				break;
@@ -388,7 +371,7 @@ static LONG_PTR WINAPI MacroEditDlgProc(HANDLE hDlg, int Msg, int Param1, LONG_P
 
 							// workaround because DI_MEMOEDIT not process DN_EDITCHANGE properly
 							DlgDefaultMark(hDlg, ME_MEMOEDIT_SEQUENCE-1, // mark (un)changed
-								IsMemoEditChanged(hDlg, ME_MEMOEDIT_SEQUENCE, MEParam->mr->Src) );
+								IsEditChanged(hDlg, ME_MEMOEDIT_SEQUENCE, MEParam->mr->Src) );
 
 							// workaround to activate cursor in DI_MEMOEDIT after change mark
 							SendDlgMessage(hDlg, DM_SETFOCUS, ME_MEMOEDIT_SEQUENCE, 0);
@@ -726,7 +709,7 @@ bool MacroBrowser::Edit(int imacro)
 
 	Dialog Dlg(MacroEditDlg, ARRAYSIZE(MacroEditDlg), MacroEditDlgProc, (LONG_PTR)&Param);
 	Dlg.SetPosition(-1, -1, DLG_WIDTH, DLG_HEIGHT);
-	Dlg.SetHelp(L"KeyMacroSetting"/*KeyMacroLang"*/);
+	Dlg.SetHelp(L"KeyMacroLang"/*KeyMacroSetting"*/);
 	{
 		LockBottomFrame LBF;	// временно отменим прорисовку фрейма
 		Dlg.Process();
@@ -1027,8 +1010,8 @@ void MacroBrowser::PrepareVMenu()
 	fs2copy += "\n" + mi.strName;
 	v_menu_macroindex.emplace_back(-1, -1);
 
-	mi.strName.Format(L" Global: Constants=%d, Variables=%d, MacroFunctions=%d",
-		stat_glbConsts, stat_glbVars, Macro->CMacroFunction);
+	mi.strName.Format(L" Global: Constants=%d, Variables=%d, MacroFunctions=%zu",
+		stat_glbConsts, stat_glbVars, Macro->GetCountMacroFunction());
 	mi.Flags = 0;
 	ListMacro.AddItem(&mi);
 	fs2copy += "\n" + mi.strName;

--- a/far2l/src/plug/wrap.cpp
+++ b/far2l/src/plug/wrap.cpp
@@ -3757,6 +3757,7 @@ int WINAPI FarEditorControlA(int Command, void *Param)
 				oei->CurState = ei.CurState;
 				oei->WindowX = ei.WindowX;
 				oei->WindowY = ei.WindowY;
+				oei->IsMemoEdit = ei.IsMemoEdit;
 				return TRUE;
 			}
 

--- a/far2l/src/plug/wrap.cpp
+++ b/far2l/src/plug/wrap.cpp
@@ -3757,7 +3757,6 @@ int WINAPI FarEditorControlA(int Command, void *Param)
 				oei->CurState = ei.CurState;
 				oei->WindowX = ei.WindowX;
 				oei->WindowY = ei.WindowY;
-				oei->IsMemoEdit = ei.IsMemoEdit;
 				return TRUE;
 			}
 


### PR DESCRIPTION
Based on far2m
 * MemoEdit changes (Add ProcessEditorInput in Editor::ProcessKey()): from: https://github.com/shmuz/far2m/commit/c76e91a7b29fd64806195e072a7ce1bf403b20d0
 * Add ECTL_PROCESSINPUT for MemoEdit from: https://github.com/shmuz/far2m/commit/5df379e0c3039c08b7e60c67cc805f58f55d8f9f
 * FAR API: add "IsMemoEdit" member to EditorInfo from: https://github.com/shmuz/far2m/commit/abf3a2acf8d93604f862a2fc55373df6b84e3366
 * Corrections related to DI_MEMOEDIT from: https://github.com/shmuz/far2m/commit/a3006dafd72ea1285517a0d9c43b159378467cfb

+ not need individual function `IsMemoEditChanged(`