### PR TITLE
colorer: inline static inherited scheme nodes

### DIFF
--- a/colorer/src/Colorer-library/src/colorer/cregexp/cregexp.cpp
+++ b/colorer/src/Colorer-library/src/colorer/cregexp/cregexp.cpp
@@ -1370,6 +1370,11 @@ bool CRegExp::lowParse(SRegInfo* re, SRegInfo* prev, int toParse)
   }
 }
 
+bool CRegExp::canStartWith(wchar ch) const
+{
+  return firstChar == BAD_WCHAR || matchChars(ch, firstChar);
+}
+
 inline bool CRegExp::quickCheck(int toParse)
 {
   if (firstChar != BAD_WCHAR) {

--- a/colorer/src/Colorer-library/src/colorer/cregexp/cregexp.cpp
+++ b/colorer/src/Colorer-library/src/colorer/cregexp/cregexp.cpp
@@ -22,8 +22,8 @@ void SMatches::topnseSanitize(int cur)
 {
     while (topnse < cur) {
       ++topnse;
-      s[topnse] = -1;
-      e[topnse] = -1;
+      ns[topnse] = -1;
+      ne[topnse] = -1;
     }
 }
 #endif
@@ -1430,6 +1430,10 @@ inline bool CRegExp::parseRE(int pos)
   do {
     // stack=null;
     if (lowParse(tree_root, nullptr, toParse)) {
+      matches->topseSanitize(cMatch - 1);
+#ifndef NAMED_MATCHES_IN_HASH
+      matches->topnseSanitize(cnMatch - 1);
+#endif
       return true;
     }
     if (!positionMoves)

--- a/colorer/src/Colorer-library/src/colorer/cregexp/cregexp.cpp
+++ b/colorer/src/Colorer-library/src/colorer/cregexp/cregexp.cpp
@@ -65,7 +65,7 @@ void CRegExp::init()
   tree_root = nullptr;
   positionMoves = false;
   error = EError::EERROR;
-  firstChar = 0;
+  firstNode = nullptr;
   cMatch = 0;
   global_pattern = nullptr;
 #ifdef COLORERMODE
@@ -169,30 +169,40 @@ EError CRegExp::setRELow(const UnicodeString& expr)
 void CRegExp::optimize()
 {
   SRegInfo* next = tree_root;
-  firstChar = BAD_WCHAR;
-  firstMetaChar = EMetaSymbols::ReBadMeta;
+  firstNode = nullptr;
   while (next) {
     if (next->op == EOps::ReBrackets) {
       next = next->un.param;
       continue;
     }
-    /*    if (next->op == EOps::ReMetaSymb &&
-            next->un.metaSymbol >= ReWBound && next->un.metaSymbol < ReChrLast){
+    if (next->op == EOps::ReAhead || next->op == EOps::ReNAhead ||
+        next->op == EOps::ReBehind || next->op == EOps::ReNBehind) {
+      next = next->next;
+      continue;
+    }
+    if (next->op == EOps::ReMetaSymb) {
+      firstNode = next;
+      switch (next->un.metaSymbol) {
+        case EMetaSymbols::ReSoL:
+        case EMetaSymbols::ReEoL:
+        case EMetaSymbols::ReWBound:
+        case EMetaSymbols::ReNWBound:
+        case EMetaSymbols::RePreNW:
+#ifdef COLORERMODE
+        case EMetaSymbols::ReSoScheme:
+        case EMetaSymbols::ReStart:
+        case EMetaSymbols::ReEnd:
+#endif
           next = next->next;
           continue;
-        };*/
-    if (next->op == EOps::ReMetaSymb) {
-      if (next->un.metaSymbol != EMetaSymbols::ReSoL && next->un.metaSymbol != EMetaSymbols::ReWBound)
-        break;
-      firstMetaChar = next->un.metaSymbol;
+        default:
+          break;
+      }
       break;
     }
-    if (next->op == EOps::ReSymb) {
-      firstChar = next->un.symbol;
-      break;
-    }
-    if (next->op == EOps::ReWord) {
-      firstChar = (*next->un.word)[0];
+    if (next->op == EOps::ReSymb || next->op == EOps::ReWord ||
+        next->op == EOps::ReEnum || next->op == EOps::ReNEnum) {
+      firstNode = next;
     }
     break;
   }
@@ -1372,49 +1382,75 @@ bool CRegExp::lowParse(SRegInfo* re, SRegInfo* prev, int toParse)
 
 bool CRegExp::canStartWith(wchar ch) const
 {
-  return firstChar == BAD_WCHAR || matchChars(ch, firstChar);
+  if (!firstNode) {
+    return true;
+  }
+  switch (firstNode->op) {
+    case EOps::ReSymb:
+      return matchChars(ch, firstNode->un.symbol);
+    case EOps::ReWord:
+      return matchChars(ch, (*firstNode->un.word)[0]);
+    case EOps::ReEnum:
+      return firstNode->un.charclass->contains(ch);
+    case EOps::ReNEnum:
+      return !firstNode->un.charclass->contains(ch);
+    case EOps::ReMetaSymb:
+      switch (firstNode->un.metaSymbol) {
+        case EMetaSymbols::ReAnyChr:
+          return singleLine || (ch != 0x0A && ch != 0x0B && ch != 0x0C && ch != 0x0D &&
+                                ch != 0x85 && ch != 0x2028 && ch != 0x2029);
+        case EMetaSymbols::ReDigit:
+          return Character::isDigit(ch);
+        case EMetaSymbols::ReNDigit:
+          return !Character::isDigit(ch);
+        case EMetaSymbols::ReWordSymb:
+          return Character::isLetterOrDigitOrUnderscore(ch);
+        case EMetaSymbols::ReNWordSymb:
+          return !Character::isLetterOrDigitOrUnderscore(ch);
+        case EMetaSymbols::ReWSpace:
+          return Character::isWhitespace(ch);
+        case EMetaSymbols::ReNWSpace:
+          return !Character::isWhitespace(ch);
+        case EMetaSymbols::ReUCase:
+          return Character::isUpperCase(ch);
+        case EMetaSymbols::ReNUCase:
+          return Character::isLowerCase(ch);
+        default:
+          return true;
+      }
+    default:
+      return true;
+  }
 }
 
 inline bool CRegExp::quickCheck(int toParse)
 {
-  if (firstChar != BAD_WCHAR) {
-    return toParse < end && matchChars((*global_pattern)[toParse], firstChar);
-  }
-  if (firstMetaChar != EMetaSymbols::ReBadMeta)
-    switch (firstMetaChar) {
-      case EMetaSymbols::ReSoL:
-        if (toParse != 0)
-          return false;
-        return true;
+  switch (firstNode->op) {
+    case EOps::ReSymb:
+      return toParse < end && matchChars((*global_pattern)[toParse], firstNode->un.symbol);
+    case EOps::ReWord:
+      return toParse < end && matchChars((*global_pattern)[toParse], (*firstNode->un.word)[0]);
+    case EOps::ReEnum:
+    case EOps::ReNEnum:
+      return toParse < end &&
+             (firstNode->un.charclass->contains((*global_pattern)[toParse]) ==
+              (firstNode->op == EOps::ReEnum));
+    case EOps::ReMetaSymb:
+      switch (firstNode->un.metaSymbol) {
 #ifdef COLORERMODE
-      case EMetaSymbols::ReSoScheme:
-        if (toParse != schemeStart)
-          return false;
-        return true;
+        case EMetaSymbols::ReStart:
+        case EMetaSymbols::ReEnd:
+          return true;
 #endif
-        //    case ReWBound:
-        //      return relocale->cl_isword(*toParse) && (toParse == start ||
-        //      !relocale->cl_isword(*(toParse-1)));
-      case EMetaSymbols::ReBadMeta:
-      case EMetaSymbols::ReAnyChr:
-      case EMetaSymbols::ReEoL:
-      case EMetaSymbols::ReDigit:
-      case EMetaSymbols::ReNDigit:
-      case EMetaSymbols::ReWordSymb:
-      case EMetaSymbols::ReNWordSymb:
-      case EMetaSymbols::ReWSpace:
-      case EMetaSymbols::ReNWSpace:
-      case EMetaSymbols::ReUCase:
-      case EMetaSymbols::ReNUCase:
-      case EMetaSymbols::ReWBound:
-      case EMetaSymbols::ReNWBound:
-      case EMetaSymbols::RePreNW:
-      case EMetaSymbols::ReStart:
-      case EMetaSymbols::ReEnd:
-      case EMetaSymbols::ReChrLast:
-        break;
-    }
-  return true;
+        case EMetaSymbols::ReBadMeta:
+        case EMetaSymbols::ReChrLast:
+          return true;
+        default:
+          return checkMetaSymbol(firstNode->un.metaSymbol, toParse);
+      }
+    default:
+      return true;
+  }
 }
 
 inline bool CRegExp::parseRE(int pos)
@@ -1424,7 +1460,7 @@ inline bool CRegExp::parseRE(int pos)
 
   int toParse = pos;
 
-  if (!positionMoves && (firstChar != BAD_WCHAR || firstMetaChar != EMetaSymbols::ReBadMeta) && !quickCheck(toParse))
+  if (!positionMoves && firstNode && !quickCheck(toParse))
     return false;
 
   matches->reset();

--- a/colorer/src/Colorer-library/src/colorer/cregexp/cregexp.h
+++ b/colorer/src/Colorer-library/src/colorer/cregexp/cregexp.h
@@ -335,6 +335,7 @@ class CRegExp
   bool parse(const UnicodeString* str, int pos, int eol, SMatches* mtch, int soscheme = 0,
              int moves = -1);
 #endif
+  bool canStartWith(wchar ch) const;
 
  private:
   bool ignoreCase = false;

--- a/colorer/src/Colorer-library/src/colorer/cregexp/cregexp.h
+++ b/colorer/src/Colorer-library/src/colorer/cregexp/cregexp.h
@@ -345,8 +345,7 @@ class CRegExp
   bool multiLine = false;
   SRegInfo* tree_root = nullptr;
   EError error = EError::EOK;
-  UChar firstChar = 0;
-  EMetaSymbols firstMetaChar = EMetaSymbols::ReBadMeta;
+  SRegInfo* firstNode = nullptr;
 #ifdef COLORERMODE
   CRegExp* backRE = nullptr;
   const UnicodeString* backStr = nullptr;

--- a/colorer/src/Colorer-library/src/colorer/parsers/HrcLibraryImpl.cpp
+++ b/colorer/src/Colorer-library/src/colorer/parsers/HrcLibraryImpl.cpp
@@ -1026,6 +1026,23 @@ void HrcLibrary::Impl::updateLinks()
     }
   }
 
+  const auto canStartWith = [](const SchemeNode* node, wchar ch) {
+    switch (node->type) {
+      case SchemeNode::SchemeNodeType::SNT_RE:
+        return static_cast<const SchemeNodeRegexp*>(node)->start->canStartWith(ch);
+      case SchemeNode::SchemeNodeType::SNT_BLOCK:
+        return static_cast<const SchemeNodeBlock*>(node)->start->canStartWith(ch);
+      case SchemeNode::SchemeNodeType::SNT_KEYWORDS: {
+        const auto* keywords = static_cast<const SchemeNodeKeywords*>(node)->kwList.get();
+        return keywords->count != 0 && keywords->firstChar->contains(
+          keywords->matchCase ? ch : Character::toLowerCase(ch));
+      }
+      case SchemeNode::SchemeNodeType::SNT_INHERIT:
+        return true;
+    }
+    return true;
+  };
+
   for (const auto& [key, scheme] : schemeHash) {
     scheme->searchNodes.clear();
     for (const auto& node : scheme->nodes) {
@@ -1039,6 +1056,25 @@ void HrcLibrary::Impl::updateLinks()
         }
       }
       scheme->searchNodes.push_back(node.get());
+    }
+
+    scheme->searchDispatch.reset();
+    if (scheme->searchNodes.size() >= 2) {
+      auto dispatch = std::make_unique<SchemeImpl::SearchDispatch>();
+      dispatch->masks.resize(scheme->searchNodes.size());
+      size_t candidates = 0;
+      for (size_t i = 0; i < scheme->searchNodes.size(); i++) {
+        auto* node = scheme->searchNodes[i];
+        for (uint32_t ch = 0; ch < 128; ch++) {
+          if (canStartWith(node, static_cast<wchar>(ch))) {
+            dispatch->masks[i][ch / 64] |= uint64_t {1} << (ch % 64);
+            candidates++;
+          }
+        }
+      }
+      if (candidates * 4 <= scheme->searchNodes.size() * 128 * 3) {
+        scheme->searchDispatch = std::move(dispatch);
+      }
     }
   }
 }

--- a/colorer/src/Colorer-library/src/colorer/parsers/HrcLibraryImpl.cpp
+++ b/colorer/src/Colorer-library/src/colorer/parsers/HrcLibraryImpl.cpp
@@ -1,4 +1,6 @@
 #include "colorer/parsers/HrcLibraryImpl.h"
+
+#include <algorithm>
 #include <memory>
 #include "colorer/base/XmlTagDefs.h"
 #include "colorer/parsers/FileTypeImpl.h"
@@ -1011,6 +1013,9 @@ void HrcLibrary::Impl::updateLinks()
           updateSchemeLink(snode_inherit->schemeName, &snode_inherit->scheme, 1, scheme);
           for (auto* vt : snode_inherit->virtualEntryVector) {
             updateSchemeLink(vt->virtSchemeName, &vt->virtScheme, 2, scheme);
+            if (vt->virtScheme) {
+              vt->virtScheme->virtualTarget = true;
+            }
             updateSchemeLink(vt->substSchemeName, &vt->substScheme, 3, scheme);
           }
         }
@@ -1019,6 +1024,26 @@ void HrcLibrary::Impl::updateLinks()
       if (structureChanged) {
         break;
       }
+    }
+  }
+
+  for (const auto& [key, scheme] : schemeHash) {
+    scheme->searchNodes.clear();
+    for (const auto& node : scheme->nodes) {
+      if (node->type == SchemeNode::SchemeNodeType::SNT_INHERIT) {
+        auto* inherit = static_cast<SchemeNodeInherit*>(node.get());
+        if (inherit->scheme && inherit->virtualEntryVector.empty() &&
+            !inherit->scheme->virtualTarget && std::none_of(
+              inherit->scheme->nodes.begin(), inherit->scheme->nodes.end(), [](const auto& node) {
+                return node->type == SchemeNode::SchemeNodeType::SNT_INHERIT;
+              })) {
+          for (const auto& inheritedNode : inherit->scheme->nodes) {
+            scheme->searchNodes.push_back(inheritedNode.get());
+          }
+          continue;
+        }
+      }
+      scheme->searchNodes.push_back(node.get());
     }
   }
 }

--- a/colorer/src/Colorer-library/src/colorer/parsers/HrcLibraryImpl.cpp
+++ b/colorer/src/Colorer-library/src/colorer/parsers/HrcLibraryImpl.cpp
@@ -1,6 +1,5 @@
 #include "colorer/parsers/HrcLibraryImpl.h"
 
-#include <algorithm>
 #include <memory>
 #include "colorer/base/XmlTagDefs.h"
 #include "colorer/parsers/FileTypeImpl.h"
@@ -1032,11 +1031,7 @@ void HrcLibrary::Impl::updateLinks()
     for (const auto& node : scheme->nodes) {
       if (node->type == SchemeNode::SchemeNodeType::SNT_INHERIT) {
         auto* inherit = static_cast<SchemeNodeInherit*>(node.get());
-        if (inherit->scheme && inherit->virtualEntryVector.empty() &&
-            !inherit->scheme->virtualTarget && std::none_of(
-              inherit->scheme->nodes.begin(), inherit->scheme->nodes.end(), [](const auto& node) {
-                return node->type == SchemeNode::SchemeNodeType::SNT_INHERIT;
-              })) {
+        if (inherit->scheme && inherit->virtualEntryVector.empty() && !inherit->scheme->virtualTarget) {
           for (const auto& inheritedNode : inherit->scheme->nodes) {
             scheme->searchNodes.push_back(inheritedNode.get());
           }

--- a/colorer/src/Colorer-library/src/colorer/parsers/SchemeImpl.h
+++ b/colorer/src/Colorer-library/src/colorer/parsers/SchemeImpl.h
@@ -1,6 +1,8 @@
 #ifndef COLORER_HRCPARSERPELPERS_H
 #define COLORER_HRCPARSERPELPERS_H
 
+#include <array>
+#include <cstdint>
 #include <memory>
 #include <vector>
 #include "colorer/Scheme.h"
@@ -31,9 +33,15 @@ class SchemeImpl : public Scheme
   }
 
  protected:
+  struct SearchDispatch
+  {
+    std::vector<std::array<uint64_t, 2>> masks;
+  };
+
   uUnicodeString schemeName;
   std::vector<std::unique_ptr<SchemeNode>> nodes;
   std::vector<SchemeNode*> searchNodes;
+  std::unique_ptr<SearchDispatch> searchDispatch;
   FileType* fileType = nullptr;
   bool virtualTarget = false;
 

--- a/colorer/src/Colorer-library/src/colorer/parsers/SchemeImpl.h
+++ b/colorer/src/Colorer-library/src/colorer/parsers/SchemeImpl.h
@@ -33,7 +33,9 @@ class SchemeImpl : public Scheme
  protected:
   uUnicodeString schemeName;
   std::vector<std::unique_ptr<SchemeNode>> nodes;
+  std::vector<SchemeNode*> searchNodes;
   FileType* fileType = nullptr;
+  bool virtualTarget = false;
 
   explicit SchemeImpl(const UnicodeString* sn)
   {

--- a/colorer/src/Colorer-library/src/colorer/parsers/TextParserImpl.cpp
+++ b/colorer/src/Colorer-library/src/colorer/parsers/TextParserImpl.cpp
@@ -459,13 +459,13 @@ int TextParser::Impl::searchMatch(const SchemeImpl* cscheme, int no, int lowLen,
 #ifdef COLORER_USE_DEEPTRACE
   int idx = 0;
 #endif
-  for (auto const& schemeNode : cscheme->nodes) {
+  for (auto* schemeNode : cscheme->searchNodes) {
     COLORER_LOG_DEEPTRACE("[TextParserImpl] searchMatch: processing node:%/%, type:%", idx + 1,
-                         cscheme->nodes.size(),
+                         cscheme->searchNodes.size(),
                          SchemeNode::schemeNodeTypeNames[static_cast<int>(schemeNode->type)]);
     switch (schemeNode->type) {
       case SchemeNode::SchemeNodeType::SNT_INHERIT: {
-        auto schemeNodeInherit = static_cast<SchemeNodeInherit*>(schemeNode.get());
+        auto schemeNodeInherit = static_cast<SchemeNodeInherit*>(schemeNode);
         int re_result = searchIN(schemeNodeInherit, no, lowLen, hiLen);
         if (re_result != MATCH_NOTHING) {
           return re_result;
@@ -473,21 +473,21 @@ int TextParser::Impl::searchMatch(const SchemeImpl* cscheme, int no, int lowLen,
         break;
       }
       case SchemeNode::SchemeNodeType::SNT_KEYWORDS: {
-        auto schemeNodeKe = static_cast<SchemeNodeKeywords*>(schemeNode.get());
+        auto schemeNodeKe = static_cast<SchemeNodeKeywords*>(schemeNode);
         if (searchKW(schemeNodeKe, no, lowLen, hiLen) == MATCH_RE) {
           return MATCH_RE;
         }
         break;
       }
       case SchemeNode::SchemeNodeType::SNT_RE: {
-        auto schemeNodeRe = static_cast<SchemeNodeRegexp*>(schemeNode.get());
+        auto schemeNodeRe = static_cast<SchemeNodeRegexp*>(schemeNode);
         if (searchRE(schemeNodeRe, no, lowLen, hiLen) == MATCH_RE) {
           return MATCH_RE;
         }
         break;
       }
       case SchemeNode::SchemeNodeType::SNT_BLOCK: {
-        auto schemeNodeBlock = static_cast<SchemeNodeBlock*>(schemeNode.get());
+        auto schemeNodeBlock = static_cast<SchemeNodeBlock*>(schemeNode);
         if (searchBL(schemeNodeBlock, no, lowLen, hiLen) != MATCH_NOTHING) {
           return MATCH_SCHEME;
         }

--- a/colorer/src/Colorer-library/src/colorer/parsers/TextParserImpl.cpp
+++ b/colorer/src/Colorer-library/src/colorer/parsers/TextParserImpl.cpp
@@ -278,7 +278,7 @@ int TextParser::Impl::searchIN(SchemeNodeInherit* node, int no, int lowLen, int 
 
   int re_result = MATCH_NOTHING;
   // ищем для текущей схемы возможную замену через virtual предыдущих inherit
-  SchemeImpl* ssubst = vtlist->pushvirt(node->scheme);
+  SchemeImpl* ssubst = node->scheme->virtualTarget ? vtlist->pushvirt(node->scheme) : nullptr;
   if (!ssubst) {
     // не нашли замену
     // помещаем текущий inherit в список для будущих замен. True - если поместили, не было
@@ -341,7 +341,7 @@ int TextParser::Impl::searchBL(SchemeNodeBlock* node, int no, int lowLen, int hi
   COLORER_LOG_DEEPTRACE("[TextParserImpl] Scheme matched. gx=%", gx);
   gx = match.e[0];
   // проверяем наличие замены через virtual для данной схемы
-  SchemeImpl* ssubst = vtlist->pushvirt(node->scheme);
+  SchemeImpl* ssubst = node->scheme->virtualTarget ? vtlist->pushvirt(node->scheme) : nullptr;
   if (!ssubst) {
     // замены нет, работаем с текущей
     ssubst = node->scheme;
@@ -459,7 +459,20 @@ int TextParser::Impl::searchMatch(const SchemeImpl* cscheme, int no, int lowLen,
 #ifdef COLORER_USE_DEEPTRACE
   int idx = 0;
 #endif
-  for (auto* schemeNode : cscheme->searchNodes) {
+  uint32_t dispatchChar = 128;
+  if (cscheme->searchDispatch && gx < str->length()) {
+    const auto ch = static_cast<uint32_t>((*str)[gx]);
+    if (ch < 128) {
+      dispatchChar = ch;
+    }
+  }
+  for (size_t i = 0; i < cscheme->searchNodes.size(); i++) {
+    if (dispatchChar < 128 &&
+        !(cscheme->searchDispatch->masks[i][dispatchChar / 64] &
+          (uint64_t {1} << (dispatchChar % 64)))) {
+      continue;
+    }
+    auto* schemeNode = cscheme->searchNodes[i];
     COLORER_LOG_DEEPTRACE("[TextParserImpl] searchMatch: processing node:%/%, type:%", idx + 1,
                          cscheme->searchNodes.size(),
                          SchemeNode::schemeNodeTypeNames[static_cast<int>(schemeNode->type)]);


### PR DESCRIPTION
Colorer теперь заранее разворачивает статические `<inherit>` после загрузки HRC-схем. При разборе текста узлы унаследованных схем обходятся напрямую, без повторных вызовов searchIN() и searchMatch().

Виртуальные наследования не изменены и по-прежнему разрешаются динамически. Это уменьшает глубину вызовов и накладные расходы при разборе языков с цепочками статических наследований, включая C/C++.