### PR TITLE
Add OpenBSD build compatibility

### DIFF
--- a/WinPort/src/APIFiles.cpp
+++ b/WinPort/src/APIFiles.cpp
@@ -194,7 +194,7 @@ extern "C"
 		if ((dwFlagsAndAttributes & (FILE_FLAG_WRITE_THROUGH|FILE_FLAG_NO_BUFFERING)) != 0) {
 #if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__) || defined(__HAIKU__)
 			fcntl(r, O_DIRECT, 1);
-#elif !defined(__CYGWIN__)
+#elif !defined(__CYGWIN__) && !defined(__OpenBSD__)
 			fcntl(r, F_NOCACHE, 1);
 #endif // __FreeBSD__
 		}

--- a/WinPort/src/APIMemory.cpp
+++ b/WinPort/src/APIMemory.cpp
@@ -10,7 +10,7 @@
 // # include <sys/sysctl.h>
 #include <mach/mach_host.h>
 #include <mach/vm_statistics.h>
-#elif !defined(__FreeBSD__) && !defined(__NetBSD__) && !defined(__DragonFly__) && !defined(__HAIKU__)
+#elif !defined(__FreeBSD__) && !defined(__NetBSD__) && !defined(__OpenBSD__) && !defined(__DragonFly__) && !defined(__HAIKU__)
 #include <sys/sysinfo.h>
 #endif
 
@@ -85,7 +85,7 @@ WINPORT_DECL(GlobalMemoryStatusEx, BOOL, (LPMEMORYSTATUSEX ms))
 		return TRUE;
 	}
 
-#elif !defined(__FreeBSD__) && !defined(__NetBSD__) && !defined(__DragonFly__) && !defined(__HAIKU__)
+#elif !defined(__FreeBSD__) && !defined(__NetBSD__) && !defined(__OpenBSD__) && !defined(__DragonFly__) && !defined(__HAIKU__)
 	struct sysinfo si = {};
 	if (sysinfo(&si) == 0) {
 		ms->dwMemoryLoad = 100 - ToPercent64(si.freeram + si.freeswap, si.totalram + si.totalswap);

--- a/WinPort/src/Backend/TTY/TTYCaps.h
+++ b/WinPort/src/Backend/TTY/TTYCaps.h
@@ -32,5 +32,5 @@ struct TTYCaps
 	bool wayland : 1;       // set by Setup()
 };
 
-unsigned int TTYKernelQueryControlKeys(int stdin);
+unsigned int TTYKernelQueryControlKeys(int fd);
 bool TTYWriteAndDrain(int fd, const std::string &str);

--- a/WinPort/src/sudo/sudo_client_api.cpp
+++ b/WinPort/src/sudo/sudo_client_api.cpp
@@ -8,14 +8,14 @@
 #include <dlfcn.h>
 #include <sys/stat.h>
 #include <sys/statvfs.h>
-#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__) || defined(__CYGWIN__)
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__) || defined(__CYGWIN__)
 # include <sys/mount.h>
 #elif !defined(__HAIKU__)
 # include <sys/statfs.h>
 #endif
 #include <sys/time.h>
 #include <sys/types.h>
-#if !defined(__FreeBSD__) && !defined(__NetBSD__) && !defined(__DragonFly__)
+#if !defined(__FreeBSD__) && !defined(__NetBSD__) && !defined(__OpenBSD__) && !defined(__DragonFly__)
 # include <sys/xattr.h>
 #endif
 #include <map>
@@ -24,7 +24,7 @@
 #include "sudo_private.h"
 #include "sudo.h"
 
-#if !defined(__APPLE__) and !defined(__FreeBSD__) && !defined(__NetBSD__) && !defined(__DragonFly__) && !defined(__CYGWIN__) && !defined(__HAIKU__)
+#if !defined(__APPLE__) and !defined(__FreeBSD__) && !defined(__NetBSD__) && !defined(__OpenBSD__) && !defined(__DragonFly__) && !defined(__CYGWIN__) && !defined(__HAIKU__)
 # include <sys/ioctl.h>
 # include <linux/fs.h>
 #endif

--- a/WinPort/src/sudo/sudo_dispatcher.cpp
+++ b/WinPort/src/sudo/sudo_dispatcher.cpp
@@ -6,7 +6,7 @@
 #include <fcntl.h>
 #include <string.h>
 #include <sys/stat.h>
-#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__)
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
 	#include <sys/mount.h>
 #elif !defined(__HAIKU__)
 	#include <sys/statfs.h>
@@ -18,7 +18,7 @@
 #include <sys/statvfs.h>
 #include <sys/time.h>
 #include <sys/types.h>
-#if !defined(__FreeBSD__) && !defined(__DragonFly__)
+#if !defined(__FreeBSD__) && !defined(__OpenBSD__) && !defined(__DragonFly__)
 # include <sys/xattr.h>
 #endif
 #include <stdexcept>
@@ -301,7 +301,7 @@ namespace Sudo
 
 	static void OnSudoDispatch_FSFlagsGet(BaseTransaction &bt)
 	{
-#if !defined(__APPLE__) && !defined(__FreeBSD__) && !defined(__NetBSD__) && !defined(__DragonFly__) && !defined(__CYGWIN__) && !defined(__HAIKU__)
+#if !defined(__APPLE__) && !defined(__FreeBSD__) && !defined(__NetBSD__) && !defined(__OpenBSD__) && !defined(__DragonFly__) && !defined(__CYGWIN__) && !defined(__HAIKU__)
 		std::string path;
 		bt.RecvStr(path);
 		int r = -1;
@@ -328,7 +328,7 @@ namespace Sudo
 		bt.RecvStr(path);
 		bt.RecvPOD(flags);
 
-#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__)
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
 		if (chflags(path.c_str(), flags) == 0) {
 			bt.SendInt(0);
 			return;

--- a/WinPort/src/sudo/sudo_private.h
+++ b/WinPort/src/sudo/sudo_private.h
@@ -101,7 +101,7 @@ namespace Sudo
 		~ClientReconstructCurDir();
 	};
 
-#if !defined(__APPLE__) && !defined(__FreeBSD__) && !defined(__NetBSD__) && !defined(__DragonFly__)
+#if !defined(__APPLE__) && !defined(__FreeBSD__) && !defined(__NetBSD__) && !defined(__OpenBSD__) && !defined(__DragonFly__)
 	int bugaware_ioctl_pint(int fd, unsigned long req, unsigned long *v);
 #endif
 

--- a/WinPort/sudo.h
+++ b/WinPort/sudo.h
@@ -2,7 +2,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/statvfs.h>
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__OpenBSD__)
 	#include <sys/mount.h>
 #elif defined(__NetBSD__)
 	struct statfs : statvfs {

--- a/far2l/CMakeLists.txt
+++ b/far2l/CMakeLists.txt
@@ -273,7 +273,7 @@ set_target_properties(far2l
     PROPERTIES
     ENABLE_EXPORTS TRUE)
 
-if (${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD|NetBSD")
+if (${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD|NetBSD|OpenBSD")
     target_link_libraries(far2l
     PRIVATE ${WINPORT}
     PRIVATE c
@@ -288,6 +288,10 @@ else()
     PRIVATE ${WINPORT}
         PRIVATE dl
         PRIVATE ${UCHARDET_LIBRARIES})
+endif()
+
+if(CMAKE_SYSTEM_NAME MATCHES "OpenBSD")
+    target_link_libraries(far2l PRIVATE execinfo)
 endif()
 
 add_custom_command(TARGET far2l POST_BUILD

--- a/far2l/src/base/SafeMMap.cpp
+++ b/far2l/src/base/SafeMMap.cpp
@@ -1,4 +1,4 @@
-#ifndef __NetBSD__
+#if !defined(__NetBSD__) && !defined(__OpenBSD__)
 # define _XOPEN_SOURCE // macos wants it for ucontext
 #endif
 
@@ -19,7 +19,7 @@
 #include "../WinPort/sudo.h"
 #include <sys/mman.h>
 #include <sys/stat.h>
-#if !defined(__HAIKU__)
+#if !defined(__HAIKU__) && !defined(__OpenBSD__)
 #include <ucontext.h>
 #endif
 
@@ -103,8 +103,13 @@ static void FDWriteSignalInfo(int fd, int num, siginfo_t *info, void *ctx)
 	FDWriteStr(fd, errmsg);
 
 	const ucontext_t *uctx = (const ucontext_t *)ctx;
+#ifdef __OpenBSD__
+	const long *mctx = (const long *)uctx;
+	const size_t mctx_count = sizeof(*uctx) / sizeof(*mctx);
+#else
 	const long *mctx = (const long *)&uctx->uc_mcontext;
 	const size_t mctx_count = sizeof(uctx->uc_mcontext) / sizeof(*mctx);
+#endif
 
 	for (size_t i = 0; i < mctx_count; ++i) {
 		if (i == 0) {

--- a/far2l/src/base/farrtl.cpp
+++ b/far2l/src/base/farrtl.cpp
@@ -30,7 +30,7 @@ wchar_t *__cdecl far_wcsncpy(wchar_t *dest, const wchar_t *src, size_t DestSize)
 	return tmpsrc;
 }
 
-#if defined(__MUSL__) || defined(__ANDROID__)
+#if defined(__MUSL__) || defined(__ANDROID__) || defined(__OpenBSD__)
 struct QSortExAdapterArg
 {
 	int (*__cdecl comp)(const void *, const void *, void *);

--- a/far2l/src/farwinapi.cpp
+++ b/far2l/src/farwinapi.cpp
@@ -37,7 +37,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <sys/statvfs.h>
 #include <fcntl.h>
 #include <errno.h>
-#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__) || defined(__CYGWIN__)
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__) || defined(__OpenBSD__) || defined(__CYGWIN__)
 #include <sys/mount.h>
 #elif !defined(__HAIKU__)
 #include <sys/statfs.h>

--- a/far2l/src/headers.hpp
+++ b/far2l/src/headers.hpp
@@ -44,9 +44,6 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifdef __GNUC__
 #include <cctype>
 #include <climits>
-#if !defined(__APPLE__) and !defined(__FreeBSD__) && !defined(__NetBSD__) && !defined(__DragonFly__)
-#include <malloc.h>
-#endif
 #endif	//__GNUC__
 
 #include <search.h>

--- a/far2l/src/headers.hpp
+++ b/far2l/src/headers.hpp
@@ -44,6 +44,9 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifdef __GNUC__
 #include <cctype>
 #include <climits>
+#if !defined(__APPLE__) and !defined(__FreeBSD__) && !defined(__NetBSD__) && !defined(__OpenBSD__) && !defined(__DragonFly__)
+#include <malloc.h>
+#endif
 #endif	//__GNUC__
 
 #include <search.h>

--- a/far2l/src/mix/FSFileFlags.h
+++ b/far2l/src/mix/FSFileFlags.h
@@ -37,7 +37,7 @@ public:
 #endif
 };
 
-#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__)
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
 # define FS_FLAGS_CONTAIN_IMMUTABLE(flags) (((flags) & (UF_IMMUTABLE | SF_IMMUTABLE)) != 0)
 # define FS_FLAGS_WITHOUT_IMMUTABLE(flags) ((flags) & (~(UF_IMMUTABLE | SF_IMMUTABLE)))
 # define FS_FLAGS_WITH_IMMUTABLE(flags) ((flags) | (UF_IMMUTABLE))

--- a/far2l/src/mix/MountInfo.cpp
+++ b/far2l/src/mix/MountInfo.cpp
@@ -6,7 +6,7 @@
 #include <sys/stat.h>
 #include <sys/statvfs.h>
 #include <fcntl.h>
-#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__) || defined(__CYGWIN__)
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__) || defined(__OpenBSD__) || defined(__CYGWIN__)
 # if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__)
 #  include <sys/param.h>
 #  include <sys/ucred.h>
@@ -272,7 +272,7 @@ MountInfo::MountInfo(bool for_location_menu)
 		}
 	}
 
-#elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__)
+#elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__) || defined(__OpenBSD__)
 
 #ifdef __NetBSD__
 	int r = getvfsstat(nullptr, 0, MNT_NOWAIT);
@@ -373,6 +373,9 @@ std::string MountInfo::GetFileSystem(const std::string &path) const
 	if (out.empty()) {
 		struct statfs sfs{};
 		if (sdc_statfs(path.c_str(), &sfs) == 0) {
+#ifdef __OpenBSD__
+			out = sfs.f_fstypename;
+#else
 #ifdef __APPLE__
 		out = sfs.f_fstypename;
 		if (out.empty())
@@ -383,6 +386,7 @@ std::string MountInfo::GetFileSystem(const std::string &path) const
 					break;
 				}
 			}
+#endif
 		}
 	}
 #else

--- a/far2l/src/panels/infolist.cpp
+++ b/far2l/src/panels/infolist.cpp
@@ -62,7 +62,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // # include <sys/sysctl.h>
 #include <mach/mach_host.h>
 #include <mach/vm_statistics.h>
-#elif !defined(__FreeBSD__) && !defined(__NetBSD__) && !defined(__DragonFly__) && !defined(__HAIKU__)
+#elif !defined(__FreeBSD__) && !defined(__NetBSD__) && !defined(__OpenBSD__) && !defined(__DragonFly__) && !defined(__HAIKU__)
 #include <sys/sysinfo.h>
 #endif
 #include <sys/statvfs.h>
@@ -444,7 +444,7 @@ void InfoList::DisplayObject()
 			PrintInfo(strOutStr);
 		}
 
-#elif !defined(__FreeBSD__)&& !defined(__NetBSD__) && !defined(__DragonFly__) && !defined(__HAIKU__)
+#elif !defined(__FreeBSD__)&& !defined(__NetBSD__) && !defined(__OpenBSD__) && !defined(__DragonFly__) && !defined(__HAIKU__)
 		struct sysinfo si = {};
 		if (sysinfo(&si) == 0) {
 			DWORD dwMemoryLoad = 100 - ToPercent64(si.freeram + si.freeswap, si.totalram + si.totalswap);

--- a/far2l/src/panels/treelist.cpp
+++ b/far2l/src/panels/treelist.cpp
@@ -35,7 +35,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <sys/stat.h>
 #include <sys/statvfs.h>
-#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__) || defined(__CYGWIN__)
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__) || defined(__OpenBSD__) || defined(__CYGWIN__)
 #include <sys/mount.h>
 #elif !defined(__HAIKU__)
 #include <sys/statfs.h>

--- a/plugins/NetRocks/src/Host/HostLocal.cpp
+++ b/plugins/NetRocks/src/Host/HostLocal.cpp
@@ -10,7 +10,7 @@
 
 #ifdef __APPLE__
 	#include <sys/mount.h>
-#elif !defined(__FreeBSD__) && !defined(__NetBSD__) && !defined(__DragonFly__) && !defined(__HAIKU__)
+#elif !defined(__FreeBSD__) && !defined(__NetBSD__) && !defined(__OpenBSD__) && !defined(__DragonFly__) && !defined(__HAIKU__)
 	#include <sys/statfs.h>
 #endif
 

--- a/plugins/arclite/CMakeLists.txt
+++ b/plugins/arclite/CMakeLists.txt
@@ -36,6 +36,11 @@ target_compile_definitions(arclite PRIVATE -DNDEBUG)
 
 target_link_libraries(arclite utils far2l)
 
+if(CMAKE_SYSTEM_NAME MATCHES "OpenBSD")
+    find_package(Iconv REQUIRED)
+    target_link_libraries(arclite Iconv::Iconv)
+endif()
+
 target_include_directories(arclite PRIVATE 
     ${CMAKE_SOURCE_DIR}/WinPort
     ${CMAKE_SOURCE_DIR}/utils/include

--- a/plugins/arclite/src/archive.cpp
+++ b/plugins/arclite/src/archive.cpp
@@ -9,7 +9,7 @@
 #include "archive.hpp"
 #include "options.hpp"
 
-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__) || defined(__APPLE__)
+#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__) || defined(__OpenBSD__) || defined(__APPLE__)
 #include <sys/types.h>
 #else
 #include <sys/sysmacros.h>	  // major / minor

--- a/plugins/arclite/src/open.cpp
+++ b/plugins/arclite/src/open.cpp
@@ -29,7 +29,7 @@
 #include <Drivers.h>
 #endif
 
-#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__) || defined(__CYGWIN__)
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__) || defined(__OpenBSD__) || defined(__CYGWIN__)
 #include <sys/mount.h>
 #elif !defined(__HAIKU__)
 #include <sys/statfs.h>

--- a/plugins/arclite/src/ui.cpp
+++ b/plugins/arclite/src/ui.cpp
@@ -15,7 +15,7 @@
 #include <Threaded.h>
 #include <algorithm>
 
-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__) || defined(__APPLE__)
+#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__) || defined(__OpenBSD__) || defined(__APPLE__)
 #include <sys/types.h>
 #else
 #include <sys/sysmacros.h>	  // major / minor

--- a/plugins/arclite/src/update.cpp
+++ b/plugins/arclite/src/update.cpp
@@ -10,7 +10,7 @@
 #include "options.hpp"
 #include "sfx.hpp"
 
-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__) || defined(__APPLE__)
+#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__) || defined(__OpenBSD__) || defined(__APPLE__)
 #include <sys/types.h>
 #else
 #include <sys/sysmacros.h>	  // major / minor

--- a/plugins/farftp/fstd/all_far.h
+++ b/plugins/farftp/fstd/all_far.h
@@ -8,7 +8,7 @@
 
 #include <signal.h>		// SIGxxx
 #include <sys/stat.h>	// stat
-#if !defined(__APPLE__) && !defined(__FreeBSD__) && !defined(__DragonFly__)
+#if !defined(__APPLE__) && !defined(__FreeBSD__) && !defined(__DragonFly__) && !defined(__OpenBSD__)
 #include <malloc.h>		// alloc,NULL
 #endif
 #include <math.h>		// sqrt

--- a/plugins/incsrch/incsrch.h
+++ b/plugins/incsrch/incsrch.h
@@ -25,7 +25,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <string.h>
 #include <limits.h>
 #include <stddef.h>
-#if !defined(__APPLE__) && !defined(__FreeBSD__) && !defined(__DragonFly__)
+#if !defined(__APPLE__) && !defined(__FreeBSD__) && !defined(__DragonFly__) && !defined(__OpenBSD__)
 #include <malloc.h>
 #endif
 #include <stdlib.h>

--- a/plugins/multiarc/src/formats/7z/7z.cpp
+++ b/plugins/multiarc/src/formats/7z/7z.cpp
@@ -12,7 +12,7 @@
 #include <utils.h>
 #include "MulDiv64.h"
 #include <string.h>
-#if !defined(__APPLE__) && !defined(__FreeBSD__) && !defined(__DragonFly__)
+#if !defined(__APPLE__) && !defined(__FreeBSD__) && !defined(__DragonFly__) && !defined(__OpenBSD__)
 # include <malloc.h>
 #endif
 #include <stddef.h>

--- a/plugins/multiarc/src/formats/ace/ace.cpp
+++ b/plugins/multiarc/src/formats/ace/ace.cpp
@@ -10,7 +10,7 @@
 #include <windows.h>
 #include <utils.h>
 #include <string.h>
-#if !defined(__APPLE__) && !defined(__FreeBSD__) && !defined(__DragonFly__)
+#if !defined(__APPLE__) && !defined(__FreeBSD__) && !defined(__DragonFly__) && !defined(__OpenBSD__)
 #include <malloc.h>
 #endif
 #include <stddef.h>

--- a/utils/include/utimens_compat.h
+++ b/utils/include/utimens_compat.h
@@ -6,6 +6,20 @@
 #undef utimens
 #define utimens(PATH, TIMES) utimensat(AT_FDCWD, PATH, TIMES, 0)
 
+#ifdef __OpenBSD__
+static inline int lutimes_compat(const char *path, const struct timeval times[2])
+{
+	struct timespec ts[2] = {};
+	ts[0].tv_sec = times[0].tv_sec;
+	ts[0].tv_nsec = times[0].tv_usec * 1000;
+	ts[1].tv_sec = times[1].tv_sec;
+	ts[1].tv_nsec = times[1].tv_usec * 1000;
+	return utimensat(AT_FDCWD, path, ts, AT_SYMLINK_NOFOLLOW);
+}
+# undef lutimes
+# define lutimes lutimes_compat
+#endif
+
 #ifdef __APPLE__
 # include "Availability.h"
 # if !defined(MAC_OS_X_VERSION_10_13) || MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_13

--- a/utils/src/FSNotify.cpp
+++ b/utils/src/FSNotify.cpp
@@ -1,7 +1,7 @@
 #include <set>
 #include <vector>
 #include <atomic>
-#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__)
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
 # include <sys/types.h>
 # include <sys/event.h>
 # include <sys/time.h>
@@ -36,7 +36,7 @@ class FSNotify : public IFSNotify
 
 class FSNotify : public IFSNotify
 {
-#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__)
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
 	std::vector<struct kevent> _events;
 #endif
 	std::vector<int> _watches;
@@ -51,7 +51,7 @@ class FSNotify : public IFSNotify
 	void AddWatch(const char *path)
 	{
 		int w;
-#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__)
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
 		w = open(path, O_RDONLY | O_CLOEXEC);
 		if (w != -1) {
 			u_int fflags = NOTE_DELETE | NOTE_LINK | NOTE_RENAME;
@@ -117,7 +117,7 @@ class FSNotify : public IFSNotify
 
 	void WatcherProc()
 	{
-#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__)
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
 		struct kevent ev = {};
 		int nev = kevent(_fd, &_events[0], _events.size(), &ev, 1, nullptr);
 		if (nev > 0) {
@@ -168,7 +168,7 @@ public:
 		:
 		_watcher(0), _fd(-1), _what(what)
 	{
-#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__)
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
 		_fd = kqueue();
 		if (_fd == -1)
 			return;
@@ -184,7 +184,7 @@ public:
 		}
 
 		if (!_watches.empty() && pipe_cloexec(_pipe) == 0) {
-#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__)
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
 			_events.emplace_back();
 			EV_SET(&_events.back(), _pipe[0], EVFILT_READ, EV_ADD | EV_ENABLE | EV_ONESHOT, 0, 0, 0);
 #endif
@@ -218,7 +218,7 @@ public:
 			CheckedCloseFD(_pipe[0]);
 		}
 
-#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__)
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
 		for (auto w : _watches) {
 			close(w);
 		}

--- a/utils/src/InstallPath.cpp
+++ b/utils/src/InstallPath.cpp
@@ -5,14 +5,6 @@
 #include <dlfcn.h>
 #include <errno.h>
 
-#if defined(__FreeBSD__) || defined(__DragonFly__)
-# include <malloc_np.h>
-#elif __APPLE__
-# include <malloc/malloc.h>
-#else
-# include <malloc.h>
-#endif
-
 template <class C>
 	static bool TranslateInstallPathT(std::basic_string<C> &path, const C *dir_from, const C *dir_to, const C* prefix)
 {

--- a/utils/src/InstallPath.cpp
+++ b/utils/src/InstallPath.cpp
@@ -5,6 +5,14 @@
 #include <dlfcn.h>
 #include <errno.h>
 
+#if defined(__FreeBSD__) || defined(__DragonFly__)
+# include <malloc_np.h>
+#elif __APPLE__
+# include <malloc/malloc.h>
+#elif !defined(__OpenBSD__)
+# include <malloc.h>
+#endif
+
 template <class C>
 	static bool TranslateInstallPathT(std::basic_string<C> &path, const C *dir_from, const C *dir_to, const C* prefix)
 {

--- a/utils/src/utils.cpp
+++ b/utils/src/utils.cpp
@@ -9,6 +9,14 @@
 #include <array>
 #include <algorithm>
 
+#if defined(__FreeBSD__) || defined(__DragonFly__)
+# include <malloc_np.h>
+#elif __APPLE__
+# include <malloc/malloc.h>
+#elif !defined(__OpenBSD__)
+# include <malloc.h>
+#endif
+
 ////////////////////////////
 void CheckedCloseFD(int &fd)
 {

--- a/utils/src/utils.cpp
+++ b/utils/src/utils.cpp
@@ -9,15 +9,6 @@
 #include <array>
 #include <algorithm>
 
-#if defined(__FreeBSD__) || defined(__DragonFly__)
-# include <malloc_np.h>
-#elif __APPLE__
-# include <malloc/malloc.h>
-#else
-# include <malloc.h>
-#endif
-
-
 ////////////////////////////
 void CheckedCloseFD(int &fd)
 {


### PR DESCRIPTION
## Summary
- add OpenBSD support to BSD filesystem, kqueue, mount, and file flag code paths
- avoid Linux- and macOS-specific headers and APIs that are unavailable on OpenBSD
- add OpenBSD compatibility for qsort, signal contexts, timestamps, execinfo, and ArcLite iconv linking

## Testing
- `git diff --check`
- static verification of the OpenBSD preprocessor and CMake paths
- full OpenBSD build not run (current development host is Windows)