### PR TITLE
Fix macOS tests by raising local socket buffers

### DIFF
--- a/WinPort/src/Backend/TestController.cpp
+++ b/WinPort/src/Backend/TestController.cpp
@@ -47,6 +47,7 @@ void *TestController::ThreadProc()
 void TestController::ClientLoop(const std::string &ipc_client)
 {
 	LocalSocketClient sock(LocalSocket::DATAGRAM, _ipc_server, ipc_client);
+	sock.SetBufferSize(1024 * 1024);
 	sock.Send(&_buf, ClientDispatchStatus());
 	for (;;) {
 		size_t len = sock.Recv(&_buf, sizeof(_buf));

--- a/WinPort/src/Backend/TestProtocol.h
+++ b/WinPort/src/Backend/TestProtocol.h
@@ -3,9 +3,7 @@
 #define TEST_PROTOCOL_VERSION	0xF001
 enum
 {
-	// AF_UNIX datagrams on macOS reject payloads above 2048 bytes with EMSGSIZE.
-	// Keep every test message within that limit.
-	TEST_PROTOCOL_TEXT_MAX = 2024
+	TEST_PROTOCOL_TEXT_MAX = 2048
 };
 
 enum TestCommand
@@ -94,7 +92,3 @@ struct TestReplySync
 {
 	uint8_t waited;
 };
-
-static_assert(sizeof(TestReplyStatus) <= 2048, "TestReplyStatus must fit into one local datagram");
-static_assert(sizeof(TestReplyReadCell) <= 2048, "TestReplyReadCell must fit into one local datagram");
-static_assert(sizeof(TestRequestWaitString) <= 2048, "TestRequestWaitString must fit into one local datagram");

--- a/testing/src/main.go
+++ b/testing/src/main.go
@@ -70,10 +70,31 @@ var g_test_workdir string
 var g_calm bool = false
 var g_last_error string
 
-const far2lTestTextMax = 2024
+const far2lTestTextMax = 2048
 const far2lStatusPacketSize = 20 + far2lTestTextMax
 const far2lReadCellPacketSize = 8 + far2lTestTextMax
 const far2lWaitStringPacketSize = 24 + far2lTestTextMax
+const far2lSocketBufferSize = 1024 * 1024
+
+func far2l_ConfigureSocketBuffers(socket *net.UnixConn) error {
+	rawConn, err := socket.SyscallConn()
+	if err != nil {
+		return err
+	}
+
+	var socketErr error
+	err = rawConn.Control(func(fd uintptr) {
+		if err := syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_RCVBUF, far2lSocketBufferSize); err != nil {
+			socketErr = err
+			return
+		}
+		socketErr = syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_SNDBUF, far2lSocketBufferSize)
+	})
+	if err != nil {
+		return err
+	}
+	return socketErr
+}
 
 func stringFromBytes(buf []byte) string {
 	last := 0
@@ -431,6 +452,9 @@ func main() {
     if err != nil {
         log.Fatal(err)
     }
+	if err = far2l_ConfigureSocketBuffers(g_socket); err != nil {
+		log.Fatal(err)
+	}
 
 	initVM()
 

--- a/utils/include/LocalSocket.h
+++ b/utils/include/LocalSocket.h
@@ -28,6 +28,8 @@ protected:
 	FDScope _sock;
 
 public:
+	void SetBufferSize(int size);
+
 	size_t Send(const void *data, size_t len);
 	size_t Recv(void *data, size_t len);
 
@@ -58,4 +60,3 @@ class LocalSocketClient : public LocalSocket
 public:
 	LocalSocketClient(Kind sock_kind, const std::string &server, const std::string &client);
 };
-

--- a/utils/src/LocalSocket.cpp
+++ b/utils/src/LocalSocket.cpp
@@ -44,6 +44,14 @@ template <class IO_ERROR, class FN>
 	}
 }
 
+void LocalSocket::SetBufferSize(int size)
+{
+	if (setsockopt(_sock, SOL_SOCKET, SO_RCVBUF, &size, sizeof(size)) == -1
+		|| setsockopt(_sock, SOL_SOCKET, SO_SNDBUF, &size, sizeof(size)) == -1) {
+		throw LocalSocketSocketError();
+	}
+}
+
 size_t LocalSocket::Send(const void *data, size_t len)
 {
 	return len
@@ -245,4 +253,3 @@ void LocalSocketServer::WaitForClient(int fd_cancel, int tmout_msec)
 		}
 	}
 }
-


### PR DESCRIPTION
instead of limiting test protocol messages
touch #3554