### PR TITLE
Fix irregular PgDn scrolling in UTF-8 Hex Viewer

### DIFF
--- a/far2l/src/viewer.cpp
+++ b/far2l/src/viewer.cpp
@@ -2573,7 +2573,9 @@ LONG_PTR WINAPI ViewerSearchDlgProc(HANDLE hDlg, int Msg, int Param1, LONG_PTR P
 {
 	switch (Msg) {
 		case DN_CLOSE:
-			if (Param1 >= 0) {
+			if (Param1 >= 0
+					&& ((unsigned)(Param1) + 1) != reinterpret_cast<Dialog*>(hDlg)->GetAllItemCount()) // button Cancel is the last element
+			{
 				int Pos = SendDlgMessage(hDlg, DM_SHOWITEM, SD_EDIT_TEXT, -1) ? SD_EDIT_TEXT : SD_EDIT_HEX;
 				const wchar_t *Txt = (const wchar_t*)SendDlgMessage(hDlg, DM_GETCONSTTEXTPTR, Pos, 0);
 				bool IsEmpty;

--- a/far2l/src/viewer.cpp
+++ b/far2l/src/viewer.cpp
@@ -1166,7 +1166,7 @@ void Viewer::ReadString(ViewerString &rString, int MaxSize, int StrSize)
 				break;
 		}	// TODO: ???
 
-		OutPtr = vread(piece, len);
+		OutPtr = vread(piece, len, true);
 		piece[OutPtr] = 0;
 		rString.SetChars(0, piece, (size_t)(OutPtr + 1));
 	} else {
@@ -2573,9 +2573,7 @@ LONG_PTR WINAPI ViewerSearchDlgProc(HANDLE hDlg, int Msg, int Param1, LONG_PTR P
 {
 	switch (Msg) {
 		case DN_CLOSE:
-			if (Param1 >= 0
-					&& ((unsigned)(Param1) + 1) != reinterpret_cast<Dialog*>(hDlg)->GetAllItemCount()) // button Cancel is the last element
-			{
+			if (Param1 >= 0) {
 				int Pos = SendDlgMessage(hDlg, DM_SHOWITEM, SD_EDIT_TEXT, -1) ? SD_EDIT_TEXT : SD_EDIT_HEX;
 				const wchar_t *Txt = (const wchar_t*)SendDlgMessage(hDlg, DM_GETCONSTTEXTPTR, Pos, 0);
 				bool IsEmpty;


### PR DESCRIPTION
When scrolling down (PgDn) in Hex mode, `Viewer::ReadString` is used to advance the file pointer to calculate the new offset. For UTF-8 files, `vread` was being called without the `Raw` parameter (defaulting to `false`). This caused it to read logical UTF-8 characters instead of raw bytes. Since UTF-8 characters can be multi-byte, the file position advanced by a variable number of bytes per line instead of strictly 16 bytes, resulting in irregular page jumps.

Explicitly passing `Raw = true` to `vread` when in Hex mode ensures the file pointer advances by exactly 16 bytes per line.

Touch #3445 (regression introduced in #3338)