### PR TITLE
Fix Ctrl+= not working in WX-GUI by mapping the L'=' key to VK_OEM_PLUS

### DIFF
--- a/WinPort/src/Backend/WX/wxWinTranslations.cpp
+++ b/WinPort/src/Backend/WX/wxWinTranslations.cpp
@@ -206,7 +206,7 @@ int wxKeyCode2WinKeyCode(int code)
 	case L'.': return VK_OEM_PERIOD;
 	case L',': return VK_OEM_COMMA;
 	case L'_': case L'-': return VK_OEM_MINUS;
-	case L'+': return VK_OEM_PLUS;
+	case L'=': case L'+': return VK_OEM_PLUS;
 	case L';': case L':': return VK_OEM_1;
 	case L'/': case L'?': return VK_OEM_2;
 	case L'~': case L'`': return VK_OEM_3;


### PR DESCRIPTION
Touch #3463