### PR TITLE
Command line extensions for plugin panels (#3485)

### DIFF
--- a/far2l/src/cmdline.cpp
+++ b/far2l/src/cmdline.cpp
@@ -761,11 +761,64 @@ int64_t CommandLine::VMProcess(MacroOpcode OpCode, void *vParam, int64_t iParam)
 	return 0;
 }
 
+// Plugin panels have no local shell to ask for completions, so use what panel already
+// shows: its items are the very files that command being typed will deal with (#3485).
+// Nested paths (like dir/fi<Tab>) are out of scope: panel lists only current directory.
+static bool GetPanelPossibilities(Panel *panel, const std::string &cmd,
+		std::vector<std::string> &possibilities)
+{
+	std::string parsed = cmd;
+	Environment::Arguments args;
+	Environment::ParseCommandLine(parsed, args, false);
+	if (args.empty())
+		return false;
+
+	std::string prefix;
+	size_t insert_pos;
+	if (!cmd.empty() && cmd.back() == ' ') {	// completing whole next argument
+		insert_pos = cmd.size();
+	} else {
+		const auto &last_arg = args.back();
+		prefix = parsed.substr(last_arg.begin, last_arg.len);
+		insert_pos = last_arg.orig_begin;
+	}
+
+	// "./name" refers to panel's directory as well, so keep that prefix and match by name
+	std::string keep;
+	if (prefix.substr(0, 2) == "./") {
+		keep = prefix.substr(0, 2);
+		prefix.erase(0, 2);
+	}
+	if (prefix.find(GOOD_SLASH) != std::string::npos)
+		return false;
+
+	const long count = panel->GetFileCount();
+	for (long i = 0; i < count; ++i) {
+		FARString str_name;
+		DWORD file_attr = 0;
+		if (!panel->GetFileName(str_name, i, file_attr))
+			continue;
+
+		const std::string &name = str_name.GetMB();
+		if (name == ".." || name == ".")
+			continue;
+
+		if (!prefix.empty() && !StrStartsFrom(name, prefix.c_str()))
+			continue;
+
+		std::string possibility = keep;
+		possibility+= name;
+		QuoteCmdArgIfNeed(possibility);
+		possibility.insert(0, cmd.substr(0, insert_pos));
+		possibilities.emplace_back(possibility);
+	}
+
+	// no sorting here: items are taken in order panel shows them to user
+	return !possibilities.empty();
+}
+
 void CommandLine::ProcessTabCompletion()
 {
-	if (CtrlObject->Cp()->ActivePanel->GetMode() == PLUGIN_PANEL)
-		  return;	// silent workaround for https://github.com/elfmz/far2l/issues/3485
-
 	FARString strStr;
 	CmdStr.GetString(strStr);
 	// show all possibilities on double tab on same input string
@@ -774,6 +827,21 @@ void CommandLine::ProcessTabCompletion()
 
 	if (!strStr.IsEmpty()) {
 		std::string cmd = strStr.GetMB();
+		Panel *ActivePanel = CtrlObject->Cp()->ActivePanel;
+		if (ActivePanel->GetMode() == PLUGIN_PANEL) {
+			std::vector<std::string> panel_possibilities;
+			if (GetPanelPossibilities(ActivePanel, cmd, panel_possibilities)) {
+				if (panel_possibilities.size() == 1) {
+					strStr = panel_possibilities.front();
+					CmdStr.SetString(strStr);
+					CmdStr.Show();
+				} else {
+					CmdStr.ShowCustomCompletionList(panel_possibilities);
+				}
+			}
+			return;
+		}
+
 		VTCompletor vtc;
 		if (possibilities) {
 			std::vector<std::string> possibilities;

--- a/far2l/src/cmdline.cpp
+++ b/far2l/src/cmdline.cpp
@@ -1016,6 +1016,9 @@ int CommandLine::ProcessKey_Enter(FarKey Key)
 
 int CommandLine::ProcessKey(FarKey Key)
 {
+	// local file names have nothing to do with plugin panel's content, see #3485
+	CmdStr.SetFNComplete(CtrlObject->Cp()->ActivePanel->GetMode() != PLUGIN_PANEL);
+
 	switch (Key) {
 		case KEY_MSWHEEL_UP | KEY_CTRL | KEY_SHIFT:
 			ViewConsoleHistory(NULL, false, true);

--- a/far2l/src/edit.hpp
+++ b/far2l/src/edit.hpp
@@ -420,6 +420,13 @@ public:
 	void EnableAC(bool Permanent = false);
 	void DisableAC(bool Permanent = false);
 	void RevertAC() { ACState ? EnableAC() : DisableAC(); }
+	void SetFNComplete(bool Enable)
+	{
+		if (Enable)
+			ECFlags.Set(EC_ENABLEFNCOMPLETE);
+		else
+			ECFlags.Clear(EC_ENABLEFNCOMPLETE);
+	}
 	void ShowCustomCompletionList(const std::vector<std::string> &list);
 	void SetOverflowArrowsColor(uint64_t Color) { OverflowArrowsColor = Color; }
 };


### PR DESCRIPTION
Дополнение командной строки на плагинных панелях, по мотивам обсуждения в #3485.

Два независимых коммита.

**1. Не предлагать локальные имена файлов на плагинных панелях**

Костыль, отключивший `ProcessTabCompletion` на плагинных панелях, закрыл только Tab. Подсказки при наборе продолжали показывать локальные файлы: у командной строки безусловно включён `EC_ENABLEFNCOMPLETE`, а `MenuFilesSuggestor` перечисляет реальную ФС относительно cwd процесса, который на плагинной панели остаётся последним локальным каталогом.

`EditControl` получил `SetFNComplete()`, переключающий только файловые подсказки; `CommandLine::ProcessKey` держит флаг в согласии с типом активной панели. Подсказки из истории команд не затронуты — они честные и на плагинных панелях.

**2. Дополнять последний аргумент из содержимого плагинной панели**

Вместо молчания по Tab кандидаты берутся из элементов активной панели: она уже показывает ровно те файлы, с которыми будет работать набираемая команда. Так делал классический FAR. Протоколонезависимо, без изменений плагинного API, без обращений к сети.

Осознанные ограничения:

- вложенные пути (`dir/fi<Tab>`) не дополняются: панель знает только текущий каталог. Префикс `./` при этом поддержан — это тот же каталог;
- общий префикс не досчитывается: при нескольких совпадениях сразу показывается меню, при единственном имя подставляется в строку. Аккуратное квотирование частичной подстановки — отдельная задача;
- порядок кандидатов — тот, в котором панель показывает файлы пользователю, без дополнительной сортировки.

Дальше, если направление приемлемо, напрашивается опциональная возможность плагину отдавать кандидатов по префиксу: NetRocks мог бы отвечать через свой `DirectoryEnum` (доступен во всех протоколах, снимает ограничение по вложенным путям), а shell-протоколы со временем — через `compgen` на сервере. Это уже расширение плагинного API, поэтому в этот PR не входит.

**Проверялось** на сборке из этой ветки, SFTP-сайт в NetRocks:

- на плагинной панели `ls -l ./` больше не предлагает локальные файлы, подсказки из истории команд работают;
- Tab на плагинной панели дополняет удалёнными именами: `ls <Tab>` — меню содержимого панели, `ls -l ./<Tab>` — то же с сохранённым префиксом, `ls Suck<Tab>` — подстановка единственного совпадения;
- на обычной панели дополнение от bash и подсказки при наборе работают как прежде.
