### PR TITLE
Fix restoring inaccessible panel directories

### DIFF
--- a/far2l/src/ctrlobj.cpp
+++ b/far2l/src/ctrlobj.cpp
@@ -116,15 +116,20 @@ void ControlObject::Init()
 	FrameManager->InsertFrame(FPanels);
 	FrameManager->PluginCommit();
 
-	Cp()->LeftPanel->Update(0);
-	Cp()->RightPanel->Update(0);
+	{
+		// A cancelled elevation applies to both startup panel reads.  Do not
+		// prompt again for the other panel during the same initialization.
+		SudoClientRegion sdc_rgn;
+		Cp()->LeftPanel->Update(0);
+		Cp()->RightPanel->Update(0);
 
-	Cp()->LeftPanel->GoToFile(Opt.strLeftCurFile);
-	Cp()->RightPanel->GoToFile(Opt.strRightCurFile);
+		Cp()->LeftPanel->GoToFile(Opt.strLeftCurFile);
+		Cp()->RightPanel->GoToFile(Opt.strRightCurFile);
 
-	FARString strStartCurDir;
-	Cp()->ActivePanel->GetCurDir(strStartCurDir);
-	FarChDir(strStartCurDir);
+		FARString strStartCurDir;
+		Cp()->ActivePanel->GetCurDir(strStartCurDir);
+		FarChDir(strStartCurDir);
+	}
 	Cp()->ActivePanel->SetFocus();
 	{
 		FARString strOldTitle;

--- a/far2l/src/farwinapi.cpp
+++ b/far2l/src/farwinapi.cpp
@@ -425,7 +425,7 @@ BOOL apiSetCurrentDirectory(LPCWSTR lpPathName, bool Validate)
 	///	if ((CD[Offset] && CD[Offset+1]==L':' && !CD[Offset+2]) || IsLocalVolumeRootPath(CD))
 	// AddEndSlash(strDir);
 
-	if (strDir == strCurrentDirectory())
+	if (strDir == strCurrentDirectory() && !Validate)
 		return TRUE;
 
 	if (Validate) {
@@ -440,12 +440,10 @@ BOOL apiSetCurrentDirectory(LPCWSTR lpPathName, bool Validate)
 		}
 	}
 
-	strCurrentDirectory() = strDir;
-
 	// try to synchronize far cur dir with process cur dir
 	// WTF??? if(CtrlObject && CtrlObject->Plugins.GetOemPluginsCount())
 	{
-		if (!WINPORT(SetCurrentDirectory)(strCurrentDirectory())) {
+		if (!WINPORT(SetCurrentDirectory)(strDir)) {
 			fprintf(stderr, "apiSetCurrentDirectory: set curdir error %u for %ls\n", WINPORT(GetLastError()),
 					lpPathName);
 			if (Validate) {
@@ -453,6 +451,8 @@ BOOL apiSetCurrentDirectory(LPCWSTR lpPathName, bool Validate)
 			}
 		}
 	}
+
+	strCurrentDirectory() = strDir;
 
 	return TRUE;
 }

--- a/far2l/src/filepanels.cpp
+++ b/far2l/src/filepanels.cpp
@@ -76,19 +76,13 @@ FilePanels::FilePanels()
 	//_D(SysLog(L"MainKeyBar=0x%p",&MainKeyBar));
 }
 
-static void PrepareOptFolder(FARString &strSrc, int IsLocalPath_FarPath)
+static void PrepareOptFolder(FARString &strSrc)
 {
 	if (strSrc.IsEmpty()) {
 		strSrc = DefaultPanelInitialDirectory();
 	} else {
 		apiExpandEnvironmentStrings(strSrc, strSrc);
 	}
-
-	if (strSrc != WGOOD_SLASH) {
-		CheckShortcutFolder(strSrc, false, true);
-	}
-
-	// ConvertNameToFull(strSrc,strSrc);
 }
 
 void FilePanels::Init()
@@ -128,44 +122,34 @@ void FilePanels::Init()
 	}
 
 	ActivePanel->SetFocus();
-	// пытаемся избавится от зависания при запуске
-	int IsLocalPath_FarPath = IsLocalPath(g_strFarPath);
-	PrepareOptFolder(Opt.strLeftFolder, IsLocalPath_FarPath);
-	PrepareOptFolder(Opt.strRightFolder, IsLocalPath_FarPath);
+	PrepareOptFolder(Opt.strLeftFolder);
+	PrepareOptFolder(Opt.strRightFolder);
 
 	if (Opt.AutoSaveSetup || !Opt.SetupArgv) {
-		if (apiGetFileAttributes(Opt.strLeftFolder) != INVALID_FILE_ATTRIBUTES)
-			LeftPanel->InitCurDir(Opt.strLeftFolder);
-
-		if (apiGetFileAttributes(Opt.strRightFolder) != INVALID_FILE_ATTRIBUTES)
-			RightPanel->InitCurDir(Opt.strRightFolder);
+		LeftPanel->InitCurDir(Opt.strLeftFolder);
+		RightPanel->InitCurDir(Opt.strRightFolder);
 	}
 
 	if (!Opt.AutoSaveSetup) {
 		if (Opt.SetupArgv >= 1) {
 			if (ActivePanel == RightPanel) {
-				if (apiGetFileAttributes(Opt.strRightFolder) != INVALID_FILE_ATTRIBUTES)
-					RightPanel->InitCurDir(Opt.strRightFolder);
+				RightPanel->InitCurDir(Opt.strRightFolder);
 			} else {
-				if (apiGetFileAttributes(Opt.strLeftFolder) != INVALID_FILE_ATTRIBUTES)
-					LeftPanel->InitCurDir(Opt.strLeftFolder);
+				LeftPanel->InitCurDir(Opt.strLeftFolder);
 			}
 
 			if (Opt.SetupArgv == 2) {
 				if (ActivePanel == LeftPanel) {
-					if (apiGetFileAttributes(Opt.strRightFolder) != INVALID_FILE_ATTRIBUTES)
-						RightPanel->InitCurDir(Opt.strRightFolder);
+					RightPanel->InitCurDir(Opt.strRightFolder);
 				} else {
-					if (apiGetFileAttributes(Opt.strLeftFolder) != INVALID_FILE_ATTRIBUTES)
-						LeftPanel->InitCurDir(Opt.strLeftFolder);
+					LeftPanel->InitCurDir(Opt.strLeftFolder);
 				}
 			}
 		}
 
 		const wchar_t *PassiveFolder = PassiveIsLeftFlag ? Opt.strLeftFolder : Opt.strRightFolder;
 
-		if (Opt.SetupArgv < 2 && *PassiveFolder
-				&& (apiGetFileAttributes(PassiveFolder) != INVALID_FILE_ATTRIBUTES)) {
+		if (Opt.SetupArgv < 2 && *PassiveFolder) {
 			PassivePanel->InitCurDir(PassiveFolder);
 		}
 	}

--- a/far2l/src/filepanels.cpp
+++ b/far2l/src/filepanels.cpp
@@ -464,6 +464,12 @@ int64_t FilePanels::VMProcess(MacroOpcode OpCode, void *vParam, int64_t iParam)
 	return ActivePanel->VMProcess(OpCode, vParam, iParam);
 }
 
+void FilePanels::RetryActivePanelRead()
+{
+	if (ActivePanel->GetType() == FILE_PANEL)
+		static_cast<FileList *>(ActivePanel)->RetryFailedRead();
+}
+
 int FilePanels::ProcessKey(FarKey Key)
 {
 	if (!Key)
@@ -808,6 +814,7 @@ int FilePanels::ProcessKey(FarKey Key)
 		}
 	}
 
+	RetryActivePanelRead();
 	return TRUE;
 }
 

--- a/far2l/src/filepanels.hpp
+++ b/far2l/src/filepanels.hpp
@@ -44,6 +44,7 @@ class FilePanels : public Frame
 {
 private:
 	virtual void DisplayObject();
+	void RetryActivePanelRead();
 	typedef class Frame inherited;
 
 public:

--- a/far2l/src/panels/filelist.cpp
+++ b/far2l/src/panels/filelist.cpp
@@ -2461,12 +2461,19 @@ BOOL FileList::ChangeDir(const wchar_t *NewDir, BOOL IsUpdated)
 	SudoClientRegion sdc_rgn;
 
 	Panel *AnotherPanel;
-
-	if (PanelMode != PLUGIN_PANEL && !IsAbsolutePath(NewDir) && !TestCurrentDirectory(strCurDir))
-		FarChDir(strCurDir);
-
 	FARString strFindDir, strSetDir = NewDir;
 	bool dot2Present = !StrCmp(strSetDir, L"..");
+
+	if (PanelMode != PLUGIN_PANEL && !dot2Present && !IsAbsolutePath(NewDir) && !TestCurrentDirectory(strCurDir))
+		FarChDir(strCurDir);
+
+	if (PanelMode != PLUGIN_PANEL && dot2Present && !TestCurrentDirectory(strCurDir)) {
+		FARString strParentDir = strCurDir;
+		CutToFolderNameIfFolder(strParentDir);
+		if (!strParentDir.IsEmpty() && StrCmp(strParentDir, strCurDir))
+			strSetDir = strParentDir;
+	}
+
 	fprintf(stderr, "NewDir=%ls strCurDir=%ls dot2Present=%u\n", NewDir, strCurDir.CPtr(), dot2Present);
 
 	if (!dot2Present && StrCmp(strSetDir, L"."))

--- a/far2l/src/panels/filelist.hpp
+++ b/far2l/src/panels/filelist.hpp
@@ -181,6 +181,7 @@ private:
 
 	FARString strOriginalCurDir;
 	FARString strPluginDizName;
+	FARString strFailedReadDir;
 	ListDataVec ListData;
 	std::map<std::wstring, FARString> SymlinksCache;
 	HANDLE hPlugin;
@@ -323,6 +324,7 @@ public:
 		что панель невидима
 	*/
 	virtual void UpdateIfRequired();
+	virtual void RetryFailedRead();
 
 	virtual int SendKeyToPlugin(DWORD Key, BOOL Pred = FALSE);
 	virtual void CreateChangeNotification(int CheckTree);

--- a/far2l/src/panels/flupdate.cpp
+++ b/far2l/src/panels/flupdate.cpp
@@ -149,6 +149,21 @@ void FileList::ReadFileNames(int KeepSelection, int IgnoreVisible, int DrawMessa
 	apiGetCurrentDirectory(strSaveDir);
 	{
 		if (!SetCurPath()) {
+			// Do not leave a list read from another directory visible when the
+			// panel's current directory cannot be entered.
+			ListData.Clear();
+			SymlinksCache.clear();
+			CurFile = CurTopFile = 0;
+			LastCurFile = -1;
+			SelFileCount = 0;
+			SelFileSize = 0;
+			TotalFileCount = 0;
+			TotalFileSize = TotalFilePhysSize = LargestFilSize = LargestFilSizeL = LargestFilPhysSize = 0;
+			FreeDiskSize = 0;
+			CacheSelIndex = -1;
+			CacheSelClearIndex = -1;
+			MarkLM = 0;
+
 			if (!WinPortTesting())
 				FlushInputBuffer();		// Очистим буффер ввода, т.к. мы уже можем быть в другом месте...
 			return;

--- a/far2l/src/panels/flupdate.cpp
+++ b/far2l/src/panels/flupdate.cpp
@@ -163,9 +163,11 @@ void FileList::ReadFileNames(int KeepSelection, int IgnoreVisible, int DrawMessa
 			CacheSelIndex = -1;
 			CacheSelClearIndex = -1;
 			MarkLM = 0;
+			if (!IsLocalRootPath(strCurDir) && !IsLocalPrefixRootPath(strCurDir)
+					&& !IsLocalVolumeRootPath(strCurDir)) {
+				ListData.AddParentPoint();
+			}
 
-			if (!WinPortTesting())
-				FlushInputBuffer();		// Очистим буффер ввода, т.к. мы уже можем быть в другом месте...
 			return;
 		}
 	}

--- a/far2l/src/panels/flupdate.cpp
+++ b/far2l/src/panels/flupdate.cpp
@@ -102,6 +102,14 @@ void FileList::UpdateIfRequired()
 	}
 }
 
+void FileList::RetryFailedRead()
+{
+	if (strFailedReadDir == strCurDir && !strFailedReadDir.IsEmpty()
+			&& TestCurrentDirectory(strCurDir)) {
+		Update(0);
+	}
+}
+
 void ReadFileNamesMsg(const wchar_t *Msg)
 {
 	Message(0, 0, Msg::ReadingTitleFiles, Msg);
@@ -148,7 +156,13 @@ void FileList::ReadFileNames(int KeepSelection, int IgnoreVisible, int DrawMessa
 	FARString strSaveDir;
 	apiGetCurrentDirectory(strSaveDir);
 	{
+		FARString strReadDir = strCurDir;
 		if (!SetCurPath()) {
+			if (strCurDir == strReadDir)
+				strFailedReadDir = strReadDir;
+			else
+				strFailedReadDir.Clear();
+
 			// Do not leave a list read from another directory visible when the
 			// panel's current directory cannot be entered.
 			ListData.Clear();
@@ -171,6 +185,7 @@ void FileList::ReadFileNames(int KeepSelection, int IgnoreVisible, int DrawMessa
 			return;
 		}
 	}
+	strFailedReadDir.Clear();
 	SortGroupsRead = FALSE;
 
 	if (GetFocus())

--- a/far2l/src/panels/panel.cpp
+++ b/far2l/src/panels/panel.cpp
@@ -1403,7 +1403,7 @@ int Panel::SetCurPath()
 	}
 
 	if (!FarChDir(strCurDir)) {
-		while (!FarChDir(strCurDir)) {
+		for (;;) {
 			int Result = TestFolder(strCurDir);
 
 			if (Result == TSTFLD_NOTFOUND) {


### PR DESCRIPTION
Preserve saved panel paths until they are actually opened, avoiding fallback to unrelated directory contents. Clear the file list when entering the panel directory fails. 
Fix #2724
Fix #3444