### PR TITLE
Delete shebang line from udockerio.py

### DIFF
--- a/plugins/python/configs/plugins/udockerio.py
+++ b/plugins/python/configs/plugins/udockerio.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env vpython3
 import os
 import stat
 import time


### PR DESCRIPTION
That file is imported by udocker.py, not supposed to be run directly.

Fixes warning from Lintian (Debian linter):

    W: far2l-data: unusual-interpreter vpython3 [usr/share/far2l/Plugins/python/plugins/udockerio.py]