### PR TITLE
python plugin update

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -21,7 +21,7 @@ or via `git log --no-merges --pretty=format:"%as: %B"`).
 * _edsort plugin_: Support unique row sorting and preserve dialog values
 * _GitGutter plugin_: New plugin in editor (**F11**->GitGutter) to show Git changes directly in the far2l editor gutter; click gutter marks or press **Ctrl+G** to open the nearest hunk at or below the current editor line
 * _OpenWith plugin_: Update to v1.3. **General**: Added a progress dialog allowing cancellation of application discovery; allow plugin invocation on `..` (treated as the current directory); new option "Display filename in the menu title"; bugfixes and help updates. **Linux/BSD**: new options "Show package qualifiers", "Ignore [Removed Associations] section", "Query system defaults via xdg-mime"; new buttons "GoTo .desktop", "GoTo TryExec", and "GoTo source" in the "Details" dialog. **macOS**: more comprehensive information in the "Details" dialog; new "GoTo bundle location" button in the "Details" dialog; new options "Show UTI instead of MIME types", "Respect system ranking", "Disable ranking and sort alphabetically".
-* _python plugin_: plugin manager (upluginmanager.py), fixes and new subplugins uimgimage.py, uimgpdf.py, ustealer.py (see: [#3346](https://github.com/elfmz/far2l/issues/3346) and [#3439](https://github.com/elfmz/far2l/pull/3439))
+* _python plugin_: plugin manager (upluginmanager.py), fixes and new subplugins uhashes.py uimgimage.py, uimgpdf.py, ustealer.py (see: [#3346](https://github.com/elfmz/far2l/issues/3346) and [#3439](https://github.com/elfmz/far2l/pull/3439))
 * Several bugfixes and improvements
 
 ## 2.8.0 beta (2026-03-23)

--- a/python/configs/plug/far2l/pluginmanager.py
+++ b/python/configs/plug/far2l/pluginmanager.py
@@ -151,6 +151,10 @@ class PluginManager:
             ffic.OPEN_FILEPANEL: "FILEPANEL",
         }
         name = id2name[OpenFrom]
+        if OpenFrom == ffic.OPEN_FINDLIST:
+            # this type of opening is allowed only once per plugin,
+            # python is multi-plugin - so we don't use any python plugin :(
+            return None
         if OpenFrom == ffic.OPEN_DIALOG:
             ptr = self.ffi.cast("struct OpenDlgPluginData *", Item)
             hDLG = ptr.hDlg

--- a/python/configs/plugins/help/ucharmap/ucharmap_eng.hlf
+++ b/python/configs/plugins/help/ucharmap/ucharmap_eng.hlf
@@ -1,0 +1,15 @@
+﻿.Language=English,English (English)
+.PluginContents=ucharmap
+
+@Contents
+$ #charmap
+Plugin shows character set (utf8).
+
+Supported keys:
+  Arrow keys - change cursor position
+  PgUp/PgDn - change cursor position by the size of the page
+  Enter - copy a character to the clipboard
+
+Mouse click - move to the selected position
+
+Goto - change cursor position - enter a decimal or hexadecimal number (0x prefix) or a character.

--- a/python/configs/plugins/help/uhashes/uhashes_eng.hlf
+++ b/python/configs/plugins/help/uhashes/uhashes_eng.hlf
@@ -1,0 +1,15 @@
+﻿.Language=English,English (English)
+.PluginContents=uhashes
+
+@Contents
+$ #hashes
+The plugin calculates the hash functions known to Python
+for the selected file (editor, viewer, plugin selection).
+
+The number of functions calculated may vary depending on the
+Python version. The default values ​​are:
+adler32, crc32, blake2b, blake2s, md5, md5-sha1, ripemd160,
+sha1, sha224, sha256, sha384, sha3_224, sha3_256, sha3_384, sha3_512,
+sha512, sha512_224, sha512_256, shake_128, shake_256, sm3.
+
+For the shake_* function, the hash length is limited to 40 bytes.

--- a/python/configs/plugins/plugins.ini
+++ b/python/configs/plugins/plugins.ini
@@ -2,6 +2,7 @@
 upluginmanager=load
 ucharmap=load
 udebug=load
+uhashes=load
 uminer=load
 udocker=load
 uuuidgen=load
@@ -21,6 +22,7 @@ uedreplace=
 uedsort=
 ueduniq=
 ugtkhello=
+uhashes=
 uhexedit=
 uminer=
 uimage=

--- a/python/configs/plugins/readme-plugins.txt
+++ b/python/configs/plugins/readme-plugins.txt
@@ -128,7 +128,7 @@ usqlite.py
     active plugins, and the first one to respond becomes active.
     Keys:
         F4 - edit current item - table definition or sigle row data
-        F4+CTRL - at database structure whos pragmas used in current database
+        F4+CTRL - at database structure, shows its pragma's
 ustealer.py
     This plugin allows you to view password fields in dialogues,
     e.g. open the netrocks host list, select the one with a password,

--- a/python/configs/plugins/readme-plugins.txt
+++ b/python/configs/plugins/readme-plugins.txt
@@ -126,7 +126,9 @@ usqlite.py
     Activation occurs after CTRL+PGDN on the highlighted file in the
     standard file list. FAR2L calls the OpenFilePlugin method of
     active plugins, and the first one to respond becomes active.
-
+    Keys:
+        F4 - edit current item - table definition or sigle row data
+        F4+CTRL - at database structure whos pragmas used in current database
 ustealer.py
     This plugin allows you to view password fields in dialogues,
     e.g. open the netrocks host list, select the one with a password,

--- a/python/configs/plugins/readme-plugins.txt
+++ b/python/configs/plugins/readme-plugins.txt
@@ -87,6 +87,9 @@ ueduniq.py
 ugtkhello.py
     The plugin shows how to open a window from the gtk library.
 
+uhashes.py
+    The plugin calculates the hash functions known to Python for the specified file (editor, viewer, plugin selection).
+
 uhexedit.py
     The prototype of the standard hexitor plugin.
 

--- a/python/configs/plugins/ucharmap.py
+++ b/python/configs/plugins/ucharmap.py
@@ -1,3 +1,4 @@
+import os
 import logging
 from far2l.plugin import PluginBase
 from far2l.fardialogbuilder import (
@@ -159,6 +160,13 @@ class Plugin(PluginBase):
                     return 0
                 elif Param2 == self.ffic.KEY_ESC:
                     return 0
+                elif Param2 == self.ffic.KEY_F1:
+                    fn = os.path.normpath(__file__)
+                    dn = os.path.dirname(fn)
+                    bn = os.path.splitext(os.path.basename(fn))[0]
+                    nn = os.path.join(dn, 'help', bn, bn)+'.hlp'
+                    self.info.ShowHelp(self.s2f(nn), self.ffi.NULL, 0)
+                    return 1
                 else:
                     return self.info.DefDlgProc(hDlg, Msg, Param1, Param2)
                 if col == self.max_col:

--- a/python/configs/plugins/uhashes.py
+++ b/python/configs/plugins/uhashes.py
@@ -1,0 +1,137 @@
+import os
+import zlib
+import hashlib
+import logging
+from far2l.plugin import PluginBase
+from far2l import far2leditor
+from far2l.fardialogbuilder import (
+    TEXT,
+    EDIT,
+    BUTTON,
+    HLine,
+    HSizer,
+    VSizer,
+    DialogBuilder,
+)
+
+log = logging.getLogger(__name__)
+progs = {}
+for name in sorted(hashlib.algorithms_available):
+    progs[name] = hashlib.new(name)
+
+
+class Plugin(PluginBase):
+    label = "Python Hashes"
+    openFrom = ["PLUGINSMENU", "COMMANDLINE", "EDITOR", "VIEWER"]
+
+    def OpenPlugin(self, OpenFrom, Item):
+        # 5=edit, 6=viewer, 1=panel
+        if OpenFrom == 5:
+            fqname = far2leditor.Editor(self).GetFileName()
+        elif OpenFrom == 6:
+            data = self.ffi.new("struct ViewerInfo *")
+            data.StructSize = self.ffi.sizeof("struct ViewerInfo")
+            self.info.ViewerControl(self.ffic.VCTL_GETINFO, data)
+            fqname = self.f2s(data.FileName)
+        elif OpenFrom == 1:
+            pnli, pnlidata = self.panel.GetCurrentPanelItem()
+            fname = self.f2s(pnli.FindData.lpwszFileName)
+            fqname = os.path.join(self.panel.GetPanelDir(), fname)
+        else:
+            log.debug(f"unsupported open from {OpenFrom}")
+            return
+        try:
+            self.Dialog(fqname)
+        except Exception as ex:
+            log.exception('run')
+
+    def Calculate(self, fname):
+        result = {}
+        with open(fname, 'rb') as fp:
+            ha = 1
+            hc = 0
+            b = fp.read(1024*1024)
+            while b:
+                ha = zlib.adler32(b, ha)
+                hc = zlib.crc32(b, hc)
+                for name, prog in progs.items():
+                    prog.update(b)
+                b = fp.read(1024)
+            fp.close()
+
+        result = {
+            'adler32': (8, f'{ha:08x}'),
+            'crc32': (8, f'{hc:08x}'),
+        }
+        for name in sorted(progs):
+            prog = progs[name]
+            if name[:5] == 'shake':
+                s = prog.hexdigest(40)
+            else:
+                s = prog.hexdigest()
+            result[name] = (len(s), s)
+        return result
+
+    def Dialog(self, fqname):
+        hashes = self.Calculate(fqname)
+        def DialogProc(hDlg, Msg, Param1, Param2):
+            if Msg == self.ffic.DN_INITDIALOG:
+                dlg.SetText(dlg.ID_fqname, fqname)
+                for name in sorted(hashes):
+                    hlen, hhash = hashes[name]
+                    dlgid = getattr(dlg, f'ID_{name}')
+                    dlg.SetText(dlgid, hhash)
+            elif Msg == self.ffic.DN_KEY:
+                if Param2 == self.ffic.KEY_F1:
+                    fn = os.path.normpath(__file__)
+                    dn = os.path.dirname(fn)
+                    bn = os.path.splitext(os.path.basename(fn))[0]
+                    nn = os.path.join(dn, 'help', bn, bn)+'.hlp'
+                    self.info.ShowHelp(self.s2f(nn), self.ffi.NULL, 0)
+                    return 1
+            return self.info.DefDlgProc(hDlg, Msg, Param1, Param2)
+
+        @self.ffi.callback("FARWINDOWPROC")
+        def _DialogProc(hDlg, Msg, Param1, Param2):
+            try:
+                return DialogProc(hDlg, Msg, Param1, Param2)
+            except:
+                log.exception('dialogproc')
+                return self.info.DefDlgProc(hDlg, Msg, Param1, Param2)
+
+        body = [
+            HSizer(
+                TEXT(None, "File"),
+                EDIT("fqname", 40),
+            ),
+        ]
+        nlen = 0
+        for name in sorted(hashes):
+            nlen = max(nlen, len(name)+1)
+        for name in sorted(hashes):
+            hlen, hhash = hashes[name]
+            body.append(
+                HSizer(
+                    TEXT(None, name.ljust(nlen)),
+                    EDIT(name, 60),
+                ),
+            )
+        body.extend([
+            HLine(),
+            HSizer(
+                BUTTON("vok", "OK", default=True, flags=self.ffic.DIF_CENTERGROUP),
+                BUTTON("vcancel", "Cancel", flags=self.ffic.DIF_CENTERGROUP),
+            ),
+        ])
+        b = DialogBuilder(
+            self,
+            _DialogProc,
+            "Python hashes",
+            "helptopic",
+            0,
+            VSizer(*body),
+        )
+        dlg = b.build(-1, -1)
+
+        res = self.info.DialogRun(dlg.hDlg)
+        self.info.DialogFree(dlg.hDlg)

--- a/python/configs/plugins/uimgpdf.py
+++ b/python/configs/plugins/uimgpdf.py
@@ -1,6 +1,5 @@
 import os
 import logging
-import debugpy
 
 from far2l.plugin import PluginBase
 from far2l.fardialogbuilder import (
@@ -177,7 +176,6 @@ class Plugin(PluginBase):
             log.error('Error: %s [%s]', ex.errno, ex.args)
             return
 
-        #debugpy.breakpoint()
         area = self.GetFarRect()
         imgarea = self.ffi.new("SMALL_RECT *", (0, 0, area.Right, area.Bottom-1))
         canvas_w = imgarea.Right * wgi.PixPerCell.X

--- a/python/configs/plugins/usqlite.py
+++ b/python/configs/plugins/usqlite.py
@@ -82,7 +82,7 @@ limit {}, {}
         cur.close()
         #log.debug('desc:{}'.format(self.desc))
 
-    def GetOpenPluginInfo(self, OpenInfo, Item):
+    def GetOpenPluginInfo(self, OpenInfo):
         #log.debug("usqlite.SqlDataHandler.GetOpenPluginInfo")
         self.paneltitle = self.parent.label+': {}/{}'.format(self.parent.dbname.split('/')[-1], self.tablename)
 
@@ -153,7 +153,7 @@ limit {}, {}
         #InfoLinesNumber
         Info.PanelModesArray = self.pm
         Info.PanelModesNumber = 1
-        Info.StartPanelMode = PanelModeDetailed
+        Info.StartPanelMode = PanelModeAlternative
         Info.StartSortMode = self.ffic.SM_UNSORTED
         #Info.StartSortOrder
         Info.KeyBar = self.kbt
@@ -205,7 +205,7 @@ limit {}, {}
 
     def SetDirectory(self, dirname):
         if dirname == '..':
-            self.parent.dbhandler = SqlMetadataHandler(self.parent, self.parent.dbconn)
+            self.parent.HandlerPop()
             return 1
         return 0
 
@@ -302,13 +302,11 @@ limit {}, {}
 class SqlMetadataHandler(SqlData):
     def GetOpenPluginInfo(self, OpenInfo):
         #log.debug("usqlite.SqlMetadataHandler.GetOpenPluginInfo")
-        py_pm_py_titles = [
-            self.s2f("name"),
-            self.s2f("type"),
-            self.s2f("count"),
-        ]
-        self.py_pm_titles = self.ffi.new("wchar_t *[]", py_pm_py_titles)
-        py_pm = [
+        self.paneltitle = self.parent.label+': '+self.parent.dbname.split('/')[-1]
+        self.py_titles = ["name", "type", "size"]
+        self.py_titles_c = [self.s2f(n) for n in self.py_titles]
+        self.py_pm_titles = self.ffi.new("wchar_t *[]", self.py_titles_c)
+        self.py_pm = [
             self.s2f("N,C0,C1"),    # ColumnTypes
             self.s2f("0,5,6"),      # ColumnWidths
             self.py_pm_titles,      # ColumnTitles
@@ -320,7 +318,7 @@ class SqlMetadataHandler(SqlData):
             self.ffi.NULL,          # StatusColumnWidths
             [0,0],                  # Reserved
         ]
-        self.pm = self.ffi.new("struct PanelMode *", py_pm)
+        self.pm = self.ffi.new("struct PanelMode *", self.py_pm)
 
         wcn = self.ffi.cast("wchar_t *", self.ffi.NULL)
         py_kbt_normal = [wcn]*12
@@ -331,6 +329,7 @@ class SqlMetadataHandler(SqlData):
         py_kbt_ctrl_alt = [wcn]*12
 
         py_kbt_normal[4-1]=self.s2f("DDL")
+        py_kbt_ctrl[4-1]=self.s2f("Pragma")
 
         self.py_kbt = [
             py_kbt_normal,
@@ -343,7 +342,7 @@ class SqlMetadataHandler(SqlData):
         self.kbt = self.ffi.new("struct KeyBarTitles *", self.py_kbt)
 
         self.py_curdir = self.s2f(self.parent.dbname.split('/')[-1])
-        self.py_paneltitle = self.s2f(self.parent.label)
+        self.py_paneltitle = self.s2f(self.paneltitle)
 
         Info = self.ffi.cast("struct OpenPluginInfo *", OpenInfo)
         Info.Flags = (
@@ -358,8 +357,8 @@ class SqlMetadataHandler(SqlData):
         #InfoLines
         #InfoLinesNumber
         Info.PanelModesArray = self.pm
-        Info.PanelModesNumber = 1
-        Info.StartPanelMode = PanelModeDetailed
+        Info.PanelModesNumber = len(self.py_pm)
+        Info.StartPanelMode = PanelModeAlternative
         Info.StartSortMode = self.ffic.SM_UNSORTED
         #Info.StartSortOrder
         Info.KeyBar = self.kbt
@@ -373,6 +372,8 @@ class SqlMetadataHandler(SqlData):
 select
     name, type, sql
 from sqlite_master
+order by
+    type, name
 '''
         cur = self.conn.cursor()
         res = cur.execute(stmt)
@@ -384,6 +385,7 @@ from sqlite_master
             items = self.ffi.new("struct PluginPanelItem []", len(rows))
             for no in range(len(rows)):
                 rec = rows[no]
+                #log.debug(f'row[{no}] = {rec}')
                 names.append(self.s2f(rec[0])) # name
                 items[no].FindData.lpwszFileName = names[-1]
                 if rec[1] in ('table', 'view'):
@@ -398,10 +400,10 @@ from sqlite_master
                 names.append([self.s2f(rec[1]), self.s2f(names[-1])]) # type, size
                 names.append(self.ffi.new("wchar_t *[]", names[-1]))
                 items[no].CustomColumnData = names[-1]
-                items[no].CustomColumnNumber = 2
+                items[no].CustomColumnNumber = len(names[-2])
             self.Items = items
             self.names = names
-            self.rows = rows
+        self.rows = rows
 
         PanelItem = self.ffi.cast("struct PluginPanelItem **", PanelItem)
         ItemsNumber = self.ffi.cast("int *", ItemsNumber)
@@ -419,13 +421,31 @@ from sqlite_master
 
     def SetDirectory(self, dirname):
         if dirname == '..':
-            self.parent.info.Control(self.parent.hplugin, self.ffic.FCTL_CLOSEPLUGIN, 0, 0)
+            self.parent.HandlerPop()
             return 1
         for rec in self.rows:
             if rec[0] == dirname and rec[1] in ('table', 'view'):
-                self.parent.dbhandler = SqlDataHandler(self.parent, self.parent.dbconn, dirname)
+                self.parent.HandlerPush(SqlDataHandler(self.parent, self.parent.dbconn, dirname))
                 return 1
         return 0
+
+    def EditData(self, data):
+        if data is None:
+            return
+        fd, fname = tempfile.mkstemp(suffix='.sql', prefix=None, dir='/tmp', text=True)
+        os.close(fd)
+        with open(fname, 'wt') as fp:
+            fp.write(data)
+        self.parent.info.Editor(
+            fname,
+            fname,
+            0, 0, -1, -1,
+            self.ffic.EF_DISABLEHISTORY,#|self.ffic.EF_DELETEONCLOSE,
+            0,
+            0,
+            0xFFFFFFFF,  # =-1=self.ffic.CP_AUTODETECT
+        )
+        os.unlink(fname)
 
     def ProcessKey(self, Key, ControlState):
         #log.debug('usqlite.SqlMetadataHandler.ProcessKey: key:{:x} state:{:x} f4:{}'.format(Key, ControlState, Key == self.ffic.VK_F4))
@@ -437,30 +457,70 @@ from sqlite_master
                     #log.debug('F4: rc={} {}'.format(rc, name))
                     for rec in self.rows:
                         if rec[0] == name:
-                            fd, fname = tempfile.mkstemp(suffix='.sql', prefix=None, dir='/tmp', text=True)
-                            os.close(fd)
-                            with open(fname, 'wt') as fp:
-                                fp.write(rec[2])
-                            self.parent.info.Editor(
-                                fname,
-                                fname,
-                                0, 0, -1, -1,
-                                self.ffic.EF_DISABLEHISTORY,#|self.ffic.EF_DELETEONCLOSE,
-                                0,
-                                0,
-                                0xFFFFFFFF,  # =-1=self.ffic.CP_AUTODETECT
-                            )
-                            os.unlink(fname)
+                            self.EditData(rec[2])
                             break
                 return True
-            #elif ControlState & self.ffic.PKF_SHIFT:
+            elif ControlState & self.ffic.PKF_CONTROL:
+                data = []
+                rec = self.conn.execute("select sqlite_version()").fetchone()
+                data.append("/*")
+                data.append(f"SQLite version: {rec[0]}")
+                data.append("SQLite compile options:")
+                for r in self.conn.execute("pragma compile_options").fetchall():
+                    data.append(f"    {r[0]}")
+                data.append('')
+                data.append("Pragmas:")
+                data.append("*/")
+                for pragma in (
+                    "auto_vacuum",
+                    "automatic_index",
+                    "busy_timeout",
+                    "cache_size",
+                    "checkpoint_fullfsync",
+                    "defer_foreign_keys",
+                    "encoding",
+                    "foreign_keys",
+                    "freelist_count",
+                    "fullfsync",
+                    "ignore_check_constraints",
+                    "integrity_check",
+                    "journal_mode",
+                    "journal_size_limit",
+                    "legacy_alter_table",
+                    "legacy_file_format",
+                    "locking_mode",
+                    "max_page_count",
+                    "page_count",
+                    "page_size",
+                    "quick_check",
+                    "read_uncommitted",
+                    "recursive_triggers",
+                    "reverse_unordered_selects",
+                    "schema_version",
+                    "secure_delete",
+                    "synchronous",
+                    "temp_store",
+                    "user_version",
+                    "wal_autocheckpoint",
+                    "wal_checkpoint",
+                    "writable_schema",
+                ):
+                    rec = self.conn.execute("pragma %s" % pragma).fetchone()
+                    if rec:
+                        data.append(f"pragma {pragma} = {rec[0]}")
+                    else:
+                        data.append(f"-- pragma {pragma} = --unset--")
+                data.append('')
+                self.EditData('\n'.join(data))
+            return True
+
         return False
 
 
 
 class Plugin(PluginVFS):
     label = "Python usqlite"
-    openFrom = ["PLUGINSMENU", "DISKMENU"]
+    openFrom = ["PLUGINSMENU"]
 
     dbname = ''
 
@@ -468,7 +528,9 @@ class Plugin(PluginVFS):
         super().__init__(parent, info, ffi, ffic)
         self.dbname = name
         self.dbconn = conn
-        self.dbhandler = SqlMetadataHandler(self, self.dbconn)
+        self.dbhandlers = []
+        self.dbhandler = None
+        self.HandlerPush(SqlMetadataHandler(self, self.dbconn))
 
     def Close(self):
         if self.dbhandler:
@@ -478,6 +540,26 @@ class Plugin(PluginVFS):
         self.dbconn = None
         self.dbhandler = None
         super().Close()
+
+    def HandlerPush(self, handler):
+        if self.dbhandler:
+            pnl = self.panel.GetPanelInfo()
+            data = pnl.TopPanelItem, pnl.CurrentItem
+            self.dbhandlers.append((self.dbhandler, data))
+
+        self.dbhandler = handler
+
+    def HandlerPop(self):
+        if self.dbhandlers:
+            self.dbhandler, data = self.dbhandlers.pop()
+            redraw = self.ffi.new('struct PanelRedrawInfo *')
+            redraw.TopPanelItem = data[0]
+            redraw.CurrentItem = data[1]
+            self.panel.UpdatePanel()
+            self.panel.RedrawPanel(redraw)
+        else:
+            self.info.Control(self.hplugin, self.ffic.FCTL_CLOSEPLUGIN, 0, 0)
+            self.dbhandler = None
 
     @staticmethod
     def OpenFilePlugin(parent, info, ffi, ffic, Name, Data, DataSize, OpMode):

--- a/python/configs/plugins/usqlite.py
+++ b/python/configs/plugins/usqlite.py
@@ -118,6 +118,7 @@ limit {}, {}
         py_kbt_normal = [wcn]*12
         py_kbt_ctrl = [wcn]*12
         py_kbt_alt = [wcn]*12
+        py_kbt_shift = [wcn]*12
         py_kbt_ctrl_shift = [wcn]*12
         py_kbt_alt_shift = [wcn]*12
         py_kbt_ctrl_alt = [wcn]*12
@@ -130,6 +131,7 @@ limit {}, {}
             py_kbt_normal,
             py_kbt_ctrl,
             py_kbt_alt,
+            py_kbt_shift,
             py_kbt_ctrl_shift,
             py_kbt_alt_shift,
             py_kbt_ctrl_alt
@@ -324,6 +326,7 @@ class SqlMetadataHandler(SqlData):
         py_kbt_normal = [wcn]*12
         py_kbt_ctrl = [wcn]*12
         py_kbt_alt = [wcn]*12
+        py_kbt_shift = [wcn]*12
         py_kbt_ctrl_shift = [wcn]*12
         py_kbt_alt_shift = [wcn]*12
         py_kbt_ctrl_alt = [wcn]*12
@@ -335,6 +338,7 @@ class SqlMetadataHandler(SqlData):
             py_kbt_normal,
             py_kbt_ctrl,
             py_kbt_alt,
+            py_kbt_shift,
             py_kbt_ctrl_shift,
             py_kbt_alt_shift,
             py_kbt_ctrl_alt


### PR DESCRIPTION
- disabled OPEN_FINDLIST type plugins in the plugin manager - due to Far2L language limitations, according to which a plugin written in C can only handle this type in one way
- fixed usqlite plugin