### PR TITLE
ExecAsync: fix O(N^2) stdin write by tracking offset instead of erasing

### DIFF
--- a/utils/include/ExecAsync.h
+++ b/utils/include/ExecAsync.h
@@ -10,6 +10,7 @@ class ExecAsync : Threaded
 	std::vector<std::string> _args;
 
 	std::vector<char> _stdin, _stdout, _stderr;
+	size_t _stdin_offset{0};
 	std::mutex _mtx;
 	bool _dont_care{false};
 	bool _started{false};

--- a/utils/src/ExecAsync.cpp
+++ b/utils/src/ExecAsync.cpp
@@ -170,7 +170,7 @@ void *ExecAsync::ThreadProc()
 	std::string print_str;
 	if (!_program.empty()) {
 		print_str = '[';
-		print_str = _program;
+		print_str+= _program;
 		print_str+= ']';
 	}
 	std::vector<char *> argv(_args.size() + 1);
@@ -265,13 +265,22 @@ void *ExecAsync::ThreadProc()
 			fprintf(stderr, "ExecAsync: select timeout???\n");
 			continue;
 		}
-        if (in.fd[1] != -1 && FD_ISSET(in.fd[1], &write_fds)) {
-			if (_stdin.empty()) {
+		if (in.fd[1] != -1 && FD_ISSET(in.fd[1], &write_fds)) {
+			if (_stdin_offset >= _stdin.size()) {
 				CheckedCloseFD(in.fd[1]);
 			} else {
-				ssize_t r = write(in.fd[1], _stdin.data(), _stdin.size());
-				if (r > 0) {
-					_stdin.erase(_stdin.begin(), _stdin.begin() + r);
+				ssize_t nw = write(in.fd[1],
+								  _stdin.data() + _stdin_offset,
+								  _stdin.size() - _stdin_offset);
+				if (nw > 0) {
+					_stdin_offset += static_cast<size_t>(nw);
+					if (_stdin_offset >= _stdin.size()) {
+						std::vector<char>().swap(_stdin);
+						_stdin_offset = 0;
+						CheckedCloseFD(in.fd[1]);
+					}
+				} else if (nw < 0 && errno != EAGAIN && errno != EINTR) {
+					CheckedCloseFD(in.fd[1]);
 				}
 			}
 		}


### PR DESCRIPTION
При каждом частичном `write()` в **stdin** дочернего процесса выполнялся `erase()` с начала буфера — операция _O(N)_, из-за которой суммарная стоимость записи росла квадратично от объёма данных. Исправление заменяет удаление смещением позиции записи: после каждого `write()` продвигается маркер, буфер не затрагивается, память освобождается гарантированным swap-ом по завершении. Ошибки записи, кроме транзиентных (EAGAIN, EINTR), теперь корректно завершают запись - fd закрывается, исключая лишние итерации цикла select.

На практике проблема проявлялась в плагине **ImageViewer** при применении команд обработки изображения (F4): raw RGB данные кадра передавались через **stdin** во внешний инструмент (convert), и для изображений высокого разрешения задержка перед появлением результата росла непропорционально размеру файла.