### PR TITLE
Fix Editor::DeleteBlock() regression

### DIFF
--- a/far2l/src/base/EcoPool.hpp
+++ b/far2l/src/base/EcoPool.hpp
@@ -4,15 +4,27 @@
 template <class T>
 	class EcoPool
 {
+	static constexpr size_t PoolBlockSize()
+	{
+		size_t size = 8;
+		const size_t required = sizeof(T) > alignof(T) ? sizeof(T) : alignof(T);
+		while (size < required)
+			size <<= 1;
+		return size;
+	}
+
+	static constexpr size_t BlockSize = PoolBlockSize();
+
 	std::pmr::unsynchronized_pool_resource _pool {
-		{2 * 1024 * 1024 / sizeof(T), sizeof(T) }
+		// libc++ otherwise routes this size class through its O(n) ad-hoc pool.
+		{2 * 1024 * 1024 / BlockSize, 4 * BlockSize}
 	};
 
 public:
 	template <typename... Args>
 		T *Construct(Args... args)
 	{
-		void *p = _pool.allocate(sizeof(T), 2 * sizeof(void *));
+		void *p = _pool.allocate(sizeof(T), alignof(T));
 		if (!p) {
 			return nullptr;
 		}
@@ -22,7 +34,7 @@ public:
 	void Destruct(T *p)
 	{
 		p->~T();
-		_pool.deallocate(p, sizeof(T), 2 * sizeof(void *));
+		_pool.deallocate(p, sizeof(T), alignof(T));
 	}
 
 	void Purge()


### PR DESCRIPTION
Opening a large file with many many lines, going near the end, selecting many many lines with Shift+Ctrl+Home, deleting with backspace - far2l hangs
Profiler shows std::pmr
```
3.56 G  100.0%	-	 far2l (11679)
3.56 G  99.9%	-	  thread_start
3.56 G  99.9%	-	   _pthread_start
3.56 G  99.9%	-	    wxThreadInternal::PthreadStart(wxThread*)
3.56 G  99.9%	-	     WinPortAppThread::Entry()
3.56 G  99.9%	-	      FarAppMain(int, char**)
3.56 G  99.9%	-	       Manager::EnterMainLoop()
3.56 G  99.9%	-	        Manager::ProcessKey(unsigned int)
3.56 G  99.9%	-	         FileEditor::ReProcessKey(unsigned int, int)
3.56 G  99.9%	-	          Editor::ProcessKey(unsigned int)
3.56 G  99.9%	-	           Editor::DeleteBlock()
3.56 G  99.9%	3.56 G	            std::__1::pmr::unsynchronized_pool_resource::__adhoc_pool::__do_deallocate(std::__1::pmr::memory_resource*, void*, unsigned long, unsigned long)
```

Fix explanation from robots

> EcoPool<Edit> requested 16-byte alignment although Edit needs only 8 bytes on macOS. libc++ therefore bypassed its fixed  pool and put every editor line in an ad-hoc list; freeing a large selected block then scanned that list per line.
> Use alignof(T) and configure the pool to cover T’s power-of-two size class. Individual line destruction then returns blocks to the fixed-pool free list in O(1).