### PR TITLE
Workaround for wxOSX 3.3.3 clipboard issue

### DIFF
--- a/WinPort/src/Backend/WX/wxClipboardBackend.cpp
+++ b/WinPort/src/Backend/WX/wxClipboardBackend.cpp
@@ -7,10 +7,15 @@
 #include <utils.h>
 #include <dlfcn.h>
 
-// #698: Mac: Copying to clipboard stopped working in wx 3.1 (not 100% sure about exact version).
-// The fix is submitted, supposedly, into 3.2: https://github.com/wxWidgets/wxWidgets/pull/1623/files
-// Guess the problem is only present in 3.1.
-#if defined(__APPLE__) && (wxMAJOR_VERSION == 3) && (wxMINOR_VERSION == 1)
+// wxOSX 3.3.3 pastes text with interleaved NULs, see https://github.com/wxWidgets/wxWidgets/issues/26680
+#if defined(__APPLE__) && (wxMAJOR_VERSION == 3) && (wxMINOR_VERSION == 3) && (wxRELEASE_NUMBER == 3)
+#define CLIPBOARD_NATIVE_ONLY 1
+#else
+#define CLIPBOARD_NATIVE_ONLY 0
+#endif
+
+// #698: Mac: Copying to clipboard stopped working in wx 3.1.
+#if defined(__APPLE__) && (wxMAJOR_VERSION == 3) && ((wxMINOR_VERSION == 1) || CLIPBOARD_NATIVE_ONLY)
 #define CLIPBOARD_HACK 1
 #include "Mac/pasteboard.h"
 #else
@@ -110,7 +115,7 @@ void wxClipboardBackend::OnClipboardClose()
 		fprintf(stderr, "CloseClipboard without data\n");
 	}
 
-#if !defined(__WXGTK__)
+#if !defined(__WXGTK__) && !CLIPBOARD_NATIVE_ONLY
 	// it never did what supposed to, and under Ubuntu 22.04/Wayland it started to kill gnome-shell
 	wxTheClipboard->Flush();
 #endif
@@ -204,6 +209,14 @@ void *wxClipboardBackend::OnClipboardSetData(UINT format, void *data)
 		auto fn = std::bind(&wxClipboardBackend::OnClipboardSetData, this, format, data);
 		return CallInMain<void *>(fn);
 	}
+
+#if CLIPBOARD_NATIVE_ONLY
+	if (format == CF_UNICODETEXT)
+		CopyToPasteboard((const wchar_t *)data);
+	else if (format == CF_TEXT)
+		CopyToPasteboard((const char *)data);
+	return data;
+#endif
 
 	size_t len = WINPORT(ClipboardSize)(data);
 	fprintf(stderr, "SetClipboardData: format=%u len=%lu\n", format, (unsigned long)len);


### PR DESCRIPTION
Fix #3512