### PR TITLE
Don't ask OSC52 first-start question under testing

### DIFF
--- a/far2l/src/main.cpp
+++ b/far2l/src/main.cpp
@@ -329,7 +329,11 @@ static int MainProcess(FARString strEditViewArg, FARString strDestName1, FARStri
 			if( Opt.IsFirstStart ) {
 				Help::Present(L"Far2lGettingStarted",L"",FHELP_NOSHOWERROR);
 
-				DWORD tweaks = WINPORT(SetConsoleTweaks)(TWEAKS_ONLY_QUERY_SUPPORTED);
+				// Under test control there is no human to answer the OSC52
+				// first-start question, so it would just invisibly swallow all
+				// injected input in its modal loop (same pattern as the
+				// WinPortTesting() guards around FlushInputBuffer in filelist.cpp).
+				DWORD tweaks = WinPortTesting() ? 0 : WINPORT(SetConsoleTweaks)(TWEAKS_ONLY_QUERY_SUPPORTED);
 				if (tweaks & TWEAK_STATUS_SUPPORT_OSC52CLIP_SET) {
 					SetMessageHelp(L"Far2lGettingStarted");
 


### PR DESCRIPTION
The OSC52 first-start confirmation runs its own modal message loop before EnterMainLoop. Under test control (--test=) there is no human to answer it, and in any environment without X11/far2l extensions (plain TTY, e.g. a headless CI runner: the test harness spawns far2l with a minimal environment, so DISPLAY is never set and --nodetect disables extension detection) the question appears on every test run with a fresh profile. Its modal loop then consumes the injected keys, so every smoke test fails on its first dialog-triggering key (F10/F5/ F3 do nothing, the expected dialog never appears).

Follow the established WinPortTesting() pattern (see FlushInputBuffer guards in filelist.cpp) and skip the question in testing mode.

Verified on Linux (WSL2) and macOS 15.7: without the gate the question consumes the first injected F-key and the expected dialog never appears, failing every test of the 0001-0006 suite on a fresh profile; with this gate (together with harness-side fixes in our older harness snapshot - a pty-drain workaround and a stale search-window size fix, not part of this change) the suite runs fully green, 6/6 on both systems across repeated rounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)