### PR TITLE
Avoid surprising plugin calls by : in the command line

### DIFF
--- a/far2l/src/cmdline.cpp
+++ b/far2l/src/cmdline.cpp
@@ -398,7 +398,7 @@ void CommandLine::ChangeDirFromHistory(bool PluginPath, int SelectType, FARStrin
 	if (SelectType == 6)
 		Panel = CtrlObject->Cp()->GetAnotherPanel(Panel);
 
-	if (!PluginPath || !CtrlObject->Plugins.ProcessCommandLine(strDir, Panel)) {
+	if (!PluginPath || !CtrlObject->Plugins.ProcessCommandLine(strDir, Panel, true)) {
 		if (Panel->GetMode() == PLUGIN_PANEL || CheckShortcutFolder(strDir, false)) {
 			Panel->SetCurDir(strDir, PluginPath ? FALSE : TRUE);
 			//fprintf(stderr, "=== ChangeDirFromHistory():\n  strDir=\"%ls\"\n  strFile=\"%ls\"\n", strDir.CPtr(), strFile.CPtr());

--- a/far2l/src/panels/panel.cpp
+++ b/far2l/src/panels/panel.cpp
@@ -837,7 +837,7 @@ bool Panel::SetLocation_Plugin(bool file_plugin, Plugin *plugin, const wchar_t *
 bool Panel::SetLocation_Directory(const wchar_t *path)
 {
 	if (!FarChDir(path)) {
-		if (CtrlObject->Plugins.ProcessCommandLine(path)) {
+		if (CtrlObject->Plugins.ProcessCommandLine(path, nullptr, true)) {
 			fprintf(stderr, "SetLocation_Directory('%ls') PLUGIN\n", path);
 			return true;
 		}

--- a/far2l/src/plug/plugins.cpp
+++ b/far2l/src/plug/plugins.cpp
@@ -1557,7 +1557,7 @@ struct PluginData
 	DWORD PluginFlags;
 };
 
-int PluginManager::ProcessCommandLine(const wchar_t *CommandParam, Panel *Target)
+int PluginManager::ProcessCommandLine(const wchar_t *CommandParam, Panel *Target, bool AllowPathPrefix)
 {
 	size_t PrefixLength = 0, slash_pos = 0;
 	FARString strPrefix;
@@ -1565,16 +1565,32 @@ int PluginManager::ProcessCommandLine(const wchar_t *CommandParam, Panel *Target
 	UnquoteExternal(strCommand);
 	RemoveLeadingSpaces(strCommand);
 
-	std::wstring command(strCommand.CPtr());
-	PrefixLength = command.find(L':');
-	if (PrefixLength == std::wstring::npos)
-		return FALSE;
+	if (AllowPathPrefix) {
+		std::wstring command(strCommand.CPtr());
+		PrefixLength = command.find(L':');
+		if (PrefixLength == std::wstring::npos)
+			return FALSE;
 
-	slash_pos = command.rfind(L'/',PrefixLength);
-	if (slash_pos == std::wstring::npos)
-		strPrefix = command.substr(0, PrefixLength);
-	else
-		strPrefix = command.substr(slash_pos + 1, PrefixLength - slash_pos - 1);
+		slash_pos = command.rfind(L'/', PrefixLength);
+		if (slash_pos == std::wstring::npos)
+			strPrefix = command.substr(0, PrefixLength);
+		else
+			strPrefix = command.substr(slash_pos + 1, PrefixLength - slash_pos - 1);
+	} else {
+		for (;;) {
+			const wchar_t Ch = strCommand.At(PrefixLength);
+			if (!Ch || IsSpace(Ch) || Ch == L'/' || Ch == L'\'' || Ch == L'"' || PrefixLength > 64)
+				return FALSE;
+			if (Ch == L':' && PrefixLength > 0)
+				break;
+			PrefixLength++;
+		}
+
+		strPrefix = FARString(strCommand, PrefixLength);
+	}
+
+	if (strPrefix.IsEmpty())
+		return FALSE;
 	
 	LoadIfCacheAbsent();
 	FARString strPluginPrefix;

--- a/far2l/src/plug/plugins.hpp
+++ b/far2l/src/plug/plugins.hpp
@@ -225,7 +225,7 @@ public:
 	int UseFarCommand(HANDLE hPlugin, int CommandType);
 	void ReloadLanguage();
 	void DiscardCache();
-	int ProcessCommandLine(const wchar_t *Command, Panel *Target = nullptr);
+	int ProcessCommandLine(const wchar_t *Command, Panel *Target = nullptr, bool AllowPathPrefix = false);
 
 	bool SetHotKeyDialog(const wchar_t *DlgPluginTitle, const std::string &SettingName);
 	std::string GetHotKeySettingName(Plugin *pPlugin, int ItemNumber, HotKeyKind Kind);


### PR DESCRIPTION
Fix regression after #3116
Related fix #3491
Initial report

> При попытке выполнить команду
> grep "Virtual memory map for " -A 2 ./enb_l1_b4860_v1.eld.map | awk '/Virtual memory map for/ {stack=$NF; sub(/:$/, "", stack); next} /section/ {gsub(/\.\./, " ..", $0); print $1 " " stack " / " $3, $4}'
> 
> открывается калькулятор :)
> 
> Почти уверен, что фича, но не понял, что ее триггерит и как отключить на секундочку?