### PR TITLE
Do not thread an empty prefix to run plugins

### DIFF
--- a/ImageViewer/src/Plugin.cpp
+++ b/ImageViewer/src/Plugin.cpp
@@ -56,7 +56,7 @@ SHAREDSYMBOL void WINAPI GetPluginInfoW(struct PluginInfo *Info)
 	Info->PluginMenuStrings = menu_strings;
 	Info->PluginMenuStringsNumber = 1;
 
-	Info->CommandPrefix = L"img:";
+	Info->CommandPrefix = L"img";
 }
 
 static std::pair<std::string, bool> GetPanelItem(int cmd, int index)

--- a/NetRocks/src/NetRocks.cpp
+++ b/NetRocks/src/NetRocks.cpp
@@ -203,10 +203,10 @@ SHAREDSYMBOL int WINAPI _export MayExitFARW()
 
 static std::wstring CombineAllProtocolPrefixes()
 {
-	std::wstring out = L"net:";
+	std::wstring out = L"net";
 	for (auto pi = ProtocolInfoHead(); pi->name; ++pi) {
-		out+= MB2Wide(pi->name);
 		out+= L':';
+		out+= MB2Wide(pi->name);
 	}
 	return out;
 }

--- a/calc/src/plugcalc/api.h
+++ b/calc/src/plugcalc/api.h
@@ -15,7 +15,7 @@
 #include <farkeys.h>
 #include <farcolor.h>
 
-#define CALC_PREFIX L"calc:"
+#define CALC_PREFIX L"calc"
 
 struct CalcCoord
 {


### PR DESCRIPTION
Before, simply the ':' symbol at the beginning of the command line runs the calculator plugin