### PR TITLE
Trim byte order mark at the start of pasted text

### DIFF
--- a/far2l/src/clipboard.cpp
+++ b/far2l/src/clipboard.cpp
@@ -244,6 +244,8 @@ wchar_t *Clipboard::Paste(bool &IsVertical, int MaxChars)
 	if (ClipText) {
 		wmemcpy(ClipText, (const wchar_t *)ClipData, CharsCount);
 		ClipText[CharsCount] = 0;
+		if (ClipText[0] == L'\xFEFF')
+			wmemmove(ClipText, ClipText + 1, wcslen(ClipText));
 	}
 
 	IsVertical = false;

--- a/far2l/src/clipboard.cpp
+++ b/far2l/src/clipboard.cpp
@@ -234,18 +234,21 @@ wchar_t *Clipboard::Paste(bool &IsVertical, int MaxChars)
 	if (!ClipData)
 		return nullptr;
 
-	size_t CharsCount =
-			wcsnlen((const wchar_t *)ClipData, WINPORT(ClipboardSize)(ClipData) / sizeof(wchar_t));
+	const wchar_t *ClipChars = (const wchar_t *)ClipData;
+	size_t CharsCount = wcsnlen(ClipChars, WINPORT(ClipboardSize)(ClipData) / sizeof(wchar_t));
 
-	if (MaxChars >= 0 && CharsCount < (size_t)MaxChars)
+	if (CharsCount > 0 && ClipChars[0] == L'\xFEFF') {
+		++ClipChars;
+		--CharsCount;
+	}
+
+	if (MaxChars >= 0 && CharsCount > (size_t)MaxChars)
 		CharsCount = (size_t)MaxChars;
 
 	wchar_t *ClipText = (wchar_t *)malloc((CharsCount + 1) * sizeof(wchar_t));
 	if (ClipText) {
-		wmemcpy(ClipText, (const wchar_t *)ClipData, CharsCount);
+		wmemcpy(ClipText, ClipChars, CharsCount);
 		ClipText[CharsCount] = 0;
-		if (ClipText[0] == L'\xFEFF')
-			wmemmove(ClipText, ClipText + 1, wcslen(ClipText));
 	}
 
 	IsVertical = false;

--- a/far2l/src/console/keyboard.cpp
+++ b/far2l/src/console/keyboard.cpp
@@ -74,6 +74,12 @@ int ReturnAltValue = 0;
 bool BracketedPasteMode = false;
 FARString GPastedText;
 
+static void StripPastedBOM()
+{
+	if (!GPastedText.IsEmpty() && GPastedText.At(0) == L'\xFEFF')
+		GPastedText.LShift(1);
+}
+
 /* end Глобальные переменные */
 
 // static SHORT KeyToVKey[MAX_VKEY_CODE];
@@ -652,6 +658,7 @@ static DWORD GetInputRecordInner(INPUT_RECORD *rec, bool ExcludeMacro, bool Proc
 					else if (rec->Event.KeyEvent.wVirtualKeyCode == VK_TAB)
 						GPastedText += L'\t';
 				}
+				StripPastedBOM();
 				if (!GPastedText.IsEmpty()) {
 					memset(rec, 0, sizeof(*rec));
 					rec->EventType = NOOP_EVENT; // Fake key event
@@ -847,6 +854,7 @@ static DWORD GetInputRecordInner(INPUT_RECORD *rec, bool ExcludeMacro, bool Proc
 				}
 			}
 
+			StripPastedBOM();
 			if (!GPastedText.IsEmpty()) {
 				memset(rec, 0, sizeof(*rec));
 				rec->EventType = NOOP_EVENT; // Fake key event


### PR DESCRIPTION
added by ingenious apps like KeyPassXC

Related discussions in their repo:
https://github.com/keepassxreboot/keepassxc/issues/9249
https://github.com/keepassxreboot/keepassxc/issues/7420

Initial issue description:
> Вот это я себе тут мозг взорвал.
> Дано:
> 1) Текстовый конфиг для #sh скрипта с паролями на Linux сервере
> 2) Сам сижу в #MacOS
> 3) Под #MacOS соответственно #Far2l и #KeyPassXC
> 
> Что
> 1) Генерю пароль в #KeyPassXC
> 2) Делаю copy
> 3) Подключаюсь через #Far2l #NetRocks к #Linux сервер
> 4) Делаю paste пароля в текстовый файл через встроенный редактор #Far2l
> 5) В текстовый файл копируется пароль с !!! ДВОЙНЫМ !!! #BOM в начале
> 
> Итого трачу наверно час на выяснение.
> 
> Что это за новая реальность и как с ней бороться, чтоб больше никогда и ни при каком раскладе не получить вставку этого мерзкого BOM куда бы то ни было в принципе?!
> 
> И кто виновник, #KeyPassXC, или #Far2l ?
> 
> P.S.: Причём редактор #Far2l вставил пароль с двойным #BOM в середину файла и даже не поперхнулся его в таком виде сохранить. При этом редактор никак этот #BOM не отображает.
> 
> sh в свою очередь спарсил текстовый конфиг, и преспокойно вытащил пароль с префиксом в виде двойного #BOM.