### PR TITLE
ECTL_INSERTTEXT micro optmisation

### DIFF
--- a/far2l/src/editor.cpp
+++ b/far2l/src/editor.cpp
@@ -2625,7 +2625,8 @@ case KEY_CTRLNUMPAD3: {
 
 				Flags.Set(FEDITOR_NEWUNDO);
 				InsertString();
-				CurLine->FastShow();
+				if (!Locked())
+					CurLine->FastShow();
 				Show();
 			}
 


### PR DESCRIPTION
ECTL_INSERTTEXT is slow as it's looping through ProcessKey, and unconditional FastShow on KEY_ENTER slows it down even more by unnecessary rendering calls.
Improvement can be seen when calling transformer plugin on a text with many lines.

Further rework of ECTL_INSERTTEXT is needed