### PR TITLE
multiarc/libarch: fix AppleDouble-hiding disable option for tar reads

### DIFF
--- a/multiarc/src/formats/libarch/libarch_utils.cpp
+++ b/multiarc/src/formats/libarch/libarch_utils.cpp
@@ -155,9 +155,28 @@ ssize_t LibArchOpenRead::RawRead(void *data, size_t len, off_t ofs)
 
 void LibArchOpenRead::PrepareForOpen(const char *charset)
 {
+	// libarchive's tar reader hides any entry whose basename starts with
+	// "._" by default on macOS builds (HAVE_COPYFILE_H), treating it as
+	// an AppleDouble metadata blob belonging to the following entry. That
+	// heuristic misfires for archives that legitimately contain standalone
+	// "._*" files (e.g. AppleDouble sidecars synced from a filesystem
+	// without native resource-fork support), silently dropping them on
+	// read/list/extract. Disable it.
+	//
+	// Note: the option is "mac-ext", not "read_mac_metadata" (that key
+	// doesn't exist for any format and archive_read_set_options() fails
+	// with "Undefined option"). Also, per libarchive's option-value
+	// convention any non-empty value is truthy, so "mac-ext=0" would
+	// actually *enable* it; disabling requires the "!key" negation syntax.
+	int r = LibArchCall(archive_read_set_options, _arc, "!mac-ext");
+	if (r != 0) {
+		fprintf(stderr, "LibArchOpenRead::PrepareForOpen: !mac-ext error %d (%s)\n",
+			r, archive_error_string(_arc));
+	}
+
 	if (charset && *charset)  {
 		const auto &opt_hdrcharset = StrPrintf("hdrcharset=%s", charset);
-		int r = LibArchCall(archive_read_set_options, _arc, opt_hdrcharset.c_str());
+		r = LibArchCall(archive_read_set_options, _arc, opt_hdrcharset.c_str());
 		if (r != 0) {
 			fprintf(stderr, "LibArchOpenRead::PrepareForOpen('%s') hdrcharset error %d (%s)\n",
 				charset, r, archive_error_string(_arc));

--- a/multiarc/src/formats/libarch/libarch_utils.cpp
+++ b/multiarc/src/formats/libarch/libarch_utils.cpp
@@ -157,20 +157,23 @@ void LibArchOpenRead::PrepareForOpen(const char *charset)
 {
 	// libarchive's tar reader hides any entry whose basename starts with
 	// "._" by default on macOS builds (HAVE_COPYFILE_H), treating it as
-	// an AppleDouble metadata blob belonging to the following entry. That
-	// heuristic misfires for archives that legitimately contain standalone
-	// "._*" files (e.g. AppleDouble sidecars synced from a filesystem
-	// without native resource-fork support), silently dropping them on
-	// read/list/extract. Disable it.
+	// an AppleDouble metadata blob belonging to the following entry --
+	// without checking that such an entry actually follows. Archives that
+	// legitimately contain standalone "._*" files (e.g. AppleDouble
+	// sidecars synced from a filesystem without native resource-fork
+	// support) silently lose them on read/list/extract. Disable it.
 	//
-	// Note: the option is "mac-ext", not "read_mac_metadata" (that key
-	// doesn't exist for any format and archive_read_set_options() fails
-	// with "Undefined option"). Also, per libarchive's option-value
-	// convention any non-empty value is truthy, so "mac-ext=0" would
-	// actually *enable* it; disabling requires the "!key" negation syntax.
-	int r = LibArchCall(archive_read_set_options, _arc, "!mac-ext");
+	// Scoped to the tar module on purpose: zip supports the same option,
+	// but there the heuristic requires a "__MACOSX/" prefix, so it doesn't
+	// misfire -- and disabling it there would expose that service folder
+	// in listings of ordinary Mac-made zips.
+	//
+	// Note the "!key" negation syntax: libarchive treats any non-empty
+	// option value (including "0") as truthy, so "mac-ext=0" would
+	// actually *enable* the heuristic rather than disable it.
+	int r = LibArchCall(archive_read_set_options, _arc, "tar:!mac-ext");
 	if (r != 0) {
-		fprintf(stderr, "LibArchOpenRead::PrepareForOpen: !mac-ext error %d (%s)\n",
+		fprintf(stderr, "LibArchOpenRead::PrepareForOpen: tar:!mac-ext error %d (%s)\n",
 			r, archive_error_string(_arc));
 	}
 


### PR DESCRIPTION
Fixes #3381.

libarchive's tar reader hides any entry whose basename starts with `._` by default on macOS builds (`HAVE_COPYFILE_H`), treating it as an AppleDouble metadata blob for the following entry — without checking that such an entry actually follows. Archives containing standalone `._*` files (e.g. AppleDouble sidecars synced from a filesystem without native resource-fork support) silently lose them on read/list/extract, with no error.

The fix disables that heuristic for the tar module: `archive_read_set_options(_arc, "tar:!mac-ext")`.

Three details worth flagging for review:

- **The `!key` negation syntax is required.** libarchive treats any non-empty option value (including `"0"`) as truthy, so `mac-ext=0` would actually *enable* the heuristic rather than disable it.

- **This makes the merged metadata recoverable instead of permanently lost.** The point of the merge is that `write_disk` can restore resource forks from the collected blob -- but that only happens when `ARCHIVE_EXTRACT_MAC_METADATA` is requested, and `libarch_cmd_read.cpp` extracts with `ARCHIVE_EXTRACT_TIME` alone. With the heuristic enabled and that flag never requested, `archive_write_disk_posix.c` never calls `set_mac_metadata()` at all -- the blob exists only inside the `archive_entry` for the duration of that one read and is discarded, unwritten, the moment the entry is freed. So today it isn't "collected but unused," it's gone for good. After this fix, `._1.txt` extracts as an ordinary file instead of being consumed -- nothing applies it automatically, but the bytes are now sitting on disk and can be merged back by hand (`ditto`, or routing the pair back through a Mac-native copy path) if the metadata actually matters to the user. Net effect: trades silent, unrecoverable loss for a recoverable byproduct.

- **This also changes behavior for well-formed pairs, not just orphaned entries.** Tested with a real `1.txt` + `._1.txt` AppleDouble pair (built via `ditto`, genuine blob): as long as `._1.txt` isn't the very last entry in the archive, it currently gets silently merged into whatever entry follows it and never appears in the listing; after this fix it shows up and extracts as its own file (see point above for what that means in practice). It also brings tar reading in line with how GNU tar and most non-Apple tools already handle these entries (as plain regular files) -- the hiding was a macOS-only nicety, not a cross-platform convention.

Scoped to tar deliberately — zip supports the same option, but there the heuristic requires a `__MACOSX/` prefix and so doesn't misfire; disabling it there would expose that service folder in listings of ordinary Mac-made zips, which is an unrelated behaviour change.

Full root-cause writeup and a minimal repro with no far2l involved: libarchive/libarchive#3310.

Verified against the reporter's actual files: packed into a tar.gz and read back, 3 of 6 entries were silently missing before, all 6 after. Also checked that zip (with and without `__MACOSX/`) and cpio listings are unaffected and produce no option errors.
