### PR TITLE
NetRocks: sync FISH+ helper with f4

### DIFF
--- a/NetRocks/src/Protocol/FISHPLUS/Helpers/UPSTREAM.md
+++ b/NetRocks/src/Protocol/FISHPLUS/Helpers/UPSTREAM.md
@@ -6,7 +6,7 @@
 |---|---|
 | Upstream | https://github.com/unxed/f4 |
 | Path | `plugins/netfox/fishplus/helper.sh` |
-| Commit | `891a485` (mklink) |
+| Commit | `9a03d417` (portable `chown` invocation) |
 | License | BSD-3-Clause (see the f4 repository) |
 
 It is deliberately **not** edited here, not even to remove the parts NetRocks

--- a/NetRocks/src/Protocol/FISHPLUS/Helpers/helper.sh
+++ b/NetRocks/src/Protocol/FISHPLUS/Helpers/helper.sh
@@ -1011,7 +1011,10 @@ f4_cmd_chown() {
   f4_end err "nothing to change"
   return
  fi
- f4_do chown "$F4SPEC" -- "$F4PATH"
+ # "--" must come before the owner spec: GNU getopt permutes arguments,
+ # but BSD and macOS stop option parsing at the first operand, so a
+ # trailing "--" is taken as a file name there.
+ f4_do chown -- "$F4SPEC" "$F4PATH"
 }
 # grep <mode><i?> <limit>, then a pattern line and a path line. The reply is
 # one byte offset per match: the point of doing this remotely is that a


### PR DESCRIPTION
## Summary

- refresh the embedded FISH+ helper to match f4 commit `9a03d417`;
- keep `helper.sh` byte-for-byte identical to the f4 source;
- move `--` before the owner spec in `chown`, which is required on BSD/macOS shells;
- update the synchronization note to record the imported f4 revision.

## Verification

- `cmp` against `plugins/netfox/fishplus/helper.sh` from f4: identical;
- `sh -n` passes for both copies;
- f4 FISH+ package tests and the focused chown integration test pass.

The current far2l FISH+ transport is POSIX-shell based; PowerShell support remains an f4 client-side path and is not silently claimed as implemented here.
