### PR TITLE
Fix AltGr producing uppercase letters in WX backend

### DIFF
--- a/WinPort/src/Backend/WX/wxMain.cpp
+++ b/WinPort/src/Backend/WX/wxMain.cpp
@@ -1471,6 +1471,11 @@ void WinPortPanel::OnKeyDown( wxKeyEvent& event )
 	const DWORD &dwMods = (ir.Event.KeyEvent.dwControlKeyState
 		& (LEFT_ALT_PRESSED | SHIFT_PRESSED | LEFT_CTRL_PRESSED | RIGHT_CTRL_PRESSED));
 
+	DWORD activeMods = dwMods;
+	if (_key_tracker.RightAlt() && !_key_tracker.LeftControl()) {
+		activeMods &= ~LEFT_CTRL_PRESSED;
+	}
+
 	if (event.GetKeyCode() == WXK_RETURN && dwMods == LEFT_ALT_PRESSED
 		&& (_prev_key_code == WXK_ALT || _prev_key_code == WXK_RETURN)) {
 
@@ -1501,8 +1506,8 @@ void WinPortPanel::OnKeyDown( wxKeyEvent& event )
 	// We can not trust OnKeyDown Unicode character value for Alt+letter due to wx issue #23421,
 	// so let's fall back to OnChar value for such key combinations.
 
-	if ( (dwMods != 0 && event.GetUnicodeKey() < 32)
-		|| ((dwMods & (LEFT_CTRL_PRESSED | RIGHT_CTRL_PRESSED | LEFT_ALT_PRESSED))
+	if ( (activeMods != 0 && event.GetUnicodeKey() < 32 && !_key_tracker.RightAlt())
+		|| ((activeMods & (LEFT_CTRL_PRESSED | RIGHT_CTRL_PRESSED | LEFT_ALT_PRESSED))
 #if !defined(__WXOSX__) && wxCHECK_VERSION(3, 2, 3) // workaround is still needed at least in wx 3.2.6, see wx issue #24772
 
 			&& (/*g_wayland ||*/ (!event.AltDown() || _key_tracker.RightAlt()) || !isLayoutDependentKey(event)) // workaround for wx issue #23421

--- a/WinPort/src/Backend/WX/wxMain.cpp
+++ b/WinPort/src/Backend/WX/wxMain.cpp
@@ -1505,7 +1505,7 @@ void WinPortPanel::OnKeyDown( wxKeyEvent& event )
 		|| ((dwMods & (LEFT_CTRL_PRESSED | RIGHT_CTRL_PRESSED | LEFT_ALT_PRESSED))
 #if !defined(__WXOSX__) && wxCHECK_VERSION(3, 2, 3) // workaround is still needed at least in wx 3.2.6, see wx issue #24772
 
-			&& (/*g_wayland ||*/ !event.AltDown() || !isLayoutDependentKey(event)) // workaround for wx issue #23421
+			&& (/*g_wayland ||*/ (!event.AltDown() || _key_tracker.RightAlt()) || !isLayoutDependentKey(event)) // workaround for wx issue #23421
 #endif
 			)
 		|| event.GetKeyCode() == WXK_DELETE || event.GetKeyCode() == WXK_RETURN
@@ -1730,7 +1730,7 @@ void WinPortPanel::OnChar( wxKeyEvent& event )
 		ir.Event.KeyEvent.uChar.UnicodeChar = event.GetUnicodeKey();
 
 #if !defined(__WXOSX__) && wxCHECK_VERSION(3, 2, 3)
-		if (event.AltDown() && isLayoutDependentKey(event)) {
+		if (event.AltDown() && !_key_tracker.RightAlt() && isLayoutDependentKey(event)) {
 
 			// workaround for wx issue #23421
 

--- a/WinPort/src/Backend/WX/wxWinTranslations.cpp
+++ b/WinPort/src/Backend/WX/wxWinTranslations.cpp
@@ -310,6 +310,10 @@ void KeyTracker::OnKeyDown(wxKeyEvent& event, DWORD ticks)
 	if (event.GetKeyCode() == WXK_CONTROL && event.GetRawKeyCode() == RAW_RCTRL) {
 		_right_control = true;
 	}
+	if ((event.GetKeyCode() == WXK_ALT || event.GetKeyCode() == 0) &&
+		(event.GetRawKeyCode() == RAW_ALTGR || event.GetRawKeyCode() == RAW_CONTEXT)) {
+		_right_alt = true;
+	}
 #endif
 }
 
@@ -332,6 +336,9 @@ bool KeyTracker::OnKeyUp(wxKeyEvent& event)
 #if defined(wxHAS_RAW_KEY_CODES) && !defined(__WXMAC__)
 	if (event.GetKeyCode() == WXK_CONTROL) {
 		_right_control = false;
+	}
+	if (event.GetKeyCode() == WXK_ALT || event.GetKeyCode() == 0) {
+		_right_alt = false;
 	}
 #endif
 
@@ -419,6 +426,7 @@ void KeyTracker::ForceAllUp()
 	_pressed_keys.clear();
 #ifndef __WXMAC__
 	_right_control = false;
+	_right_alt = false;
 #endif
 	_composing = false;
 }
@@ -461,6 +469,20 @@ bool KeyTracker::RightControl() const
 #else
 	return _right_control;
 #endif
+}
+
+bool KeyTracker::RightAlt() const
+{
+#ifdef __WXMAC__
+	return false;
+#else
+	return _right_alt;
+#endif
+}
+
+bool KeyTracker::LeftAlt() const
+{
+	return Alt() && !RightAlt();
 }
 
 //////////////////////
@@ -603,7 +625,8 @@ wx2INPUT_RECORD::wx2INPUT_RECORD(BOOL KeyDown, const wxKeyEvent& event, const Ke
 #endif
 
 #if defined(wxHAS_RAW_KEY_CODES) && !defined(__WXMAC__)
-	if (!event.GetKeyCode() && event.GetRawKeyCode() == RAW_CONTEXT) {
+	if ((!event.GetKeyCode() || event.GetKeyCode() == WXK_ALT) &&
+		(event.GetRawKeyCode() == RAW_CONTEXT || event.GetRawKeyCode() == RAW_ALTGR)) {
 		if (KeyDown) {
 			Event.KeyEvent.dwControlKeyState|= RIGHT_ALT_PRESSED;
 		}
@@ -628,8 +651,12 @@ wx2INPUT_RECORD::wx2INPUT_RECORD(BOOL KeyDown, const wxKeyEvent& event, const Ke
 	// so if event.ControlDown() and event.AltDown() are together then don't believe them and
 	// use only state maintained key_tracker. Unless under broadway, that may miss separate control
 	// keys events.
-	if (key_tracker.Alt() || (event.AltDown() && (!event.ControlDown() || g_broadway))) {
+	if (key_tracker.LeftAlt() || (event.AltDown() && !key_tracker.RightAlt() && (!event.ControlDown() || g_broadway))) {
 		Event.KeyEvent.dwControlKeyState|= LEFT_ALT_PRESSED;
+	}
+
+	if (key_tracker.RightAlt()) {
+		Event.KeyEvent.dwControlKeyState|= RIGHT_ALT_PRESSED;
 	}
 
 	if (key_tracker.Shift() || event.ShiftDown()) {

--- a/WinPort/src/Backend/WX/wxWinTranslations.cpp
+++ b/WinPort/src/Backend/WX/wxWinTranslations.cpp
@@ -628,7 +628,7 @@ wx2INPUT_RECORD::wx2INPUT_RECORD(BOOL KeyDown, const wxKeyEvent& event, const Ke
 	if ((!event.GetKeyCode() || event.GetKeyCode() == WXK_ALT) &&
 		(event.GetRawKeyCode() == RAW_CONTEXT || event.GetRawKeyCode() == RAW_ALTGR)) {
 		if (KeyDown) {
-			Event.KeyEvent.dwControlKeyState|= RIGHT_ALT_PRESSED;
+			Event.KeyEvent.dwControlKeyState|= RIGHT_ALT_PRESSED | LEFT_CTRL_PRESSED;
 		}
 		Event.KeyEvent.dwControlKeyState|= ENHANCED_KEY;
 		Event.KeyEvent.wVirtualKeyCode = VK_MENU;
@@ -656,7 +656,7 @@ wx2INPUT_RECORD::wx2INPUT_RECORD(BOOL KeyDown, const wxKeyEvent& event, const Ke
 	}
 
 	if (key_tracker.RightAlt()) {
-		Event.KeyEvent.dwControlKeyState|= RIGHT_ALT_PRESSED;
+		Event.KeyEvent.dwControlKeyState|= RIGHT_ALT_PRESSED | LEFT_CTRL_PRESSED;
 	}
 
 	if (key_tracker.Shift() || event.ShiftDown()) {

--- a/WinPort/src/Backend/WX/wxWinTranslations.h
+++ b/WinPort/src/Backend/WX/wxWinTranslations.h
@@ -14,6 +14,7 @@ class KeyTracker
 	bool _composing = false;
 #ifndef __WXMAC__
 	bool _right_control = false;
+	bool _right_alt = false;
 #endif
 	wxKeyEvent _last_keydown;
 	DWORD _last_keydown_ticks = 0;
@@ -31,6 +32,9 @@ public:
 	bool Shift() const;
 	bool LeftControl() const;
 	bool RightControl() const;
+
+	bool RightAlt() const;
+	bool LeftAlt() const;
 
 	bool Composing() const { return _composing; }
 


### PR DESCRIPTION
Modern wxWidgets releases treat AltGr (Right Alt) as active AltDown(). This caused the layout-dependent workaround (introduced for wx issue forcing Polish letters and other national characters into uppercase.

To resolve this:
- Introduced explicit Right Alt tracking via KeyTracker using GDK/X11 raw keycodes (RAW_ALTGR / RAW_CONTEXT).
- Updated wx2INPUT_RECORD to correctly map RIGHT_ALT_PRESSED and avoid injecting LEFT_ALT_PRESSED on AltGr actions.
- Bypassed the layout-dependent uppercase workaround in OnKeyDown and OnChar when RightAlt() is active.

Touch #3448