### PR TITLE
utils: share one ls-permission-field parser across NetRocks and adb, and fix its set-id handling

### DIFF
--- a/NetRocks/src/Protocol/FTP/FTPParseLIST.cpp
+++ b/NetRocks/src/Protocol/FTP/FTPParseLIST.cpp
@@ -22,6 +22,7 @@ NCSA Telnet FTP server. Has LIST = NLST (and bad NLST for directories).
 */
 
 #include <sys/types.h>
+#include <UnixModeStr.h>
 #include <time.h>
 #include <stdio.h>
 #include <sys/stat.h>
@@ -284,24 +285,11 @@ int ftpparse(struct ftpparse *fp, const char *buf, int len)
 				if ((buf[j] == ' ') && (buf[j - 1] != ' ')) {
 					switch (state) {
 						case 1: /* handling perm */
-							if (len > 1 && buf[1] != '-')
-								fp->mode|= S_IRUSR;
-							if (len > 2 && buf[2] != '-')
-								fp->mode|= S_IWUSR;
-							if (len > 3 && buf[3] != '-')
-								fp->mode|= S_IXUSR;
-							if (len > 4 && buf[4] != '-')
-								fp->mode|= S_IRGRP;
-							if (len > 5 && buf[5] != '-')
-								fp->mode|= S_IWGRP;
-							if (len > 6 && buf[6] != '-')
-								fp->mode|= S_IXGRP;
-							if (len > 7 && buf[7] != '-')
-								fp->mode|= S_IROTH;
-							if (len > 8 && buf[8] != '-')
-								fp->mode|= S_IWOTH;
-							if (len > 9 && buf[9] != '-')
-								fp->mode|= S_IXOTH;
+							// Type bits were set from buf[0] above, so take permissions only.
+							// The previous "any character but '-' sets the bit" rule marked
+							// "-rwSr--r--" executable and turned NetWare's "d [R----F--]" into
+							// nonsense.
+							fp->mode|= UnixModeStr::Parse(buf, len) & 07777;
 							state = 2;
 							break;
 						case 2:										/* skipping nlink */

--- a/NetRocks/src/Protocol/SHELL/Parse.cpp
+++ b/NetRocks/src/Protocol/SHELL/Parse.cpp
@@ -3,6 +3,7 @@
 #include <utils.h>
 
 #include "Parse.h"
+#include <UnixModeStr.h>
 #include "../ShellParseUtils.h"
 #include "../Protocol.h"
 
@@ -21,7 +22,7 @@ static std::string FetchHead(std::string &line)
 static void SHELLParseLSPermissions(FileInfo &fi, const char *line, size_t line_len)
 {
 //	drwxr-xr-x 0 0
-	fi.mode = ShellParseUtils::Str2Mode(line, line_len);
+	fi.mode = UnixModeStr::Parse(line, line_len);
 	for (size_t i = line_len, j = line_len; i--;) {
 		if (line[i] == ' ' || line[i] == '.') {
 			if (j > i) {
@@ -51,7 +52,7 @@ static unsigned int ParseModeByStatOrFindLine(const std::string &s)
 		return strtoul(s.c_str(), nullptr, 16);
 	}
 
-	return ShellParseUtils::Str2Mode(s.c_str(), s.size());
+	return UnixModeStr::Parse(s.c_str(), s.size());
 }
 
 static bool SHELLParseEnumByStatOrFindLine(FileInfo &fi, std::string line)

--- a/NetRocks/src/Protocol/ShellParseUtils.cpp
+++ b/NetRocks/src/Protocol/ShellParseUtils.cpp
@@ -2,6 +2,7 @@
 #include <time.h>
 #include <string.h>
 #include <utils.h>
+#include <UnixModeStr.h>
 
 #include "ShellParseUtils.h"
 
@@ -37,65 +38,6 @@ namespace ShellParseUtils
 		}
 
 		return out;
-	}
-
-////////////////////
-	unsigned int Char2FileType(char c)
-	{
-		switch (c) {
-			case 'l':
-				return S_IFLNK;
-
-			case 'd':
-				return S_IFDIR;
-
-			case 'c':
-				return S_IFCHR;
-
-			case 'b':
-				return S_IFBLK;
-
-			case 'p':
-				return S_IFIFO;
-
-			case 's':
-				return S_IFSOCK;
-
-			case 'f':
-			default:
-				return S_IFREG;
-		}
-	}
-
-	unsigned int Triplet2FileMode(const char *c)
-	{
-		unsigned int out = 0;
-		if (c[0] == 'r') out|= 4;
-		if (c[1] == 'w') out|= 2;
-		if (c[2] == 'x' || c[1] == 's' || c[1] == 't') out|= 1;
-		return out;
-	}
-
-	unsigned int Str2Mode(const char *str, size_t len)
-	{
-		unsigned int mode = 0;
-		if (len >= 1) {
-			mode = Char2FileType(*str);
-		}
-
-		if (len >= 4) {
-			mode|= Triplet2FileMode(str + 1) << 6;
-		}
-
-		if (len >= 7) {
-			mode|= Triplet2FileMode(str + 4) << 3;
-		}
-
-		if (len >= 10) {
-			mode|= Triplet2FileMode(str + 7);
-		}
-
-		return mode;
 	}
 
 	bool ParseLineFromLS(std::string &line,
@@ -154,7 +96,7 @@ namespace ShellParseUtils
 		if (line.empty())
 			return false;
 
-		mode = ShellParseUtils::Str2Mode(str_mode.c_str(), str_mode.size());
+		mode = UnixModeStr::Parse(str_mode.c_str(), str_mode.size());
 		if (S_ISLNK(mode)) {
 			size_t p = line.find(" -> ");
 			if (p != std::string::npos)

--- a/NetRocks/src/Protocol/ShellParseUtils.h
+++ b/NetRocks/src/Protocol/ShellParseUtils.h
@@ -8,8 +8,6 @@ namespace ShellParseUtils
 	std::string ExtractStringTail(std::string &line, const char *separators);
 	std::string ExtractStringHead(std::string &line, const char *separators);
 
-	unsigned int Str2Mode(const char *str, size_t len);
-
 	bool ParseLineFromLS(std::string &line, // input but also used as scratch string
 		std::string &name, std::string &owner, std::string &group,
 		timespec &access_time, timespec &modification_time, timespec &status_change_time,

--- a/adb/src/ADBDevice.cpp
+++ b/adb/src/ADBDevice.cpp
@@ -11,6 +11,7 @@
 #include <wchar.h>
 #include <errno.h>
 #include <utils.h>
+#include <UnixModeStr.h>
 #include <fstream>
 #include <chrono>
 #include <cctype>
@@ -53,47 +54,6 @@ void TrimTrailingNewlines(std::string& s)
     while (!s.empty() && (s.back() == '\n' || s.back() == '\r')) {
         s.pop_back();
     }
-}
-
-// "drwxr-xr-x" -> S_IFDIR|0755. Panels need the real bits: far2l derives the permission
-// column, the executable/symlink highlighting and the attribute flags from dwUnixMode, so a
-// hardcoded 0755/0644 makes all three wrong.
-// NB: a fixed variant of NetRocks' ShellParseUtils::{Char2FileType,Triplet2FileMode,Str2Mode},
-// which is private to that plugin, omits the setuid/setgid/sticky bits and tests the wrong
-// character for 's'. Promoting a shared implementation to utils/ would suit both.
-mode_t LsPermsToMode(const std::string &perms)
-{
-    static const auto triplet = [](const char *c) -> mode_t {
-        mode_t out = 0;
-        if (c[0] == 'r') out |= 4;
-        if (c[1] == 'w') out |= 2;
-        // x, or s/t which mean "set-id/sticky *and* executable"; S/T mean the bit without x.
-        if (c[2] == 'x' || c[2] == 's' || c[2] == 't') out |= 1;
-        return out;
-    };
-
-    mode_t mode = 0;
-    switch (perms.empty() ? '-' : perms[0]) {
-        case 'd': mode = S_IFDIR; break;
-        case 'l': mode = S_IFLNK; break;
-        case 'c': mode = S_IFCHR; break;
-        case 'b': mode = S_IFBLK; break;
-        case 'p': mode = S_IFIFO; break;
-        case 's': mode = S_IFSOCK; break;
-        default:  mode = S_IFREG; break;
-    }
-    // Entries the shell could not stat come back as "d?????????" - keep the type, no bits.
-    if (perms.size() >= 4)  mode |= triplet(perms.c_str() + 1) << 6;
-    if (perms.size() >= 7)  mode |= triplet(perms.c_str() + 4) << 3;
-    if (perms.size() >= 10) mode |= triplet(perms.c_str() + 7);
-
-    // The set-id and sticky bits live in the x positions as s/S (user, group) and t/T (other);
-    // far2l renders them in the permission column, so losing them shows a setuid binary as a
-    // plain -rwxr-xr-x.
-    if (perms.size() >= 4  && (perms[3] == 's' || perms[3] == 'S')) mode |= S_ISUID;
-    if (perms.size() >= 7  && (perms[6] == 's' || perms[6] == 'S')) mode |= S_ISGID;
-    if (perms.size() >= 10 && (perms[9] == 't' || perms[9] == 'T')) mode |= S_ISVTX;
-    return mode;
 }
 
 int CheckConnection(bool connected)
@@ -636,7 +596,7 @@ std::string ADBDevice::DirectoryEnum(const std::string &path, std::vector<Plugin
 
         PluginPanelItem item{};
         item.FindData.lpwszFileName = AllocateItemString(filename);
-        item.FindData.dwUnixMode = ADBUtils::LsPermsToMode(perms);
+        item.FindData.dwUnixMode = UnixModeStr::Parse(perms.c_str(), perms.size());
         item.FindData.dwFileAttributes = WINPORT(EvaluateAttributesA)(item.FindData.dwUnixMode, filename.c_str());
         if (perms[0] == 'd') item.FindData.dwFileAttributes |= FILE_ATTRIBUTE_DIRECTORY;
 

--- a/utils/include/UnixModeStr.h
+++ b/utils/include/UnixModeStr.h
@@ -1,0 +1,65 @@
+#pragma once
+#include <sys/stat.h>
+#include <stddef.h>
+
+// Recovering a mode_t from the textual permission field of an `ls -l` line, e.g. "drwxr-sr-t".
+//
+// Plugins that browse a remote filesystem through a shell have no stat(2) available, so a
+// human-formatted listing is often the only metadata source. far2l renders the permission
+// column, the executable highlighting and the FILE_ATTRIBUTE_* flags out of dwUnixMode, so
+// getting this field right is what makes those correct.
+namespace UnixModeStr
+{
+	inline mode_t Char2FileType(char c)
+	{
+		switch (c) {
+			case 'l': return S_IFLNK;
+			case 'd': return S_IFDIR;
+			case 'c': return S_IFCHR;
+			case 'b': return S_IFBLK;
+			case 'p': return S_IFIFO;
+			case 's': return S_IFSOCK;
+			case 'f':
+			default: return S_IFREG;
+		}
+	}
+
+	// One "rwx" group. Note the execute bit also has to be recognised in its set-id/sticky
+	// spellings: lowercase s/t mean "that bit AND executable", uppercase S/T mean the bit
+	// without executable.
+	inline mode_t Triplet2Perm(const char *c)
+	{
+		mode_t out = 0;
+		if (c[0] == 'r') out|= 4;
+		if (c[1] == 'w') out|= 2;
+		if (c[2] == 'x' || c[2] == 's' || c[2] == 't') out|= 1;
+		return out;
+	}
+
+	// Full field -> mode. Shorter or partly unknown fields degrade gracefully: entries the
+	// remote shell could not stat come back as "d?????????", which yields the type and no
+	// permission bits at all.
+	inline mode_t Parse(const char *str, size_t len)
+	{
+		mode_t mode = 0;
+		if (len >= 1) {
+			mode = Char2FileType(*str);
+		}
+		if (len >= 4) {
+			mode|= Triplet2Perm(str + 1) << 6;
+		}
+		if (len >= 7) {
+			mode|= Triplet2Perm(str + 4) << 3;
+		}
+		if (len >= 10) {
+			mode|= Triplet2Perm(str + 7);
+		}
+
+		// The set-id and sticky bits are encoded in the execute positions.
+		if (len >= 4 && (str[3] == 's' || str[3] == 'S')) mode|= S_ISUID;
+		if (len >= 7 && (str[6] == 's' || str[6] == 'S')) mode|= S_ISGID;
+		if (len >= 10 && (str[9] == 't' || str[9] == 'T')) mode|= S_ISVTX;
+
+		return mode;
+	}
+}


### PR DESCRIPTION
> **Depends on #3531** — this branch is stacked on it, so the first four commits shown here belong to that PR. Only the last commit, `utils: share one ls-permission-field parser…`, is new. Happy to rebase once #3531 is resolved, or to drop the `adb/` hunk and land the `utils/` + `NetRocks/` part on its own if you prefer.

Recovering a `mode_t` from the textual permission field of an `ls -l` line was implemented **three** times — NetRocks' `ShellParseUtils` (SHELL and SCP), NetRocks' vendored FTP LIST parser, and the `adb` plugin — and all three mishandled the set-id and sticky spellings.

`ShellParseUtils` tested the wrong character:

```c
if (c[2] == 'x' || c[1] == 's' || c[1] == 't') out |= 1;
```

`c[1]` is the *write* position, which is never `s` or `t`, so the execute bit was dropped for every set-id or sticky entry. And `S_ISUID` / `S_ISGID` / `S_ISVTX` were never extracted at all. far2l renders exactly those out of `dwUnixMode` (`panelmix.cpp`), so on a remote listing `/system/bin/run-as` showed up as `-rwxr-xr-x` and `/tmp` as `drwxrwxrwx`.

This moves one implementation into `utils/include/UnixModeStr.h` and deletes all three copies. The header is enough on its own: the top-level `CMakeLists.txt` already does `include_directories(utils/include)`, so every target sees it without build changes.

`FTPParseLIST` was looser still — *any character but `-` sets the bit* — so `-rwSr--r--` came out executable, and NetWare's `d [RWCEAFMS] …` form yielded `0777` from the bracketed flags instead of no permission bits:

| field | expected | old FTP rule |
|---|---|---|
| `-rwSr--r--` | `4644` | `0744` — marked executable |
| `-rwsr-xr-x` | `4755` | `0755` — setuid lost |
| `drwxrwxrwt` | `1777` | `0777` — sticky lost |
| `d [RWCEAFMS]` | `0000` | `0777` |

**Net effect: 78 insertions against 124 deletions across 6 files.**

### Correctness

Table-tested against the previous NetRocks implementation over 17 field shapes — plain / dir / symlink / char / block / fifo / socket, `s` and `S`, `t` and `T`, truncated fields, and the `d?????????` form a shell emits for entries it may not `stat`. The new parser matches expectations on all 17; the old one was wrong on 6, every one of them set-id or sticky:

| field | expected | old NetRocks | |
|---|---|---|---|
| `-rwsr-xr-x` | `0104755` | `0100655` | setuid + exec |
| `-rwxr-sr-x` | `0102755` | `0100745` | setgid + exec |
| `drwxrwxrwt` | `0041777` | `0040776` | sticky + exec (`/tmp`) |
| `-rwSr--r--` | `0104644` | `0100644` | setuid without exec |
| `-rw-r-Sr--` | `0102644` | `0100644` | setgid without exec |
| `drwxrwxrwT` | `0041776` | `0040776` | sticky without exec |

### Behaviour changes worth naming

* far2l renders these bits from `dwUnixMode` (`mix/panelmix.cpp:487-493`), so SHELL, SCP and FTP listings now show them, and `FILE_ATTRIBUTE_EXECUTABLE` is now set for entries like `-rwsr-xr-x`. WinPort derives its attribute flags from `S_IFMT` plus the r/w/x bits only (`WinPort/src/APIFiles.cpp:24-49`), so nothing else in that mapping moves. SFTP is unaffected — it takes real permissions from the sftp attributes.
* `Op/OpXfer.cpp` propagates the source mode on copy (`:469` SetMode, `:513` FilePut, `:626` DirectoryCreate). Those bits could not previously be present for a SHELL/SCP/FTP source, so copying a setuid binary from such a host now reproduces the setuid bit at the destination where before it silently did not. That matches what a local-to-local copy already does via real `stat(2)`, but it is a privilege-bit change rather than a cosmetic one, so please weigh it.
* `OpChangeMode` now pre-checks the suid/sgid/sticky boxes for these items.

Made with [Orca](https://github.com/stablyai/orca) 🐋
