### PR TITLE
colorer: optimize keywords search

### DIFF
--- a/colorer/src/Colorer-library/src/colorer/parsers/HrcLibraryImpl.cpp
+++ b/colorer/src/Colorer-library/src/colorer/parsers/HrcLibraryImpl.cpp
@@ -774,7 +774,6 @@ void HrcLibrary::Impl::parseSchemeKeywords(SchemeImpl* scheme, const XMLNode& el
   loopSchemeKeywords(elem, scheme, scheme_node.get(), region);
   scheme_node->kwList->firstChar->freeze();
 
-  // TODO unique keywords in list
   scheme_node->kwList->sortList();
   scheme_node->kwList->substrIndex();
   scheme->nodes.push_back(std::move(scheme_node));
@@ -875,17 +874,16 @@ void HrcLibrary::Impl::addSchemeKeyword(const XMLNode& elem, const SchemeImpl* s
     rgn = getNCRegion(&elem, hrcWordAttrRegion);
   }
 
+  auto keyword = std::make_unique<UnicodeString>(keyword_value);
+  if (!scheme_node->kwList->matchCase) {
+      keyword->toLower();
+  }
   KeywordInfo& list = scheme_node->kwList->kwList[scheme_node->kwList->count];
-  list.keyword = std::make_unique<UnicodeString>(keyword_value);
+  list.keyword = std::move(keyword);
   list.region = rgn;
   list.isSymbol = keyword_type == KeywordInfo::KeywordType::KT_SYMB;
   auto* first_char = scheme_node->kwList->firstChar.get();
   first_char->add(keyword_value[0]);
-  if (!scheme_node->kwList->matchCase) {
-    first_char->add(Character::toLowerCase(keyword_value[0]));
-    first_char->add(Character::toUpperCase(keyword_value[0]));
-    first_char->add(Character::toTitleCase(keyword_value[0]));
-  }
   scheme_node->kwList->count++;
   scheme_node->kwList->minKeywordLength = std::min(scheme_node->kwList->minKeywordLength, list.keyword->length());
 }

--- a/colorer/src/Colorer-library/src/colorer/parsers/KeywordList.cpp
+++ b/colorer/src/Colorer-library/src/colorer/parsers/KeywordList.cpp
@@ -1,4 +1,5 @@
 #include "colorer/parsers/KeywordList.h"
+#include <algorithm>
 
 KeywordList::KeywordList(size_t list_size)
 {
@@ -11,27 +12,22 @@ KeywordList::~KeywordList()
   delete[] kwList;
 }
 
-int kwCompare(const void* e1, const void* e2)
+void KeywordList::sortList() // sort and remove dups
 {
-  return ((KeywordInfo*) e1)->keyword->compare(*((KeywordInfo*) e2)->keyword);
-}
-
-int kwCompareI(const void* e1, const void* e2)
-{
-  return UStr::caseCompare(*((KeywordInfo*) e1)->keyword, *((KeywordInfo*) e2)->keyword);
-}
-
-void KeywordList::sortList()
-{
-  if (count < 2) {
-    return;
-  }
-
-  if (matchCase) {
-    qsort((void*) kwList, count, sizeof(KeywordInfo), &kwCompare);
-  } else {
-    qsort((void*) kwList, count, sizeof(KeywordInfo), &kwCompareI);
-  }
+  std::sort(kwList, kwList + count, [&](const KeywordInfo& a, const KeywordInfo& b) {
+      int cmp = a.keyword->compare(*b.keyword);
+      if (cmp != 0) {
+        return cmp < 0;
+      }
+      if (a.region != b.region) {
+        return a.region < b.region;
+      }
+      return a.isSymbol < b.isSymbol;
+  });
+  KeywordInfo* new_end = std::unique(kwList, kwList + count, [&](const KeywordInfo& a, const KeywordInfo& b) {
+      return a.region == b.region && a.isSymbol == b.isSymbol && a.keyword->compare(*b.keyword) == 0; // indexOfShorter is irrelevant now
+  });
+  count = new_end - kwList;
 }
 
 /* Searches previous elements num with same partial name
@@ -43,29 +39,23 @@ void KeywordList::sortList()
 */
 void KeywordList::substrIndex()
 {
+  for (int i = 0; i < count; i++) {
+    if (kwList[i].isSymbol) {
+      hasSymbols = true;
+    } else {
+      hasNonSymbols = true;
+    }
+  }
   for (int i = count - 1; i > 0; i--) {
     for (int ii = i - 1; ii >= 0; ii--) {
-      if (matchCase) {
-        if ((*kwList[ii].keyword)[0] != (*kwList[i].keyword)[0]) {
-          break;
-        }
-        if (kwList[ii].keyword->length() < kwList[i].keyword->length() &&
-            kwList[i].keyword->compare(0, kwList[ii].keyword->length(), *kwList[ii].keyword) == 0)
-        {
-          kwList[i].indexOfShorter = ii;
-          break;
-        }
+      if ((*kwList[ii].keyword)[0] != (*kwList[i].keyword)[0]) {
+        break;
       }
-      else {
-        if (Character::toLowerCase((*kwList[ii].keyword)[0]) != Character::toLowerCase((*kwList[i].keyword)[0])) {
-          break;
-        }
-        if (kwList[ii].keyword->length() < kwList[i].keyword->length() &&
-            UStr::caseCompare(*kwList[i].keyword, 0, kwList[ii].keyword->length(), *kwList[ii].keyword) == 0)
-        {
-          kwList[i].indexOfShorter = ii;
-          break;
-        }
+      if (kwList[ii].keyword->length() < kwList[i].keyword->length() &&
+          kwList[i].keyword->compare(0, kwList[ii].keyword->length(), *kwList[ii].keyword) == 0)
+      {
+        kwList[i].indexOfShorter = ii;
+        break;
       }
     }
   }

--- a/colorer/src/Colorer-library/src/colorer/parsers/KeywordList.h
+++ b/colorer/src/Colorer-library/src/colorer/parsers/KeywordList.h
@@ -26,6 +26,8 @@ class KeywordList
 {
  public:
   bool matchCase = false;
+  bool hasSymbols = false;
+  bool hasNonSymbols = false;
   int count = 0;
   int minKeywordLength = INT_MAX;
   std::unique_ptr<CharacterClass> firstChar;

--- a/colorer/src/Colorer-library/src/colorer/parsers/TextParserImpl.cpp
+++ b/colorer/src/Colorer-library/src/colorer/parsers/TextParserImpl.cpp
@@ -201,7 +201,22 @@ int TextParser::Impl::searchKW(const SchemeNodeKeywords* node, int /*no*/, int l
     return MATCH_NOTHING;
   }
 
-  if (gx < lowlen && !node->kwList->firstChar->contains((*str)[gx])) {
+  UnicodeString *use_str = node->kwList->matchCase ? str : &str_lowercase;
+  bool leftbound_bad = false;
+  if (node->kwList->hasNonSymbols) {
+    if (gx > 0) {
+      if (!node->worddiv) { // default word bound
+        leftbound_bad = Character::isLetterOrDigitOrUnderscore((*use_str)[gx - 1]);
+      } else { // custom check for word bound
+        leftbound_bad = !node->worddiv->contains((*use_str)[gx - 1]);
+      }
+    }
+    if (leftbound_bad && !node->kwList->hasSymbols) {
+      return MATCH_NOTHING; // otherwise its just a waist of time
+    }
+  }
+
+  if (gx < lowlen && !node->kwList->firstChar->contains((*use_str)[gx])) {
     return MATCH_NOTHING;
   }
 
@@ -214,36 +229,23 @@ int TextParser::Impl::searchKW(const SchemeNodeKeywords* node, int /*no*/, int l
       kwlen = lowlen - gx;
     }
 
-    int8_t compare_result;
-    if (node->kwList->matchCase) {
-      compare_result = -str->compare(gx, kwlen, *node->kwList->kwList[pos].keyword);
-    }
-    else {
-      compare_result =
-          -UStr::caseCompare(*str, gx, kwlen, *node->kwList->kwList[pos].keyword);
-    }
+    int8_t compare_result = -use_str->compare(gx, kwlen, *node->kwList->kwList[pos].keyword);
 
     if (compare_result == 0 && right - left == 1) {
-      bool badbound = false;
       if (!node->kwList->kwList[pos].isSymbol) {
-        if (!node->worddiv) {
-          // default word bound
-          if ((gx > 0 && Character::isLetterOrDigitOrUnderscore((*str)[gx - 1])) ||
-              (gx + kwlen < lowlen && Character::isLetterOrDigitOrUnderscore((*str)[gx + kwlen])))
-          {
-            badbound = true;
-          }
+        if (leftbound_bad) {
+          compare_result = -1;
         }
-        else {
-          // custom check for word bound
-          if ((gx > 0 && !node->worddiv->contains((*str)[gx - 1])) ||
-              (gx + kwlen < lowlen && !node->worddiv->contains((*str)[gx + kwlen])))
-          {
-            badbound = true;
+        // do similar check for right boundary each iteration cuz kwlen varies
+        else if (!node->worddiv) {
+          if (gx + kwlen < lowlen && Character::isLetterOrDigitOrUnderscore((*use_str)[gx + kwlen])) {
+            compare_result = -1;
           }
+        } else if (gx + kwlen < lowlen && !node->worddiv->contains((*use_str)[gx + kwlen])) {
+          compare_result = -1;
         }
       }
-      if (!badbound) {
+      if (compare_result == 0) {
         COLORER_LOG_DEEPTRACE("[TextParserImpl] KW matched. gx=%, region=%", gx,
                              node->kwList->kwList[pos].region->getName());
         addRegion(current_parse_line, gx, gx + kwlen, node->kwList->kwList[pos].region);
@@ -253,20 +255,17 @@ int TextParser::Impl::searchKW(const SchemeNodeKeywords* node, int /*no*/, int l
     }
     if (right - left == 1) {
       left = node->kwList->kwList[pos].indexOfShorter;
-      if (left != -1) {
-        right = left + 1;
-        continue;
+      if (left == -1) {
+        return MATCH_NOTHING;
       }
-      break;
-    }
-    if (compare_result == 1) {
+      right = left + 1;
+    } else if (compare_result == 1) {
       right = pos;
-    }
-    else {  // if (compare_result == 0 || compare_result == -1)
+    } else {  // if (compare_result == 0 || compare_result == -1)
       left = pos;
     }
   }
-  return MATCH_NOTHING;
+
 }
 
 int TextParser::Impl::searchIN(SchemeNodeInherit* node, int no, int lowLen, int hiLen)
@@ -523,6 +522,8 @@ bool TextParser::Impl::colorize(CRegExp* root_end_re, bool lowContentPriority)
         throw Exception("null String passed into the parser: " +
                         UStr::to_unistr(current_parse_line));
       }
+      str_lowercase = *str;
+      str_lowercase.toLower();
       regionHandler->clearLine(current_parse_line, str);
     }
     // hack to include invisible regions in start of block

--- a/colorer/src/Colorer-library/src/colorer/parsers/TextParserImpl.h
+++ b/colorer/src/Colorer-library/src/colorer/parsers/TextParserImpl.h
@@ -29,6 +29,7 @@ class TextParser::Impl
 
  private:
   UnicodeString* str = nullptr;
+  UnicodeString str_lowercase;
   int stackLevel = 0;
   int current_parse_line = 0;
   int gx = 0;

--- a/colorer/src/Colorer-library/src/colorer/strings/legacy/UnicodeString.cpp
+++ b/colorer/src/Colorer-library/src/colorer/strings/legacy/UnicodeString.cpp
@@ -94,6 +94,14 @@ UnicodeString::UnicodeString(int no)
   construct(&dtext, 0, npos);
 }
 
+UnicodeString& UnicodeString::toLower()
+{
+  for (auto i = length(); i--;) {
+    wstr[i] = Character::toLowerCase(wstr[i]);
+  }
+  return *this;
+}
+
 UnicodeString& UnicodeString::trim()
 {
   int32_t left;

--- a/colorer/src/Colorer-library/src/colorer/strings/legacy/UnicodeString.h
+++ b/colorer/src/Colorer-library/src/colorer/strings/legacy/UnicodeString.h
@@ -111,6 +111,7 @@ class UnicodeString
   }
 
   UnicodeString& trim();
+  UnicodeString& toLower();
 
   /** Searches first index of substring @c str, starting from @c pos */
   int32_t indexOf(const UnicodeString& str, int32_t pos = 0) const;


### PR DESCRIPTION
Squeezed few seconds more (now ~45 sec on same file as previously):
- case-insensitive keyword search now implemented by lowercasing keyword on addition and then applying to whole lowercased string instead of doing char case transformations in each compare
- keywords deduplicated just after sorting (although there are no too many dups)
- some optimizations around left/right bounds checks
