### PR TITLE
NetRocks/filelist: fix Ctrl+F inserting garbage/duplicated path

### DIFF
--- a/NetRocks/src/PluginImpl.cpp
+++ b/NetRocks/src/PluginImpl.cpp
@@ -75,7 +75,7 @@ public:
 
 PluginImpl::PluginImpl(const wchar_t *path, bool path_is_standalone_config, int OpMode)
 {
-	_cur_dir[0] = _panel_title[0] = _format[0] = 0;
+	_cur_dir[0] = _panel_title[0] = _format[0] = _cur_URL[0] = 0;
 
 	_local = std::make_shared<HostLocal>();
 	if (path_is_standalone_config) {
@@ -144,6 +144,7 @@ void PluginImpl::UpdatePathInfo()
 	} else {
 		tmp = StrMB2Wide(_sites_cfg_location.TranslateToPath(false));
 		wcsncpy(_cur_dir, tmp.c_str(), ARRAYSIZE(_cur_dir) - 1);
+		_cur_URL[0] = 0;
 		if (!_standalone_config.empty()) {
 			tmp = ExtractFileName(_standalone_config);
 

--- a/far2l/src/panels/filelist.cpp
+++ b/far2l/src/panels/filelist.cpp
@@ -3800,18 +3800,20 @@ FARString &FileList::PluginGetURL(const wchar_t *Name, FARString &strDest)
 {
 	OpenPluginInfo Info = {0};
 	CtrlObject->Plugins.GetOpenPluginInfo(hPlugin, &Info);
+	FARString result;
 	if (Info.CurURL && Info.CurURL[0]) {
-		strDest = Info.CurURL;
+		result = Info.CurURL;
 	} else if (Info.CurDir && Info.CurDir[0]) {
-		strDest = Info.CurDir;
+		result = Info.CurDir;
 	} else {
 		//fprintf(stderr, "Both CurDir and CurURL are empty or null\n");
 	}
 
-	if (!strDest.IsEmpty())
-		AddEndSlash(strDest);
+	if (!result.IsEmpty())
+		AddEndSlash(result);
 
-	strDest += Name;
+	result += Name;
+	strDest = result;
 	return strDest;
 }
 


### PR DESCRIPTION
Fix `Ctrl+F` in the NetRocks plugin panel inserting garbage into the command line when no site is connected (sites list view), or a stale URL from a previous connection after disconnecting from a site.

Also fix a related **self-aliasing bug** in `FileList::PluginGetURL()` that surfaced once the above was fixed: whenever a plugin panel reports both `CurDir` and `CurURL` as empty, `Ctrl+F` would insert a duplicated name instead of the plain item name, since `Name` and `strDest` end up being the same object at the call site.

This is visible on the **NetRocks** sites list root (e.g. _"MySite/MySite"_ or _"\<Create site connection\>/\<Create site connection\>"_), and also in the **tmppanel** plugin, which always reports an empty `CurDir`: adding _"/usr/bin"_ to a temp panel and pressing `Ctrl+F` on it inserts _"/usr/bin//usr/bin"_ instead of _"/usr/bin"_.  