### PR TITLE
Fix OpenBSD sudo client support

### DIFF
--- a/WinPort/src/sudo/sudo_client_api.cpp
+++ b/WinPort/src/sudo/sudo_client_api.cpp
@@ -735,7 +735,7 @@ extern "C" __attribute__ ((visibility("default"))) char *sdc_getcwd(char *buf, s
 
 extern "C" __attribute__ ((visibility("default"))) ssize_t sdc_flistxattr(int fd, char *namebuf, size_t size)
 {
-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__) || defined(__CYGWIN__)
+#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__) || defined(__CYGWIN__)
 		return -1;
 #elif defined(__APPLE__)
 		return flistxattr(fd, namebuf, size, 0);
@@ -746,7 +746,7 @@ extern "C" __attribute__ ((visibility("default"))) ssize_t sdc_flistxattr(int fd
 
 extern "C" __attribute__ ((visibility("default"))) ssize_t sdc_fgetxattr(int fd, const char *name,void *value, size_t size)
 {
-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__) || defined(__CYGWIN__)
+#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__) || defined(__CYGWIN__)
 	return -1;
 #elif defined(__APPLE__)
 	return fgetxattr(fd, name, value, size, 0, 0);
@@ -757,7 +757,7 @@ extern "C" __attribute__ ((visibility("default"))) ssize_t sdc_fgetxattr(int fd,
 
 extern "C" __attribute__ ((visibility("default"))) int sdc_fsetxattr(int fd, const char *name, const void *value, size_t size, int flags)
 {
-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__) || defined(__CYGWIN__)
+#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__) || defined(__CYGWIN__)
 	return -1;
 #elif defined(__APPLE__)
 	return fsetxattr(fd, name, value, size, 0, flags);
@@ -776,7 +776,7 @@ extern "C" __attribute__ ((visibility("default"))) int sdc_fsetxattr(int fd, con
 	*flags = 0;
 	return 0;
 
-#elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__)
+#elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
 	struct stat s{};
 	int r = sdc_stat(path, &s);
 	if (r == 0) {
@@ -821,7 +821,7 @@ extern "C" __attribute__ ((visibility("default"))) int sdc_fs_flags_set(const ch
 #else
 	ClientReconstructCurDir crcd(path);
 	int r;
-# if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__)
+# if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
 	r = chflags(path, flags);
 # else
 	int fd = r = open(path, O_RDONLY);


### PR DESCRIPTION
Fixes the remaining OpenBSD build failures in the sudo client.

OpenBSD has neither the Linux xattr API nor the `FS_IOC_*` ioctl constants. Route it through the existing BSD paths: the xattr wrappers return unsupported, and filesystem flags use `st_flags` / `chflags`.

Tested by building the TTY-only configuration on OpenBSD.