### PR TITLE
^Enter: supports selected files to be placed in command line

### DIFF
--- a/far2l/bootstrap/scripts/farlang.templ.m4
+++ b/far2l/bootstrap/scripts/farlang.templ.m4
@@ -495,6 +495,17 @@ MultilinePaste
 "Вставка багаторядкового тексту"
 "Устаўка шматрадковага тэксту"
 
+AllowSelectionPlacement
+"Помещать список выделенных файлов в комстроку по ^Ввод"
+"Place selected files from panel to command line on ^Enter"
+upd:"Place selected files from panel to command line on ^Enter"
+upd:"Place selected files from panel to command line on ^Enter"
+upd:"Place selected files from panel to command line on ^Enter"
+upd:"Place selected files from panel to command line on ^Enter"
+upd:"Place selected files from panel to command line on ^Enter"
+upd:"Place selected files from panel to command line on ^Enter"
+upd:"Place selected files from panel to command line on ^Enter"
+
 F1
 l:
 l://functional keys - 6 characters max

--- a/far2l/src/cfg/ConfigOpt.cpp
+++ b/far2l/src/cfg/ConfigOpt.cpp
@@ -180,6 +180,8 @@ const ConfigOpt g_cfg_opts[] {
 		L"CmdlineSettings", L"Display a text block with version, copyright and keyboard tips in build-in terminal at FAR2L starts" },
 	{OST_NONE,   NSecCmdline, "AskOnMultilinePaste", &Opt.CmdLine.AskOnMultilinePaste, 1,
 		L"CmdLineCmd", L"Asks for confirmation before pasting multi-line text into the command line" },
+	{OST_NONE,   NSecCmdline, "AllowSelectionPlacement", &Opt.CmdLine.AllowSelectionPlacement, 1,
+		L"CmdLineCmd", L"Place selected files from panel to command lnue via ^Enter shortcuts family" },
 
 	{OST_COMMON, NSecInterface, "Mouse", &Opt.Mouse, 1,
 		L"InputSettings", L"Enables mouse support in the interface" },

--- a/far2l/src/cfg/config.cpp
+++ b/far2l/src/cfg/config.cpp
@@ -263,6 +263,8 @@ void PanelSettings()
 		BOOL AutoUpdate = (Opt.AutoUpdateLimit);
 		BOOL TreeScanDepthEnabled = (Opt.Tree.ScanDepthEnabled);
 
+		Builder.AddCheckbox(Msg::AllowSelectionPlacement, (BOOL*)&Opt.CmdLine.AllowSelectionPlacement);
+
 		Builder.AddCheckbox(Msg::ConfigHidden, &Opt.ShowHidden);
 
 		auto CbHighlight = Builder.AddCheckbox(Msg::ConfigHighlight, &Opt.Highlight);

--- a/far2l/src/cfg/config.hpp
+++ b/far2l/src/cfg/config.hpp
@@ -301,6 +301,7 @@ struct CommandLineOptions
 	FARString strPromptFormat;
 	FARString strShell;
 	bool AskOnMultilinePaste;
+	bool AllowSelectionPlacement;
 };
 
 struct NowellOptions

--- a/far2l/src/panels/filelist.cpp
+++ b/far2l/src/panels/filelist.cpp
@@ -1030,60 +1030,30 @@ int FileList::ProcessKey(FarKey Key)
 		case KEY_CTRLJ:
 		case KEY_CTRLF:
 		case KEY_CTRLALTF:		// 29.01.2001 VVM + По CTRL+ALT+F в командную строку сбрасывается UNC-имя текущего файла.
-		{
-			if (!ListData.IsEmpty() && SetCurPath()) {
-				FARString strFileName;
-				bool localPath = true;
-
-				if (Key == KEY_CTRLSHIFTENTER || Key == KEY_CTRLSHIFTNUMENTER) {
-					_MakePath1(Key, strFileName, L" ");
-				} else {
-					int CurrentPath = FALSE;
-					ASSERT(CurFile < ListData.Count());
-					CurPtr = ListData[CurFile];
-
-					strFileName = CurPtr->strName;
-
-					if (TestParentFolderName(strFileName)) {
-						if (PanelMode == PLUGIN_PANEL) {
-							strFileName.Clear();
-						} else {
-							strFileName.Truncate(1);	// ".."->"."
-						}
-
-						if (Key != KEY_CTRLALTF)
-							Key = KEY_CTRLF;
-
-						CurrentPath = TRUE;
+		{	// 29.01.2001 VVM + По CTRL+ALT+F в командную строку сбрасывается UNC-имя текущего файла.
+			// vk: if list have selected files, thety are pasted one-by-one; otherwise the file-under-cursor is being used as before
+			bool hasSelected = false;
+			FARString strFileName;
+			if (Opt.CmdLine.AllowSelectionPlacement && Key != KEY_CTRLSHIFTENTER && Key != KEY_CTRLSHIFTNUMENTER) {
+				for (auto &item : ListData) {
+					if(item->Selected) {
+						hasSelected = true;
+						Process_PlaceOnCmdLine(item, Key);
 					}
-
-					if (Key == KEY_CTRLF || Key == KEY_CTRLALTF) {
-						// full paths aren't needed to be prefixed with ./
-						localPath = false;
-						if (PanelMode != PLUGIN_PANEL) {
-							CreateFullPathName(strFileName, strFileName, Key == KEY_CTRLALTF);
-						} else {
-							PluginGetURL(strFileName, strFileName, Key == KEY_CTRLALTF);
-						}
-					}
-
-					if (CurrentPath)
-						AddEndSlash(strFileName);
-
-					if (Opt.QuotedName & QUOTEDNAME_INSERT)
-						EscapeSpace(strFileName);
-
-					if (localPath) {
-						EnsurePathHasParentPrefix(strFileName);
-					}
-
-					strFileName+= L" ";
 				}
-
-				CtrlObject->CmdLine->InsertString(strFileName);
 			}
 
-			return TRUE;
+			if (!hasSelected && !ListData.IsEmpty() && SetCurPath()) {
+				if (Key == KEY_CTRLSHIFTENTER || Key == KEY_CTRLSHIFTNUMENTER) {
+					_MakePath1(Key, strFileName, L" ");
+				}
+				else {
+					ASSERT(CurFile < ListData.Count());
+					CurPtr = ListData[CurFile];
+					Process_PlaceOnCmdLine(CurPtr, Key);
+				}
+			}
+    		return TRUE;
 		}
 		case KEY_CTRLALTBRACKET:			// Вставить реальный (разрешенный) путь из левой панели
 		case KEY_CTRLALTBACKBRACKET:		// Вставить реальный (разрешенный) путь из правой панели
@@ -4586,4 +4556,53 @@ void FileList::ClearAllItem()
 #endif
 
 	SymlinksCache.clear();
+}
+
+void FileList::Process_PlaceOnCmdLine(FileListItem* item, FarKey Key) 
+{
+	bool localPath = true;
+	FARString strFileName;
+
+	int CurrentPath = FALSE;
+	ASSERT(CurFile < ListData.Count());
+	auto CurPtr = item;
+
+	strFileName = CurPtr->strName;
+
+	if (TestParentFolderName(strFileName)) {
+		if (PanelMode == PLUGIN_PANEL) {
+			strFileName.Clear();
+		} else {
+			strFileName.Truncate(1);	// ".."->"."
+		}
+
+		if (Key != KEY_CTRLALTF)
+			Key = KEY_CTRLF;
+
+		CurrentPath = TRUE;
+	}
+
+	if (Key == KEY_CTRLF || Key == KEY_CTRLALTF) {
+		// full paths aren't needed to be prefixed with ./
+		localPath = false;
+		if (PanelMode != PLUGIN_PANEL) {
+			CreateFullPathName(strFileName, strFileName, Key == KEY_CTRLALTF);
+		} else {
+			PluginGetURL(strFileName, strFileName, Key == KEY_CTRLALTF);
+		}
+	}
+
+	if (CurrentPath)
+		AddEndSlash(strFileName);
+
+	if (Opt.QuotedName & QUOTEDNAME_INSERT)
+		EscapeSpace(strFileName);
+
+	if (localPath) {
+		EnsurePathHasParentPrefix(strFileName);
+	}
+
+	strFileName+= L" ";
+
+	CtrlObject->CmdLine->InsertString(strFileName);
 }

--- a/far2l/src/panels/filelist.hpp
+++ b/far2l/src/panels/filelist.hpp
@@ -248,6 +248,7 @@ private:
 	// ChangeDir возвращает FALSE, eсли не смогла выставить заданный путь
 	BOOL ChangeDir(const wchar_t *NewDir, BOOL IsUpdated = TRUE);
 	void CountDirSize(DWORD PluginFlags);
+	void Process_PlaceOnCmdLine(FileListItem* item, FarKey Key);
 	/*
 		$ 19.03.2002 DJ
 		IgnoreVisible - обновить, даже если панель невидима


### PR DESCRIPTION
Issue: there is no way to copy the file names to the command line when they are selected.

Actually, far2l supports wide range of shortcuts to place the file under cursoer to the command line, as follows:

```
		case KEY_CTRLINS:
		case KEY_CTRLNUMPAD0:
		case KEY_CTRLSHIFTINS:
		case KEY_CTRLSHIFTNUMPAD0:
		case KEY_CTRLC:				// копировать имена
		case KEY_CTRLALTINS:
		case KEY_CTRLALTNUMPAD0:	// копировать реальные (разрешенные) имена
		case KEY_ALTSHIFTINS:
		case KEY_ALTSHIFTNUMPAD0:
		case KEY_ALTSHIFTC:		// копировать полные имена

			/*
				$ 14.02.2001 VVM
				+ Ctrl: вставляет имя файла с пассивной панели.
				+ CtrlAlt: вставляет реальное (разрешенное) имя файла с пассивной панели
			*/
		case KEY_CTRL | KEY_SEMICOLON:
		case KEY_CTRL | KEY_ALT | KEY_SEMICOLON: {

		case KEY_CTRLNUMENTER:
		case KEY_CTRLSHIFTNUMENTER:
		case KEY_CTRLENTER:
		case KEY_CTRLSHIFTENTER:
		case KEY_CTRLJ:
		case KEY_CTRLF:
		case KEY_CTRLALTF:
		{	// 29.01.2001 VVM + По CTRL+ALT+F в командную строку сбрасывается UNC-имя текущего файла.

		case KEY_CTRLALTBRACKET:			// Вставить реальный (разрешенный) путь из левой панели
		case KEY_CTRLALTBACKBRACKET:		// Вставить реальный (разрешенный) путь из правой панели
		case KEY_ALTSHIFTBRACKET:			// Вставить реальный (разрешенный) путь из активной панели
		case KEY_ALTSHIFTBACKBRACKET:		// Вставить реальный (разрешенный) путь из пассивной панели
		case KEY_CTRLBRACKET:				// Вставить путь из левой панели
		case KEY_CTRLBACKBRACKET:			// Вставить путь из правой панели
		case KEY_CTRLSHIFTBRACKET:			// Вставить путь из активной панели
		case KEY_CTRLSHIFTBACKBRACKET:		// Вставить путь из пассивной панели
```

But there is no function that will work with selected files; all of them are limited to the file under cursor.

It seems there is a big misfeature; because the ability to place file names for the commands is the real base for every file manager.

So, I've tried to solve this by adding placement to the command line for the selected files; and if there is no files selected, the file under cursor is being used.

Of course, I've added a guard option to disable it for case someone will find this fix annoying.

The new code is easy and there it is:

```
		case KEY_CTRLNUMENTER:
		case KEY_CTRLSHIFTNUMENTER:
		case KEY_CTRLENTER:
		case KEY_CTRLSHIFTENTER:
		case KEY_CTRLJ:
		case KEY_CTRLF:
		case KEY_CTRLALTF:
		{	// 29.01.2001 VVM + По CTRL+ALT+F в командную строку сбрасывается UNC-имя текущего файла.
			// vk: if list have selected files, thety are pasted one-by-one; otherwise the file-under-cursor is being used as before
			bool hasSelected = false;
			FARString strFileName;
			if (Opt.CmdLine.AllowSelectionPlacement && Key != KEY_CTRLSHIFTENTER && Key != KEY_CTRLSHIFTNUMENTER) {
				for (auto &item : ListData) {
					if(item->Selected) {
						hasSelected = true;
						Process_PlaceOnCmdLine(item, Key);
					}
				}
			}

			if (!hasSelected && !ListData.IsEmpty() && SetCurPath()) {
				if (Key == KEY_CTRLSHIFTENTER || Key == KEY_CTRLSHIFTNUMENTER) {
					_MakePath1(Key, strFileName, L" ");
				}
				else {
					ASSERT(CurFile < ListData.Count());
					CurPtr = ListData[CurFile];
					Process_PlaceOnCmdLine(CurPtr, Key);
				}
			}
    		return TRUE;
		}
```

And there is an option:

<img width="609" height="89" alt="image" src="https://github.com/user-attachments/assets/58dd2154-3000-479b-be1a-74ea98a35459" />
