### PR TITLE
wineguts: fix LTO type mismatch in cptable extern declarations

### DIFF
--- a/WinPort/wineguts/cptable.c
+++ b/WinPort/wineguts/cptable.c
@@ -28,175 +28,175 @@
 
 /* Everything below this line is generated automatically by make_unicode */
 /* ### cpmap begin ### */
-extern union cptable cptable_037;
-extern union cptable cptable_424;
-extern union cptable cptable_437;
-extern union cptable cptable_500;
-extern union cptable cptable_737;
-extern union cptable cptable_775;
-extern union cptable cptable_850;
-extern union cptable cptable_852;
-extern union cptable cptable_855;
-extern union cptable cptable_856;
-extern union cptable cptable_857;
-extern union cptable cptable_860;
-extern union cptable cptable_861;
-extern union cptable cptable_862;
-extern union cptable cptable_863;
-extern union cptable cptable_864;
-extern union cptable cptable_865;
-extern union cptable cptable_866;
-extern union cptable cptable_866uk;
-extern union cptable cptable_869;
-extern union cptable cptable_874;
-extern union cptable cptable_875;
+extern const struct sbcs_table cptable_037;
+extern const struct sbcs_table cptable_424;
+extern const struct sbcs_table cptable_437;
+extern const struct sbcs_table cptable_500;
+extern const struct sbcs_table cptable_737;
+extern const struct sbcs_table cptable_775;
+extern const struct sbcs_table cptable_850;
+extern const struct sbcs_table cptable_852;
+extern const struct sbcs_table cptable_855;
+extern const struct sbcs_table cptable_856;
+extern const struct sbcs_table cptable_857;
+extern const struct sbcs_table cptable_860;
+extern const struct sbcs_table cptable_861;
+extern const struct sbcs_table cptable_862;
+extern const struct sbcs_table cptable_863;
+extern const struct sbcs_table cptable_864;
+extern const struct sbcs_table cptable_865;
+extern const struct sbcs_table cptable_866;
+extern const struct sbcs_table cptable_866uk;
+extern const struct sbcs_table cptable_869;
+extern const struct sbcs_table cptable_874;
+extern const struct sbcs_table cptable_875;
 #ifndef NO_EACP
-extern union cptable cptable_932;
-extern union cptable cptable_936;
-extern union cptable cptable_949;
-extern union cptable cptable_950;
+extern const struct dbcs_table cptable_932;
+extern const struct dbcs_table cptable_936;
+extern const struct dbcs_table cptable_949;
+extern const struct dbcs_table cptable_950;
 #endif
-extern union cptable cptable_1006;
-extern union cptable cptable_1026;
-extern union cptable cptable_1250;
-extern union cptable cptable_1251;
-extern union cptable cptable_1252;
-extern union cptable cptable_1253;
-extern union cptable cptable_1254;
-extern union cptable cptable_1255;
-extern union cptable cptable_1256;
-extern union cptable cptable_1257;
-extern union cptable cptable_1258;
+extern const struct sbcs_table cptable_1006;
+extern const struct sbcs_table cptable_1026;
+extern const struct sbcs_table cptable_1250;
+extern const struct sbcs_table cptable_1251;
+extern const struct sbcs_table cptable_1252;
+extern const struct sbcs_table cptable_1253;
+extern const struct sbcs_table cptable_1254;
+extern const struct sbcs_table cptable_1255;
+extern const struct sbcs_table cptable_1256;
+extern const struct sbcs_table cptable_1257;
+extern const struct sbcs_table cptable_1258;
 #ifndef NO_EACP
-extern union cptable cptable_1361;
+extern const struct dbcs_table cptable_1361;
 #endif
-extern union cptable cptable_10000;
+extern const struct sbcs_table cptable_10000;
 #ifndef NO_EACP
-extern union cptable cptable_10001;
-extern union cptable cptable_10002;
-extern union cptable cptable_10003;
+extern const struct dbcs_table cptable_10001;
+extern const struct dbcs_table cptable_10002;
+extern const struct dbcs_table cptable_10003;
 #endif
-extern union cptable cptable_10004;
-extern union cptable cptable_10005;
-extern union cptable cptable_10006;
-extern union cptable cptable_10007;
+extern const struct sbcs_table cptable_10004;
+extern const struct sbcs_table cptable_10005;
+extern const struct sbcs_table cptable_10006;
+extern const struct sbcs_table cptable_10007;
 #ifndef NO_EACP
-extern union cptable cptable_10008;
+extern const struct dbcs_table cptable_10008;
 #endif
-extern union cptable cptable_10010;
-extern union cptable cptable_10017;
-extern union cptable cptable_10021;
-extern union cptable cptable_10029;
-extern union cptable cptable_10079;
-extern union cptable cptable_10081;
-extern union cptable cptable_10082;
-extern union cptable cptable_20127;
-extern union cptable cptable_20866;
-extern union cptable cptable_20880;
+extern const struct sbcs_table cptable_10010;
+extern const struct sbcs_table cptable_10017;
+extern const struct sbcs_table cptable_10021;
+extern const struct sbcs_table cptable_10029;
+extern const struct sbcs_table cptable_10079;
+extern const struct sbcs_table cptable_10081;
+extern const struct sbcs_table cptable_10082;
+extern const struct sbcs_table cptable_20127;
+extern const struct sbcs_table cptable_20866;
+extern const struct sbcs_table cptable_20880;
 #ifndef NO_EACP
-extern union cptable cptable_20932;
+extern const struct dbcs_table cptable_20932;
 #endif
-extern union cptable cptable_21866;
-extern union cptable cptable_28591;
-extern union cptable cptable_28592;
-extern union cptable cptable_28593;
-extern union cptable cptable_28594;
-extern union cptable cptable_28595;
-extern union cptable cptable_28596;
-extern union cptable cptable_28597;
-extern union cptable cptable_28598;
-extern union cptable cptable_28599;
-extern union cptable cptable_28600;
-extern union cptable cptable_28603;
-extern union cptable cptable_28604;
-extern union cptable cptable_28605;
-extern union cptable cptable_28606;
+extern const struct sbcs_table cptable_21866;
+extern const struct sbcs_table cptable_28591;
+extern const struct sbcs_table cptable_28592;
+extern const struct sbcs_table cptable_28593;
+extern const struct sbcs_table cptable_28594;
+extern const struct sbcs_table cptable_28595;
+extern const struct sbcs_table cptable_28596;
+extern const struct sbcs_table cptable_28597;
+extern const struct sbcs_table cptable_28598;
+extern const struct sbcs_table cptable_28599;
+extern const struct sbcs_table cptable_28600;
+extern const struct sbcs_table cptable_28603;
+extern const struct sbcs_table cptable_28604;
+extern const struct sbcs_table cptable_28605;
+extern const struct sbcs_table cptable_28606;
 
 static const union cptable * const cptables[] =
 {
-    &cptable_037,
-    &cptable_424,
-    &cptable_437,
-    &cptable_500,
-    &cptable_737,
-    &cptable_775,
-    &cptable_850,
-    &cptable_852,
-    &cptable_855,
-    &cptable_856,
-    &cptable_857,
-    &cptable_860,
-    &cptable_861,
-    &cptable_862,
-    &cptable_863,
-    &cptable_864,
-    &cptable_865,
-    &cptable_866,
-    &cptable_866uk,
-    &cptable_869,
-    &cptable_874,
-    &cptable_875,
+    (const union cptable *)&cptable_037,
+    (const union cptable *)&cptable_424,
+    (const union cptable *)&cptable_437,
+    (const union cptable *)&cptable_500,
+    (const union cptable *)&cptable_737,
+    (const union cptable *)&cptable_775,
+    (const union cptable *)&cptable_850,
+    (const union cptable *)&cptable_852,
+    (const union cptable *)&cptable_855,
+    (const union cptable *)&cptable_856,
+    (const union cptable *)&cptable_857,
+    (const union cptable *)&cptable_860,
+    (const union cptable *)&cptable_861,
+    (const union cptable *)&cptable_862,
+    (const union cptable *)&cptable_863,
+    (const union cptable *)&cptable_864,
+    (const union cptable *)&cptable_865,
+    (const union cptable *)&cptable_866,
+    (const union cptable *)&cptable_866uk,
+    (const union cptable *)&cptable_869,
+    (const union cptable *)&cptable_874,
+    (const union cptable *)&cptable_875,
 #ifndef NO_EACP
-    &cptable_932,
-    &cptable_936,
-    &cptable_949,
-    &cptable_950,
+    (const union cptable *)&cptable_932,
+    (const union cptable *)&cptable_936,
+    (const union cptable *)&cptable_949,
+    (const union cptable *)&cptable_950,
 #endif
-    &cptable_1006,
-    &cptable_1026,
-    &cptable_1250,
-    &cptable_1251,
-    &cptable_1252,
-    &cptable_1253,
-    &cptable_1254,
-    &cptable_1255,
-    &cptable_1256,
-    &cptable_1257,
-    &cptable_1258,
+    (const union cptable *)&cptable_1006,
+    (const union cptable *)&cptable_1026,
+    (const union cptable *)&cptable_1250,
+    (const union cptable *)&cptable_1251,
+    (const union cptable *)&cptable_1252,
+    (const union cptable *)&cptable_1253,
+    (const union cptable *)&cptable_1254,
+    (const union cptable *)&cptable_1255,
+    (const union cptable *)&cptable_1256,
+    (const union cptable *)&cptable_1257,
+    (const union cptable *)&cptable_1258,
 #ifndef NO_EACP
-    &cptable_1361,
+    (const union cptable *)&cptable_1361,
 #endif
-    &cptable_10000,
+    (const union cptable *)&cptable_10000,
 #ifndef NO_EACP
-    &cptable_10001,
-    &cptable_10002,
-    &cptable_10003,
+    (const union cptable *)&cptable_10001,
+    (const union cptable *)&cptable_10002,
+    (const union cptable *)&cptable_10003,
 #endif
-    &cptable_10004,
-    &cptable_10005,
-    &cptable_10006,
-    &cptable_10007,
+    (const union cptable *)&cptable_10004,
+    (const union cptable *)&cptable_10005,
+    (const union cptable *)&cptable_10006,
+    (const union cptable *)&cptable_10007,
 #ifndef NO_EACP
-    &cptable_10008,
+    (const union cptable *)&cptable_10008,
 #endif
-    &cptable_10010,
-    &cptable_10017,
-    &cptable_10021,
-    &cptable_10029,
-    &cptable_10079,
-    &cptable_10081,
-    &cptable_10082,
-    &cptable_20127,
-    &cptable_20866,
-    &cptable_20880,
+    (const union cptable *)&cptable_10010,
+    (const union cptable *)&cptable_10017,
+    (const union cptable *)&cptable_10021,
+    (const union cptable *)&cptable_10029,
+    (const union cptable *)&cptable_10079,
+    (const union cptable *)&cptable_10081,
+    (const union cptable *)&cptable_10082,
+    (const union cptable *)&cptable_20127,
+    (const union cptable *)&cptable_20866,
+    (const union cptable *)&cptable_20880,
 #ifndef NO_EACP
-    &cptable_20932,
+    (const union cptable *)&cptable_20932,
 #endif
-    &cptable_21866,
-    &cptable_28591,
-    &cptable_28592,
-    &cptable_28593,
-    &cptable_28594,
-    &cptable_28595,
-    &cptable_28596,
-    &cptable_28597,
-    &cptable_28598,
-    &cptable_28599,
-    &cptable_28600,
-    &cptable_28603,
-    &cptable_28604,
-    &cptable_28605,
-    &cptable_28606,
+    (const union cptable *)&cptable_21866,
+    (const union cptable *)&cptable_28591,
+    (const union cptable *)&cptable_28592,
+    (const union cptable *)&cptable_28593,
+    (const union cptable *)&cptable_28594,
+    (const union cptable *)&cptable_28595,
+    (const union cptable *)&cptable_28596,
+    (const union cptable *)&cptable_28597,
+    (const union cptable *)&cptable_28598,
+    (const union cptable *)&cptable_28599,
+    (const union cptable *)&cptable_28600,
+    (const union cptable *)&cptable_28603,
+    (const union cptable *)&cptable_28604,
+    (const union cptable *)&cptable_28605,
+    (const union cptable *)&cptable_28606,
 };
 /* ### cpmap end ### */
 /* Everything above this line is generated automatically by make_unicode */


### PR DESCRIPTION
## Problem

GCC 15 with LTO enabled (`-flto`) fails to build `WinPort/wineguts/cptable.c` with:

```
cptable.c:113:22: error: type of 'cptable_28606' does not match original declaration [-Werror=lto-type-mismatch]
  113 | extern union cptable cptable_28606;
```

The root cause: `cptable.c` declared all codepage symbols as `extern union cptable cptable_XXXXX` (non-const, union type), while the generated codepage files define them as either:
- `const struct sbcs_table DECLSPEC_HIDDEN cptable_XXXXX` (SBCS codepages)
- `const struct dbcs_table DECLSPEC_HIDDEN cptable_XXXXX` (DBCS codepages: 932, 936, 949, 950, 1361, 10001, 10002, 10003, 10008, 20932)

GCC's LTO correctly flags this as a type mismatch across translation units.

## Fix

Replace all `extern union cptable` declarations with the correct concrete types (`const struct sbcs_table` or `const struct dbcs_table`), and add explicit `(const union cptable *)` casts in the `cptables[]` array. The generated codepage `.c` files are left untouched.

The cast is safe because `union cptable` has `struct sbcs_table sbcs` and `struct dbcs_table dbcs` as its first members, so the address of either struct is the same as the address of the union.