### PR TITLE
Fix text copied on macOS being published as UTF-16 under the UTF-8 UTI

### DIFF
--- a/WinPort/src/Backend/WX/wxClipboardBackend.cpp
+++ b/WinPort/src/Backend/WX/wxClipboardBackend.cpp
@@ -1,5 +1,6 @@
 #include <stdlib.h>
 #include <map>
+#include <vector>
 #include <algorithm>
 #include <wx/wx.h>
 #include <wx/display.h>
@@ -57,7 +58,39 @@ public:
 
 } g_wx_custom_formats;
 
-static wxDataObjectComposite *g_wx_data_to_clipboard = nullptr;
+// Data objects accumulated by OnClipboardSetData until OnClipboardClose hands them
+// over to wxTheClipboard. They're wrapped into a wxDataObjectComposite only if there
+// is more than one of them: wx's macOS backend publishes a composite's
+// wxDF_UNICODETEXT (UTF-16) buffer under the public.utf8-plain-text UTI, so text
+// copied out of far2l reaches other apps as UTF-16 bytes claiming to be UTF-8.
+// A standalone wxTextDataObject is handled correctly.
+static std::vector<wxDataObjectSimple *> g_wx_data_to_clipboard;
+
+static void AddDataToClipboard(wxDataObjectSimple *obj)
+{
+	g_wx_data_to_clipboard.emplace_back(obj);
+}
+
+// Returns object to be given to wxTheClipboard (ownership transferred to caller)
+// or nullptr if nothing was accumulated.
+static wxDataObject *TakeDataForClipboard()
+{
+	wxDataObject *out = nullptr;
+
+	if (g_wx_data_to_clipboard.size() == 1) {
+		out = g_wx_data_to_clipboard.front();
+
+	} else if (!g_wx_data_to_clipboard.empty()) {
+		wxDataObjectComposite *composite = new wxDataObjectComposite;
+		for (auto *obj : g_wx_data_to_clipboard) {
+			composite->Add(obj);
+		}
+		out = composite;
+	}
+
+	g_wx_data_to_clipboard.clear();
+	return out;
+}
 
 wxClipboardBackend::wxClipboardBackend()
 {
@@ -97,14 +130,14 @@ void wxClipboardBackend::OnClipboardClose()
 		return;
 	}
 
-	if (g_wx_data_to_clipboard) {
-		if (wxTheClipboard->SetData( g_wx_data_to_clipboard) ) {
+	wxDataObject *data_to_clipboard = TakeDataForClipboard();
+	if (data_to_clipboard) {
+		if (wxTheClipboard->SetData( data_to_clipboard) ) {
 			fprintf(stderr, "wxTheClipboard->SetData - OK\n");
 
 		} else {
 			fprintf(stderr, "wxTheClipboard->SetData - FAILED\n");
 		}
-		g_wx_data_to_clipboard = nullptr;
 
 	} else {
 		fprintf(stderr, "CloseClipboard without data\n");
@@ -148,8 +181,10 @@ void wxClipboardBackend::OnClipboardEmpty()
 	}
 
 	fprintf(stderr, "EmptyClipboard\n");
-	delete g_wx_data_to_clipboard;
-	g_wx_data_to_clipboard = nullptr;
+	for (auto *obj : g_wx_data_to_clipboard) {
+		delete obj;
+	}
+	g_wx_data_to_clipboard.clear();
 	wxTheClipboard->Clear();
 }
 
@@ -207,32 +242,33 @@ void *wxClipboardBackend::OnClipboardSetData(UINT format, void *data)
 
 	size_t len = WINPORT(ClipboardSize)(data);
 	fprintf(stderr, "SetClipboardData: format=%u len=%lu\n", format, (unsigned long)len);
-	if (!g_wx_data_to_clipboard) {
-		g_wx_data_to_clipboard = new wxDataObjectComposite;
-	}
-
 	if (format == CF_UNICODETEXT) {
 
 		wxString wx_str((const wchar_t *)data);
 
-		g_wx_data_to_clipboard->Add(new wxTextDataObjectTweaked(wx_str));
+		AddDataToClipboard(new wxTextDataObjectTweaked(wx_str));
 
+#ifndef __APPLE__
+		// needed by apps that look for the MIME type rather than for wxDF_TEXT;
+		// on macOS it only forces the composite that corrupts the UTF-8 flavor
 		wxCustomDataObject *cdo = new wxCustomDataObject(wxT("text/plain;charset=utf-8"));
 		const std::string &tmp = wx_str.ToStdString();
 		cdo->SetData(tmp.size(), tmp.c_str()); // not including ending NUL char
-		g_wx_data_to_clipboard->Add(cdo);
-
+		AddDataToClipboard(cdo);
+#endif
 
 #if (CLIPBOARD_HACK)
 		CopyToPasteboard((const wchar_t *)data);
 #endif
 
 	} else if (format == CF_TEXT) {
-		g_wx_data_to_clipboard->Add(new wxTextDataObjectTweaked(wxString::FromUTF8((const char *)data)));
+		AddDataToClipboard(new wxTextDataObjectTweaked(wxString::FromUTF8((const char *)data)));
 
+#ifndef __APPLE__
 		wxCustomDataObject *cdo = new wxCustomDataObject(wxT("text/plain;charset=utf-8"));
 		cdo->SetData(strlen((const char *)data), data); // not including ending NUL char
-		g_wx_data_to_clipboard->Add(cdo);
+		AddDataToClipboard(cdo);
+#endif
 
 #if (CLIPBOARD_HACK)
 		CopyToPasteboard((const char *)data);
@@ -240,7 +276,7 @@ void *wxClipboardBackend::OnClipboardSetData(UINT format, void *data)
 
 	} else if (format == CF_HTML) {
 		auto *cdo = new wxHTMLDataObject(wxString::FromUTF8((const char *)data));
-		g_wx_data_to_clipboard->Add(cdo);
+		AddDataToClipboard(cdo);
 
 	} else {
 		const wxDataFormat *data_format = g_wx_custom_formats.Lookup(format);
@@ -251,7 +287,7 @@ void *wxClipboardBackend::OnClipboardSetData(UINT format, void *data)
 		} else {
 			wxCustomDataObject *dos = new wxCustomDataObject(*data_format);
 			dos->SetData(len, data);
-			g_wx_data_to_clipboard->Add(dos);
+			AddDataToClipboard(dos);
 		}
 	}
 


### PR DESCRIPTION
## Problem

On macOS, text copied out of far2l arrives in other applications as UTF-16 bytes published under the `public.utf8-plain-text` UTI. Terminals silently ignore the embedded NULs, so pasting into iTerm looks fine — but Electron-based apps and JetBrains IDEs either show a NUL between every character or drop the text entirely.

Copying `/Users/me/some/path` and inspecting the pasteboard:

```
$ osascript -e 'clipboard info'
«class utf8», 136, Unicode text, 136, «class ut16», 274, string, 136

$ pbpaste | hexdump -C
00000000  2f 00 55 00 73 00 65 00  72 00 73 00 2f 00 76 00  |/.U.s.e.r.s./.v.|
```

The path is 68 characters, but the flavor that claims to be UTF-8 holds 136 bytes.

## Cause

`wxDataObjectComposite` on macOS publishes its `wxDF_UNICODETEXT` (UTF-16) buffer under the UTF-8 UTI. `OnClipboardSetData()` puts everything into a composite unconditionally, so all text copied from far2l goes through it.

This is independent of far2l — a standalone wx program shows the same thing (wxWidgets 3.3.3, macOS 26.5.2). Putting 8 ASCII characters on the clipboard:

| data object | `«class utf8»` flavor | bytes |
|---|---|---|
| `wxTextDataObject` | 8 | `41 42 43 44 45 46 47 48` ✅ |
| same object inside a `wxDataObjectComposite` | 16 | `41 00 42 00 43 00 44 00` ❌ |

The composite alone is enough to trigger it; the existing `wxTextDataObjectTweaked` override and the companion MIME object are not involved.

far2l does have a native-pasteboard workaround, but it is gated to `wxMINOR_VERSION == 1`, so it has been inactive since wx 3.2. Re-enabling it would not help by itself either, since `wxTheClipboard->SetData()` runs later, in `OnClipboardClose()`, and would overwrite whatever it wrote.

## Fix

Collect the data objects in a vector and wrap them into a `wxDataObjectComposite` only when there is more than one, since a standalone `wxTextDataObject` is handled correctly.

On macOS, also skip the companion `text/plain;charset=utf-8` object. It exists for apps that look for the MIME type rather than for `wxDF_TEXT`, and it was the only reason the text path ever had two objects there. It is only ever read back as a fallback when `wxDF_TEXT` is absent, so dropping it on macOS does not affect paste into far2l.

**Other platforms are unaffected for text**: it still gets both the `wxTextDataObject` and the MIME object, and therefore still goes through a composite. The `CF_HTML` and custom-format paths were already single-object and now skip the composite wrapper everywhere — I believe that is a no-op, but I could only test on macOS and would appreciate a look from someone on GTK.

## Verification

Same folder, same automated macro (`RunAfterFARStart=1`, `Sequence=Home Down CtrlAltIns F10 Enter`), isolated profile, only the binary differs. Copying a path ending in a non-ASCII filename `тест ünï.txt`:

| build | `«class utf8»` flavor | `pbpaste` |
|---|---|---|
| before | 270 bytes (UTF-16 of 135 chars) | empty — all NULs |
| after | 139 bytes, valid UTF-8 | `.../тест ünï.txt` |

The non-ASCII tail after the fix is byte-identical to the filename on disk:

```
clipboard: d1 82 d0 b5 d1 81 d1 82 20 c3 bc 6e c3 af 2e 74 78 74
on disk:   d1 82 d0 b5 d1 81 d1 82 20 c3 bc 6e c3 af 2e 74 78 74
```

Paste into far2l itself, and between far2l instances, continues to work.

Related: #909 reports being unable to copy a path to the clipboard on macOS.
