### PR TITLE
update colorer_lib to 05.09.2026

### DIFF
--- a/plugins/colorer/src/Colorer-library/src/CMakeLists.txt
+++ b/plugins/colorer/src/Colorer-library/src/CMakeLists.txt
@@ -121,6 +121,7 @@ if(COLORER_USE_ICU_STRINGS)
       colorer/strings/icu/strings.h
       colorer/strings/icu/Character.cpp
       colorer/strings/icu/Character.h
+      colorer/strings/icu/CharacterClass.h
       colorer/strings/icu/Encodings.cpp
       colorer/strings/icu/Encodings.h
       colorer/strings/icu/UnicodeStringContainer.h
@@ -241,8 +242,9 @@ else()
   )
 endif()
 
+find_package(Threads REQUIRED)
 target_link_libraries(colorer_lib
-        PUBLIC LibXml2::LibXml2
+        PUBLIC LibXml2::LibXml2 Threads::Threads
 )
 
 if(COLORER_USE_ICU_STRINGS)

--- a/plugins/colorer/src/Colorer-library/src/colorer/HrcLibrary.h
+++ b/plugins/colorer/src/Colorer-library/src/colorer/HrcLibrary.h
@@ -17,6 +17,12 @@ class HrcLibraryException : public Exception
 
 /** HrcLibrary class.
     Defines basic operations of loading and accessing HRC information.
+
+    Loading (#loadSource, #loadProtoTypes, #loadFileType, #loadHrcSettings) is exclusive
+    for one library. After a type is loaded, TextParser::parse may run concurrently
+    as a shared read. Do not destroy the library while parse is running.
+    #getRegion(const UnicodeString*) may load a type and is exclusive with parse.
+    RegionHandler callbacks must not call HrcLibrary.
 */
 class HrcLibrary
 {

--- a/plugins/colorer/src/Colorer-library/src/colorer/ParserFactory.h
+++ b/plugins/colorer/src/Colorer-library/src/colorer/ParserFactory.h
@@ -16,6 +16,10 @@
  * and creates HrcLibrary, StyledHRDMapper, TextHRDMapper and TextParser instances
  * with information, loaded from specified sources.
  *
+ * Several instances may exist in one process. Each owns an HrcLibrary.
+ * loadCatalog / loadHrcPath / loadHrcSettings / loadFileType are exclusive
+ * per library. After a type is loaded, createTextParser() instances may parse
+ * that library concurrently. Destroy the factory only after those parsers stop.
  */
 class ParserFactory
 {

--- a/plugins/colorer/src/Colorer-library/src/colorer/cregexp/cregexp.cpp
+++ b/plugins/colorer/src/Colorer-library/src/colorer/cregexp/cregexp.cpp
@@ -1,6 +1,8 @@
 #include "colorer/cregexp/cregexp.h"
+#include <algorithm>
+#include <climits>
 
-std::vector<StackElem> CRegExp::RegExpStack;
+thread_local std::vector<StackElem> CRegExp::RegExpStack;
 
 
 /////////////////////////////////////////////////////////////////////////////
@@ -67,8 +69,14 @@ void CRegExp::init()
   firstNode = nullptr;
   firstCharMask = {};
   firstCharMaskUseful = false;
+  startAnchor = StartAnchor::None;
+  endAnchor = false;
+  maxLen = -1;
+  requiredChars = {};
+  requiredCharsCount = 0;
   cMatch = 0;
   global_pattern = nullptr;
+  parseBuf = nullptr;
 #ifdef COLORERMODE
   backRE = nullptr;
   backStr = nullptr;
@@ -114,6 +122,11 @@ EError CRegExp::setRELow(const UnicodeString& expr)
   firstNode = nullptr;
   firstCharMask = {};
   firstCharMaskUseful = false;
+  startAnchor = StartAnchor::None;
+  endAnchor = false;
+  maxLen = -1;
+  requiredChars = {};
+  requiredCharsCount = 0;
   for (int bp = 0; bp < cnMatch; bp++) delete brnames[bp];
 
   cMatch = 0;
@@ -166,6 +179,8 @@ EError CRegExp::setRELow(const UnicodeString& expr)
   return EError::EOK;
 }
 
+// Fill skip facts for parseRE / mayMatch: first-char mask, start/end
+// anchors, maxLen, required ASCII sets, per-| branchFirst. See class docs.
 void CRegExp::optimize()
 {
   SRegInfo* next = tree_root;
@@ -210,6 +225,314 @@ void CRegExp::optimize()
   firstCharMask = firstChars.mask;
   firstCharMaskUseful = !firstChars.nullable &&
     (firstCharMask[0] != ~uint64_t(0) || firstCharMask[1] != ~uint64_t(0));
+
+  analyzeStartAnchor();
+  analyzeEndAnchor();
+  analyzeMaxLen();
+  analyzeRequiredChars();
+  analyzeBranchFirstChars(tree_root);
+}
+
+void CRegExp::analyzeStartAnchor()
+{
+  startAnchor = StartAnchor::None;
+  // Descend through leading brackets only; an alternation or quantifier at the
+  // front means other branches may start elsewhere.
+  const SRegInfo* node = tree_root;
+  while (node && (node->op == EOps::ReBrackets || node->op == EOps::ReNamedBrackets)) {
+    node = node->un.param;
+  }
+  if (!node || node->op != EOps::ReMetaSymb) {
+    return;
+  }
+  if (node->un.metaSymbol == EMetaSymbols::ReSoL && !multiLine) {
+    startAnchor = StartAnchor::LineStart;
+  }
+#ifdef COLORERMODE
+  else if (node->un.metaSymbol == EMetaSymbols::ReSoScheme) {
+    startAnchor = StartAnchor::SchemeStart;
+  }
+#endif
+}
+
+void CRegExp::analyzeEndAnchor()
+{
+  endAnchor = false;
+  if (multiLine) {
+    return;
+  }
+  // Last node of the top chain, descending through trailing brackets. A
+  // top-level alternation means some branch may finish before eol.
+  const SRegInfo* node = tree_root;
+  while (node) {
+    if (node->op == EOps::ReOr) {
+      return;
+    }
+    if (node->next) {
+      node = node->next;
+      continue;
+    }
+    if (node->op == EOps::ReBrackets || node->op == EOps::ReNamedBrackets) {
+      node = node->un.param;
+      continue;
+    }
+    break;
+  }
+  if (node && node->op == EOps::ReMetaSymb && node->un.metaSymbol == EMetaSymbols::ReEoL) {
+    endAnchor = true;
+  }
+}
+
+static int addBounded(int a, int b)
+{
+  if (a < 0 || b < 0) {
+    return -1;
+  }
+  if (a > INT_MAX - b) {
+    return -1;
+  }
+  return a + b;
+}
+
+int CRegExp::maxLenOfNode(const SRegInfo* re) const
+{
+  if (!re) {
+    return 0;
+  }
+  switch (re->op) {
+    case EOps::ReSymb:
+    case EOps::ReEnum:
+      return 1;
+    case EOps::ReWord:
+      return re->un.word != nullptr ? re->un.word->length() : 0;
+    case EOps::ReMetaSymb:
+      switch (re->un.metaSymbol) {
+        case EMetaSymbols::ReAnyChr:
+        case EMetaSymbols::ReDigit:
+        case EMetaSymbols::ReNDigit:
+        case EMetaSymbols::ReWordSymb:
+        case EMetaSymbols::ReNWordSymb:
+        case EMetaSymbols::ReWSpace:
+        case EMetaSymbols::ReNWSpace:
+        case EMetaSymbols::ReUCase:
+        case EMetaSymbols::ReNUCase:
+          return 1;
+        case EMetaSymbols::ReSoL:
+        case EMetaSymbols::ReEoL:
+        case EMetaSymbols::ReWBound:
+        case EMetaSymbols::ReNWBound:
+        case EMetaSymbols::RePreNW:
+#ifdef COLORERMODE
+        case EMetaSymbols::ReSoScheme:
+        case EMetaSymbols::ReStart:
+        case EMetaSymbols::ReEnd:
+#endif
+          return 0;
+        default:
+          return -1;
+      }
+    case EOps::ReBrackets:
+    case EOps::ReNamedBrackets:
+      return maxLenOfChain(re->un.param);
+    case EOps::ReRangeN:
+    case EOps::ReNGRangeN:
+      return -1;
+    case EOps::ReRangeNM:
+    case EOps::ReNGRangeNM: {
+      if (re->e < 0) {
+        return -1;
+      }
+      const int inner = maxLenOfChain(re->un.param);
+      if (inner < 0) {
+        return -1;
+      }
+      if (re->e != 0 && inner > INT_MAX / re->e) {
+        return -1;
+      }
+      return re->e * inner;
+    }
+    case EOps::ReAhead:
+    case EOps::ReNAhead:
+    case EOps::ReBehind:
+    case EOps::ReNBehind:
+    case EOps::ReEmpty:
+      return 0;
+#ifdef COLORERMODE
+    case EOps::ReBkTrace:
+    case EOps::ReBkTraceN:
+    case EOps::ReBkTraceName:
+    case EOps::ReBkTraceNName:
+#endif
+    case EOps::ReBkBrack:
+    case EOps::ReBkBrackName:
+    case EOps::ReOr:
+    default:
+      return -1;
+  }
+}
+
+int CRegExp::maxLenOfChain(const SRegInfo* re) const
+{
+  int total = 0;
+  for (const auto* node = re; node; node = node->next) {
+    if (node->op == EOps::ReOr) {
+      const int left = maxLenOfChain(node->un.param);
+      const int right = maxLenOfChain(node->next);
+      if (left < 0 || right < 0) {
+        return -1;
+      }
+      return addBounded(total, left > right ? left : right);
+    }
+    const int n = maxLenOfNode(node);
+    if (n < 0) {
+      return -1;
+    }
+    total = addBounded(total, n);
+    if (total < 0) {
+      return -1;
+    }
+  }
+  return total;
+}
+
+void CRegExp::analyzeMaxLen()
+{
+  maxLen = maxLenOfChain(tree_root);
+}
+
+static int popcountMask(const AsciiCharMask& mask)
+{
+  int count = 0;
+  for (auto word : mask) {
+    while (word) {
+      word &= word - 1;
+      count++;
+    }
+  }
+  return count;
+}
+
+void CRegExp::analyzeRequiredChars()
+{
+  requiredChars = {};
+  requiredCharsCount = 0;
+  auto sets = requiredCharsForChain(tree_root);
+  // Keep the most selective sets (fewest characters).
+  std::sort(sets.begin(), sets.end(), [](const AsciiCharMask& a, const AsciiCharMask& b) {
+    return popcountMask(a) < popcountMask(b);
+  });
+  for (const auto& set : sets) {
+    if (requiredCharsCount == MAX_REQUIRED_SETS) {
+      break;
+    }
+    bool duplicate = false;
+    for (int i = 0; i < requiredCharsCount; i++) {
+      if (requiredChars[i] == set) {
+        duplicate = true;
+        break;
+      }
+    }
+    if (!duplicate) {
+      requiredChars[requiredCharsCount++] = set;
+    }
+  }
+}
+
+void CRegExp::addRequiredChar(std::vector<AsciiCharMask>& out, wchar ch) const
+{
+  const auto value = static_cast<uint32_t>(ch);
+  if (value >= 128) {
+    return;
+  }
+  // Under /i a letter may also match a non-ASCII case variant (e.g. KELVIN SIGN for k),
+  // which the ASCII line mask cannot see.
+  if (ignoreCase && ((value >= 'A' && value <= 'Z') || (value >= 'a' && value <= 'z'))) {
+    return;
+  }
+  AsciiCharMask set = {};
+  set[value >> 6] |= uint64_t(1) << (value & 63);
+  out.push_back(set);
+}
+
+std::vector<AsciiCharMask> CRegExp::requiredCharsForNode(const SRegInfo* re) const
+{
+  std::vector<AsciiCharMask> result;
+  if (!re) {
+    return result;
+  }
+  switch (re->op) {
+    case EOps::ReSymb:
+      addRequiredChar(result, re->un.symbol);
+      break;
+    case EOps::ReWord:
+      for (int i = 0; i < re->un.word->length(); i++) {
+        addRequiredChar(result, (*re->un.word)[i]);
+      }
+      break;
+    case EOps::ReBrackets:
+    case EOps::ReNamedBrackets:
+    case EOps::ReAhead:
+    case EOps::ReBehind:
+      result = requiredCharsForChain(re->un.param);
+      break;
+    case EOps::ReRangeN:
+    case EOps::ReRangeNM:
+    case EOps::ReNGRangeN:
+    case EOps::ReNGRangeNM:
+      if (re->s > 0) {
+        result = requiredCharsForChain(re->un.param);
+      }
+      break;
+    default:
+      // Character classes and meta symbols may match non-ASCII text; back
+      // references and negative look-arounds add nothing certain.
+      break;
+  }
+  return result;
+}
+
+std::vector<AsciiCharMask> CRegExp::requiredCharsForChain(const SRegInfo* re) const
+{
+  std::vector<AsciiCharMask> result;
+  for (const auto* node = re; node; node = node->next) {
+    if (node->op == EOps::ReOr) {
+      // Either branch may match: any (left ∪ right) pair is still required.
+      const auto left = requiredCharsForChain(node->un.param);
+      const auto right = requiredCharsForChain(node->next);
+      for (const auto& l : left) {
+        for (const auto& r : right) {
+          result.push_back({l[0] | r[0], l[1] | r[1]});
+        }
+      }
+      // Nested alternations multiply the pairs; keep the few most selective ones.
+      if (result.size() > static_cast<size_t>(MAX_REQUIRED_SETS)) {
+        std::sort(result.begin(), result.end(), [](const AsciiCharMask& a, const AsciiCharMask& b) {
+          return popcountMask(a) < popcountMask(b);
+        });
+        result.resize(MAX_REQUIRED_SETS);
+      }
+      break;
+    }
+    auto current = requiredCharsForNode(node);
+    result.insert(result.end(), current.begin(), current.end());
+  }
+  return result;
+}
+
+void CRegExp::collectAsciiChars(const UnicodeString& str, AsciiCharMask& mask)
+{
+  mask = {};
+  const wchar* buf = str.getBuffer();
+  if (buf == nullptr) {
+    return;
+  }
+  const int len = str.length();
+  for (int i = 0; i < len; i++) {
+    const auto value = static_cast<uint32_t>(buf[i]);
+    if (value < 128) {
+      mask[value >> 6] |= uint64_t(1) << (value & 63);
+    }
+  }
 }
 
 void CRegExp::addFirstChar(FirstChars& result, wchar ch) const
@@ -332,6 +655,44 @@ CRegExp::FirstChars CRegExp::analyzeFirstChars(const SRegInfo* re) const
     if (node->op == EOps::ReOr) break;
   }
   return result;
+}
+
+void CRegExp::analyzeBranchFirstChars(SRegInfo* re)
+{
+  for (SRegInfo* node = re; node; node = node->next) {
+    switch (node->op) {
+      case EOps::ReOr: {
+        const auto first = analyzeFirstChars(node->un.param);
+        // Descend through grouping so (\M\s+) is treated like \M\s+. A
+        // zero-width head (\m \M \b lookaround ^ $ empty) must not be skipped:
+        // \M in a failed alternative still bounds group 0 for a later one.
+        const SRegInfo* atom = node->un.param;
+        while (atom && (atom->op == EOps::ReBrackets || atom->op == EOps::ReNamedBrackets)) {
+          atom = atom->un.param;
+        }
+        const bool leadingNullable = !atom || firstCharsForNode(atom).nullable;
+        node->branchFirst = first.mask;
+        node->branchFirstUseful = !leadingNullable && !first.nullable &&
+          (first.mask[0] != ~uint64_t(0) || first.mask[1] != ~uint64_t(0));
+        analyzeBranchFirstChars(node->un.param);
+        break;
+      }
+      case EOps::ReBrackets:
+      case EOps::ReNamedBrackets:
+      case EOps::ReAhead:
+      case EOps::ReNAhead:
+      case EOps::ReBehind:
+      case EOps::ReNBehind:
+      case EOps::ReRangeN:
+      case EOps::ReRangeNM:
+      case EOps::ReNGRangeN:
+      case EOps::ReNGRangeNM:
+        analyzeBranchFirstChars(node->un.param);
+        break;
+      default:
+        break;
+    }
+  }
 }
 
 EError CRegExp::setStructs(SRegInfo*& re, const UnicodeString& expr, int from, int to, int& retPos)
@@ -808,130 +1169,9 @@ EError CRegExp::setStructs(SRegInfo*& re, const UnicodeString& expr, int from, i
 // parsing
 ////////////////////////////////////////////////////////////////////////////
 
-static bool isLineBreak(wchar c)
+void CRegExp::growRegExpStack()
 {
-   return c == 0x0A || c == 0x0B || c == 0x0C || c == 0x0D || c == 0x85 || c == 0x2028 || c == 0x2029;
-}
-
-bool CRegExp::isWordBoundary(int toParse)
-{
-  const bool after = (toParse < end && Character::isLetterOrDigitOrUnderscore((*global_pattern)[toParse]));
-  const bool before = (toParse > 0 && Character::isLetterOrDigitOrUnderscore((*global_pattern)[toParse - 1]));
-  return before != after;
-}
-
-bool CRegExp::checkMetaSymbol(EMetaSymbols symb, int& toParse)
-{
-  const UnicodeString& pattern = *global_pattern;
-
-  switch (symb) {
-    case EMetaSymbols::ReAnyChr:
-      if (toParse >= end || (!singleLine && isLineBreak(pattern[toParse])))
-        return false;
-      toParse++;
-      return true;
-
-    case EMetaSymbols::ReSoL:
-        return toParse == 0 || (multiLine && isLineBreak(pattern[toParse - 1]));
-
-    case EMetaSymbols::ReEoL:
-      return toParse == end || (multiLine && toParse && toParse < end && isLineBreak(pattern[toParse - 1]));
-
-    case EMetaSymbols::ReDigit:
-      if (toParse >= end || !Character::isDigit(pattern[toParse]))
-        return false;
-      toParse++;
-      return true;
-
-    case EMetaSymbols::ReNDigit:
-      if (toParse >= end || Character::isDigit(pattern[toParse]))
-        return false;
-      toParse++;
-      return true;
-
-    case EMetaSymbols::ReWordSymb:
-      if (toParse >= end || !Character::isLetterOrDigitOrUnderscore(pattern[toParse]))
-        return false;
-      toParse++;
-      return true;
-
-    case EMetaSymbols::ReNWordSymb:
-      if (toParse >= end || Character::isLetterOrDigitOrUnderscore(pattern[toParse]))
-        return false;
-      toParse++;
-      return true;
-
-    case EMetaSymbols::ReWSpace:
-      if (toParse >= end || !Character::isWhitespace(pattern[toParse]))
-        return false;
-      toParse++;
-      return true;
-
-    case EMetaSymbols::ReNWSpace:
-      if (toParse >= end || Character::isWhitespace(pattern[toParse]))
-        return false;
-      toParse++;
-      return true;
-
-    case EMetaSymbols::ReUCase:
-      if (toParse >= end || !Character::isUpperCase(pattern[toParse]))
-        return false;
-      toParse++;
-      return true;
-
-    case EMetaSymbols::ReNUCase:
-      if (toParse >= end || !Character::isLowerCase(pattern[toParse]))
-        return false;
-      toParse++;
-      return true;
-
-    case EMetaSymbols::ReWBound:
-      return isWordBoundary(toParse);
-
-    case EMetaSymbols::ReNWBound:
-      return !isWordBoundary(toParse);
-
-    case EMetaSymbols::RePreNW:
-      return toParse == 0 || toParse >= end || !Character::isLetter(pattern[toParse - 1]);
-
-#ifdef COLORERMODE
-    case EMetaSymbols::ReSoScheme:
-      return (schemeStart == toParse);
-
-    case EMetaSymbols::ReStart:
-      matches->s[0] = toParse;
-      startChange = true;
-      return true;
-
-    case EMetaSymbols::ReEnd:
-      matches->e[0] = toParse;
-      endChange = true;
-      return true;
-#endif
-
-    default:
-      return false;
-  }
-}
-
-void CRegExp::check_stack(bool res, SRegInfo** re, SRegInfo** prev, int* toParse, bool* leftenter, ReAction* action)
-{
-  if (count_elem == 0) {
-    *action = res ? rea_True : rea_False;
-    return;
-  }
-
-  StackElem& ne = CRegExp::RegExpStack[--count_elem];
-  if (res) {
-    *action = ne.ifTrueReturn;
-  }
-  else {
-    *action = ne.ifFalseReturn;
-  }
-  *re = ne.re;
-  *prev = ne.prev;
-  *toParse = ne.toParse;
-  *leftenter = ne.leftenter;
+  RegExpStack.resize(RegExpStack.empty() ? INIT_MEM_SIZE : RegExpStack.size() + MEM_INC);
 }
 
 bool CRegExp::matchCopiedRange(const UnicodeString& src, int from, int to, int& toParse, bool icase) const
@@ -939,15 +1179,19 @@ bool CRegExp::matchCopiedRange(const UnicodeString& src, int from, int to, int& 
   // Unmatched groups are stored as -1,-1; the classic copy loop then does nothing.
   if (from < 0 || to < 0)
     return true;
-  const UnicodeString& pattern = *global_pattern;
+  if (from >= to)
+    return true;
+  const wchar* srcBuf = src.getBuffer();
+  if (srcBuf == nullptr)
+    return false;
   for (int i = from; i < to; i++) {
     if (toParse >= end)
       return false;
     if (icase) {
-      if (Character::toLowerCase(pattern[toParse]) != Character::toLowerCase(src[i]))
+      if (Character::toLowerCase(parseBuf[toParse]) != Character::toLowerCase(srcBuf[i]))
         return false;
     }
-    else if (pattern[toParse] != src[i]) {
+    else if (parseBuf[toParse] != srcBuf[i]) {
       return false;
     }
     toParse++;
@@ -955,43 +1199,18 @@ bool CRegExp::matchCopiedRange(const UnicodeString& src, int from, int to, int& 
   return true;
 }
 
-void CRegExp::insert_stack(SRegInfo** re, SRegInfo** prev, int* toParse, bool* leftenter, ReAction ifTrueReturn,
-                           ReAction ifFalseReturn, SRegInfo** re2, SRegInfo** prev2, int toParse2)
-{
-  if (RegExpStack.size() == static_cast<size_t>(count_elem)) {
-    RegExpStack.resize(RegExpStack.empty() ? INIT_MEM_SIZE : RegExpStack.size() + MEM_INC);
-  }
-  StackElem& ne = CRegExp::RegExpStack[static_cast<size_t>(count_elem++)];
-  ne.re = *re;
-  ne.prev = *prev;
-  ne.toParse = *toParse;
-  ne.ifTrueReturn = ifTrueReturn;
-  ne.ifFalseReturn = ifFalseReturn;
-  ne.leftenter = *leftenter;
-
-  if (prev2 == nullptr)
-    *prev = nullptr;
-  else
-    *prev = *prev2;
-  *re = *re2;
-  *toParse = toParse2;
-  // this is init operation from lowParse
-  *leftenter = true;
-  if (!*re) {
-    *re = (*prev)->parent;
-    *leftenter = false;
-  }
-}
-
 bool CRegExp::lowParse(SRegInfo* re, SRegInfo* prev, int toParse)
 {
   int i, sv, wlen;
   bool leftenter = true;
   bool br = false;
-  const UnicodeString& pattern = *global_pattern;
+  const wchar* const buf = parseBuf;
   ReAction action = rea_None;
 
   if (!re) {
+    if (prev == nullptr) {
+      return false;
+    }
     re = prev->parent;
     leftenter = false;
   }
@@ -1033,36 +1252,47 @@ bool CRegExp::lowParse(SRegInfo* re, SRegInfo* prev, int toParse)
             break;
           case EOps::ReSymb:
             if (toParse >= end) {
-              check_stack(false, &re, &prev, &toParse, &leftenter, &action);
+              check_stack(false, re, prev, toParse, leftenter, action);
               continue;
             }
-            if (!matchChars(pattern[toParse], re->un.symbol)) {
-              check_stack(false, &re, &prev, &toParse, &leftenter, &action);
+            if (!matchChars(buf[toParse], re->un.symbol)) {
+              check_stack(false, re, prev, toParse, leftenter, action);
               continue;
             }
             toParse++;
             break;
           case EOps::ReMetaSymb:
             if (!checkMetaSymbol(re->un.metaSymbol, toParse)) {
-              check_stack(false, &re, &prev, &toParse, &leftenter, &action);
+              check_stack(false, re, prev, toParse, leftenter, action);
               continue;
             }
             break;
           case EOps::ReWord:
             wlen = re->un.word->length();
             if (toParse + wlen > end) {
-              check_stack(false, &re, &prev, &toParse, &leftenter, &action);
+              check_stack(false, re, prev, toParse, leftenter, action);
               continue;
             }
             if (ignoreCase) {
-              if (UStr::caseCompare(pattern, toParse, wlen, *re->un.word) != 0) {
-                check_stack(false, &re, &prev, &toParse, &leftenter, &action);
+              if (UStr::caseCompare(*global_pattern, toParse, wlen, *re->un.word) != 0) {
+                check_stack(false, re, prev, toParse, leftenter, action);
                 continue;
               }
             }
-            else {
-              if (pattern.compare(toParse, wlen, *re->un.word) != 0) {
-                check_stack(false, &re, &prev, &toParse, &leftenter, &action);
+            else if (wlen != 0) {
+              const wchar* wordBuf = re->un.word->getBuffer();
+              if (wordBuf == nullptr) {
+                check_stack(false, re, prev, toParse, leftenter, action);
+                continue;
+              }
+              int k = 0;
+              for (; k < wlen; k++) {
+                if (buf[toParse + k] != wordBuf[k]) {
+                  break;
+                }
+              }
+              if (k != wlen) {
+                check_stack(false, re, prev, toParse, leftenter, action);
                 continue;
               }
             }
@@ -1070,11 +1300,11 @@ bool CRegExp::lowParse(SRegInfo* re, SRegInfo* prev, int toParse)
             break;
           case EOps::ReEnum:
             if (toParse >= end) {
-              check_stack(false, &re, &prev, &toParse, &leftenter, &action);
+              check_stack(false, re, prev, toParse, leftenter, action);
               continue;
             }
-            if (!re->un.charclass->contains(pattern[toParse])) {
-              check_stack(false, &re, &prev, &toParse, &leftenter, &action);
+            if (!re->un.charclass->contains(buf[toParse])) {
+              check_stack(false, re, prev, toParse, leftenter, action);
               continue;
             }
             toParse++;
@@ -1083,52 +1313,52 @@ bool CRegExp::lowParse(SRegInfo* re, SRegInfo* prev, int toParse)
           case EOps::ReBkTrace:
             sv = re->param0;
             if (!backStr || !backTrace || sv < 0 || sv >= MATCHES_NUM) {
-              check_stack(false, &re, &prev, &toParse, &leftenter, &action);
+              check_stack(false, re, prev, toParse, leftenter, action);
               continue;
             }
             backTrace->topseSanitize(sv);
             if (!matchCopiedRange(*backStr, backTrace->s[sv], backTrace->e[sv], toParse, false)) {
-              check_stack(false, &re, &prev, &toParse, &leftenter, &action);
+              check_stack(false, re, prev, toParse, leftenter, action);
               continue;
             }
             break;
           case EOps::ReBkTraceN:
             sv = re->param0;
             if (!backStr || !backTrace || sv < 0 || sv >= MATCHES_NUM) {
-              check_stack(false, &re, &prev, &toParse, &leftenter, &action);
+              check_stack(false, re, prev, toParse, leftenter, action);
               continue;
             }
             backTrace->topseSanitize(sv);
             if (!matchCopiedRange(*backStr, backTrace->s[sv], backTrace->e[sv], toParse, true)) {
-              check_stack(false, &re, &prev, &toParse, &leftenter, &action);
+              check_stack(false, re, prev, toParse, leftenter, action);
               continue;
             }
             break;
           case EOps::ReBkTraceName:
             sv = re->param0;
             if (!backStr || !backTrace || sv < 0 || sv >= NAMED_MATCHES_NUM) {
-              check_stack(false, &re, &prev, &toParse, &leftenter, &action);
+              check_stack(false, re, prev, toParse, leftenter, action);
               continue;
             }
             backTrace->topnseSanitize(sv);
             if (!matchCopiedRange(*backStr, backTrace->ns[sv], backTrace->ne[sv], toParse, false)) {
-              check_stack(false, &re, &prev, &toParse, &leftenter, &action);
+              check_stack(false, re, prev, toParse, leftenter, action);
               continue;
             }
             break;
           case EOps::ReBkTraceNName:
             sv = re->param0;
             if (!backStr || !backTrace || sv < 0 || sv >= NAMED_MATCHES_NUM || backTrace->cnMatch <= sv) {
-              check_stack(false, &re, &prev, &toParse, &leftenter, &action);
+              check_stack(false, re, prev, toParse, leftenter, action);
               continue;
             }
             backTrace->topnseSanitize(sv);
             if (backTrace->ns[sv] == -1 || backTrace->ne[sv] == -1) {
-              check_stack(false, &re, &prev, &toParse, &leftenter, &action);
+              check_stack(false, re, prev, toParse, leftenter, action);
               continue;
             }
             if (!matchCopiedRange(*backStr, backTrace->ns[sv], backTrace->ne[sv], toParse, true)) {
-              check_stack(false, &re, &prev, &toParse, &leftenter, &action);
+              check_stack(false, re, prev, toParse, leftenter, action);
               continue;
             }
             break;
@@ -1137,18 +1367,18 @@ bool CRegExp::lowParse(SRegInfo* re, SRegInfo* prev, int toParse)
           case EOps::ReBkBrackName:
             sv = re->param0;
             if (sv == -1 || cnMatch <= sv) {
-              check_stack(false, &re, &prev, &toParse, &leftenter, &action);
+              check_stack(false, re, prev, toParse, leftenter, action);
               continue;
             }
             matches->topnseSanitize(sv);
             if (matches->ns[sv] == -1 || matches->ne[sv] == -1) {
-              check_stack(false, &re, &prev, &toParse, &leftenter, &action);
+              check_stack(false, re, prev, toParse, leftenter, action);
               continue;
             }
             br = false;
             for (i = matches->ns[sv]; i < matches->ne[sv]; i++) {
-              if (toParse >= end || pattern[toParse] != pattern[i]) {
-                check_stack(false, &re, &prev, &toParse, &leftenter, &action);
+              if (toParse >= end || buf[toParse] != buf[i]) {
+                check_stack(false, re, prev, toParse, leftenter, action);
                 br = true;
                 break;
               }
@@ -1161,18 +1391,18 @@ bool CRegExp::lowParse(SRegInfo* re, SRegInfo* prev, int toParse)
           case EOps::ReBkBrack:
             sv = re->param0;
             if (sv == -1 || cMatch <= sv) {
-              check_stack(false, &re, &prev, &toParse, &leftenter, &action);
+              check_stack(false, re, prev, toParse, leftenter, action);
               continue;
             }
             matches->topseSanitize(sv);
             if (matches->s[sv] == -1 || matches->e[sv] == -1) {
-              check_stack(false, &re, &prev, &toParse, &leftenter, &action);
+              check_stack(false, re, prev, toParse, leftenter, action);
               continue;
             }
             br = false;
             for (i = matches->s[sv]; i < matches->e[sv]; i++) {
-              if (toParse >= end || pattern[toParse] != pattern[i]) {
-                check_stack(false, &re, &prev, &toParse, &leftenter, &action);
+              if (toParse >= end || buf[toParse] != buf[i]) {
+                check_stack(false, re, prev, toParse, leftenter, action);
                 br = true;
                 break;
               }
@@ -1183,46 +1413,46 @@ bool CRegExp::lowParse(SRegInfo* re, SRegInfo* prev, int toParse)
             break;
           case EOps::ReAhead:
             if (!leftenter) {
-              check_stack(true, &re, &prev, &toParse, &leftenter, &action);
+              check_stack(true, re, prev, toParse, leftenter, action);
               continue;
             }
             {
-              insert_stack(&re, &prev, &toParse, &leftenter, rea_Break, rea_False, &re->un.param, nullptr, toParse);
+              insert_stack(re, prev, toParse, leftenter, rea_Break, rea_False, re->un.param, nullptr, toParse);
               continue;
             }
             break;
           case EOps::ReNAhead:
             if (!leftenter) {
-              check_stack(true, &re, &prev, &toParse, &leftenter, &action);
+              check_stack(true, re, prev, toParse, leftenter, action);
               continue;
             }
             {
-              insert_stack(&re, &prev, &toParse, &leftenter, rea_False, rea_Break, &re->un.param, nullptr, toParse);
+              insert_stack(re, prev, toParse, leftenter, rea_False, rea_Break, re->un.param, nullptr, toParse);
               continue;
             }
             break;
           case EOps::ReBehind:
             if (!leftenter) {
-              check_stack(true, &re, &prev, &toParse, &leftenter, &action);
+              check_stack(true, re, prev, toParse, leftenter, action);
               continue;
             }
             if (toParse - re->param0 < 0) {
-              check_stack(false, &re, &prev, &toParse, &leftenter, &action);
+              check_stack(false, re, prev, toParse, leftenter, action);
               continue;
             }
             else {
-              insert_stack(&re, &prev, &toParse, &leftenter, rea_Break, rea_False, &re->un.param, nullptr,
+              insert_stack(re, prev, toParse, leftenter, rea_Break, rea_False, re->un.param, nullptr,
                            toParse - re->param0);
               continue;
             }
             break;
           case EOps::ReNBehind:
             if (!leftenter) {
-              check_stack(true, &re, &prev, &toParse, &leftenter, &action);
+              check_stack(true, re, prev, toParse, leftenter, action);
               continue;
             }
             if (toParse - re->param0 >= 0) {
-              insert_stack(&re, &prev, &toParse, &leftenter, rea_False, rea_Break, &re->un.param, nullptr,
+              insert_stack(re, prev, toParse, leftenter, rea_False, rea_Break, re->un.param, nullptr,
                            toParse - re->param0);
               continue;
             }
@@ -1233,8 +1463,14 @@ bool CRegExp::lowParse(SRegInfo* re, SRegInfo* prev, int toParse)
               while (re->next) re = re->next;
               break;
             }
+            if (re->branchFirstUseful && toParse < end) {
+              const auto ch = static_cast<uint32_t>(buf[toParse]);
+              if (ch < 128 && !(re->branchFirst[ch >> 6] & (uint64_t(1) << (ch & 63)))) {
+                break;
+              }
+            }
             {
-              insert_stack(&re, &prev, &toParse, &leftenter, rea_True, rea_Break, &re->un.param, nullptr, toParse);
+              insert_stack(re, prev, toParse, leftenter, rea_True, rea_Break, re->un.param, nullptr, toParse);
               continue;
             }
             break;
@@ -1249,7 +1485,7 @@ bool CRegExp::lowParse(SRegInfo* re, SRegInfo* prev, int toParse)
             re->oldParse = toParse;
             // making branch
             if (!re->param0) {
-              insert_stack(&re, &prev, &toParse, &leftenter, rea_True, rea_RangeN_step2, &re->un.param, nullptr,
+              insert_stack(re, prev, toParse, leftenter, rea_True, rea_RangeN_step2, re->un.param, nullptr,
                            toParse);
               continue;
             }
@@ -1270,11 +1506,11 @@ bool CRegExp::lowParse(SRegInfo* re, SRegInfo* prev, int toParse)
               if (re->param1)
                 re->param1--;
               else {
-                insert_stack(&re, &prev, &toParse, &leftenter, rea_True, rea_False, &re->next, &re, toParse);
+                insert_stack(re, prev, toParse, leftenter, rea_True, rea_False, re->next, re, toParse);
                 continue;
               }
               {
-                insert_stack(&re, &prev, &toParse, &leftenter, rea_True, rea_RangeNM_step2, &re->un.param, nullptr,
+                insert_stack(re, prev, toParse, leftenter, rea_True, rea_RangeNM_step2, re->un.param, nullptr,
                              toParse);
                 continue;
               }
@@ -1293,7 +1529,7 @@ bool CRegExp::lowParse(SRegInfo* re, SRegInfo* prev, int toParse)
               break;
             re->oldParse = toParse;
             if (!re->param0) {
-              insert_stack(&re, &prev, &toParse, &leftenter, rea_True, rea_NGRangeN_step2, &re->next, &re, toParse);
+              insert_stack(re, prev, toParse, leftenter, rea_True, rea_NGRangeN_step2, re->next, re, toParse);
               continue;
             }
             else
@@ -1311,11 +1547,11 @@ bool CRegExp::lowParse(SRegInfo* re, SRegInfo* prev, int toParse)
               if (re->param1)
                 re->param1--;
               else {
-                insert_stack(&re, &prev, &toParse, &leftenter, rea_True, rea_False, &re->next, &re, toParse);
+                insert_stack(re, prev, toParse, leftenter, rea_True, rea_False, re->next, re, toParse);
                 continue;
               }
               {
-                insert_stack(&re, &prev, &toParse, &leftenter, rea_True, rea_NGRangeNM_step2, &re->next, &re, toParse);
+                insert_stack(re, prev, toParse, leftenter, rea_True, rea_NGRangeNM_step2, re->next, re, toParse);
                 continue;
               }
             }
@@ -1334,7 +1570,7 @@ bool CRegExp::lowParse(SRegInfo* re, SRegInfo* prev, int toParse)
           break;
         case rea_False:
           if (count_elem) {
-            check_stack(false, &re, &prev, &toParse, &leftenter, &action);
+            check_stack(false, re, prev, toParse, leftenter, action);
             continue;
           }
           else
@@ -1342,7 +1578,7 @@ bool CRegExp::lowParse(SRegInfo* re, SRegInfo* prev, int toParse)
           break;
         case rea_True:
           if (count_elem) {
-            check_stack(true, &re, &prev, &toParse, &leftenter, &action);
+            check_stack(true, re, prev, toParse, leftenter, action);
             continue;
           }
           else
@@ -1353,22 +1589,34 @@ bool CRegExp::lowParse(SRegInfo* re, SRegInfo* prev, int toParse)
           break;
         case rea_RangeN_step2:
           action = rea_None;
-          insert_stack(&re, &prev, &toParse, &leftenter, rea_True, rea_False, &re->next, &re, toParse);
+          if (re == nullptr) {
+            return false;
+          }
+          insert_stack(re, prev, toParse, leftenter, rea_True, rea_False, re->next, re, toParse);
           continue;
           break;
         case rea_RangeNM_step2:
           action = rea_None;
-          insert_stack(&re, &prev, &toParse, &leftenter, rea_True, rea_RangeNM_step3, &re->next, &re, toParse);
+          if (re == nullptr) {
+            return false;
+          }
+          insert_stack(re, prev, toParse, leftenter, rea_True, rea_RangeNM_step3, re->next, re, toParse);
           continue;
           break;
         case rea_RangeNM_step3:
           action = rea_None;
+          if (re == nullptr) {
+            return false;
+          }
           re->param1++;
-          check_stack(false, &re, &prev, &toParse, &leftenter, &action);
+          check_stack(false, re, prev, toParse, leftenter, action);
           continue;
           break;
         case rea_NGRangeN_step2:
           action = rea_None;
+          if (re == nullptr) {
+            return false;
+          }
           if (re->param0)
             re->param0--;
           re = re->un.param;
@@ -1377,16 +1625,25 @@ bool CRegExp::lowParse(SRegInfo* re, SRegInfo* prev, int toParse)
           break;
         case rea_NGRangeNM_step2:
           action = rea_None;
-          insert_stack(&re, &prev, &toParse, &leftenter, rea_True, rea_NGRangeNM_step3, &re->un.param, nullptr,
+          if (re == nullptr) {
+            return false;
+          }
+          insert_stack(re, prev, toParse, leftenter, rea_True, rea_NGRangeNM_step3, re->un.param, nullptr,
                        toParse);
           continue;
           break;
         case rea_NGRangeNM_step3:
           action = rea_None;
+          if (re == nullptr) {
+            return false;
+          }
           re->param1++;
-          check_stack(false, &re, &prev, &toParse, &leftenter, &action);
+          check_stack(false, re, prev, toParse, leftenter, action);
           continue;
           break;
+      }
+      if (re == nullptr) {
+        return false;
       }
       if (!re->next) {
         re = re->parent;
@@ -1397,7 +1654,7 @@ bool CRegExp::lowParse(SRegInfo* re, SRegInfo* prev, int toParse)
         leftenter = true;
       }
     }
-    check_stack(true, &re, &prev, &toParse, &leftenter, &action);
+    check_stack(true, re, prev, toParse, leftenter, action);
   }
 }
 
@@ -1449,11 +1706,11 @@ inline bool CRegExp::quickCheck(int toParse)
 {
   switch (firstNode->op) {
     case EOps::ReSymb:
-      return toParse < end && matchChars((*global_pattern)[toParse], firstNode->un.symbol);
+      return toParse < end && matchChars(parseBuf[toParse], firstNode->un.symbol);
     case EOps::ReWord:
-      return toParse < end && matchChars((*global_pattern)[toParse], (*firstNode->un.word)[0]);
+      return toParse < end && matchChars(parseBuf[toParse], (*firstNode->un.word)[0]);
     case EOps::ReEnum:
-      return toParse < end && firstNode->un.charclass->contains((*global_pattern)[toParse]);
+      return toParse < end && firstNode->un.charclass->contains(parseBuf[toParse]);
     case EOps::ReMetaSymb:
       switch (firstNode->un.metaSymbol) {
 #ifdef COLORERMODE
@@ -1472,9 +1729,11 @@ inline bool CRegExp::quickCheck(int toParse)
   }
 }
 
-inline bool CRegExp::parseRE(int pos)
+// Cheap rejects (required chars, ^/~/$+maxLen, first-char), then NFA.
+// positionMoves slides the start; a start-anchor still fails outright.
+inline bool CRegExp::parseRE(int pos, const AsciiCharMask* subjectChars)
 {
-  if (error != EError::EOK)
+  if (error != EError::EOK || tree_root == nullptr)
     return false;
 
   count_elem = 0;
@@ -1486,9 +1745,37 @@ inline bool CRegExp::parseRE(int pos)
   endChange = false;
   int toParse = pos;
 
+  if (subjectChars != nullptr) {
+    for (int i = 0; i < requiredCharsCount; i++) {
+      if (((requiredChars[i][0] & (*subjectChars)[0]) | (requiredChars[i][1] & (*subjectChars)[1])) == 0)
+        return false;
+    }
+  }
+  // An anchored pattern matches at one position only, whether or not the caller
+  // asked for a moving search.
+  const bool anchored = startAnchor != StartAnchor::None;
+  if (startAnchor == StartAnchor::LineStart && toParse != 0)
+    return false;
+#ifdef COLORERMODE
+  if (startAnchor == StartAnchor::SchemeStart && toParse != schemeStart)
+    return false;
+#endif
+
+  if (endAnchor && maxLen >= 0) {
+    // A moving search can skip forward; ^ / ~ still pin the only start.
+    if (positionMoves && startAnchor == StartAnchor::None) {
+      const int start = end - maxLen;
+      if (start > toParse) {
+        toParse = pos = start;
+      }
+    }
+    if (end - toParse > maxLen)
+      return false;
+  }
+
   if (!positionMoves && firstCharMaskUseful) {
     if (toParse >= end) return false;
-    const auto ch = static_cast<uint32_t>((*global_pattern)[toParse]);
+    const auto ch = static_cast<uint32_t>(parseBuf[toParse]);
     if (ch < 128 && !(firstCharMask[ch >> 6] & (uint64_t(1) << (ch & 63)))) return false;
   }
   if (!positionMoves && firstNode && !quickCheck(toParse))
@@ -1505,7 +1792,7 @@ inline bool CRegExp::parseRE(int pos)
           skip = true;
         }
         else {
-          const auto ch = static_cast<uint32_t>((*global_pattern)[toParse]);
+          const auto ch = static_cast<uint32_t>(parseBuf[toParse]);
           if (ch < 128 && !(firstCharMask[ch >> 6] & (uint64_t(1) << (ch & 63))))
             skip = true;
         }
@@ -1513,6 +1800,8 @@ inline bool CRegExp::parseRE(int pos)
       if (!skip && firstNode && !quickCheck(toParse))
         skip = true;
       if (skip) {
+        if (anchored)
+          return false;
         toParse = ++pos;
         continue;
       }
@@ -1529,15 +1818,25 @@ inline bool CRegExp::parseRE(int pos)
     }
     if (stepBudgetExceeded)
       return false;
-    if (!positionMoves)
+    if (!positionMoves || anchored)
       return false;
     toParse = ++pos;
   } while (toParse <= end);
   return false;
 }
 
+void CRegExp::bindSubject(const UnicodeString* str)
+{
+  global_pattern = str;
+  parseBuf = str != nullptr ? str->getBuffer() : nullptr;
+  if (parseBuf == nullptr) {
+    static const wchar empty = 0;
+    parseBuf = &empty;
+  }
+}
+
 bool CRegExp::parse(const UnicodeString* str, int pos, int eol, SMatches* mtch, int soScheme,
-                    int posMoves)
+                    int posMoves, const AsciiCharMask* subjectChars)
 {
   bool nms = positionMoves;
   if (posMoves != -1)
@@ -1545,23 +1844,23 @@ bool CRegExp::parse(const UnicodeString* str, int pos, int eol, SMatches* mtch, 
 #ifdef COLORERMODE
   schemeStart = soScheme;
 #endif
-  global_pattern = str;
+  bindSubject(str);
   end = eol;
   matches = mtch;
-  bool result = parseRE(pos);
+  bool result = parseRE(pos, subjectChars);
   positionMoves = nms;
   return result;
 }
 
 bool CRegExp::parse(const UnicodeString* str, SMatches* mtch)
 {
-  end = str->length();
-  global_pattern = str;
+  bindSubject(str);
+  end = str != nullptr ? str->length() : 0;
 #ifdef COLORERMODE
   schemeStart = 0;
 #endif
   matches = mtch;
-  return parseRE(0);
+  return parseRE(0, nullptr);
 }
 
 /////////////////////////////////////////////////////////////////

--- a/plugins/colorer/src/Colorer-library/src/colorer/cregexp/cregexp.h
+++ b/plugins/colorer/src/Colorer-library/src/colorer/cregexp/cregexp.h
@@ -110,6 +110,9 @@ struct SMatches
   int cnMatch;
 };
 
+/// Bit per ASCII code point (0..127). Used for the first-char and required-char prefilters.
+using AsciiCharMask = std::array<uint64_t, 2>;
+
 /** Regular expressions internal tree node.
     @ingroup cregexp
 */
@@ -140,6 +143,10 @@ class SRegInfo
   int e = 0;
 
   EOps op = EOps::ReEmpty;
+  // First ASCII characters of the left ReOr branch. Used to skip that branch
+  // when the subject cannot start it; unused unless branchFirstUseful.
+  AsciiCharMask branchFirst = {};
+  bool branchFirstUseful = false;
 };
 
 enum ReAction {
@@ -168,6 +175,7 @@ struct StackElem
 
 #define INIT_MEM_SIZE 512
 #define MEM_INC 128
+
 /** Regular Expression compiler and matcher.
     Colorer regular expressions library cregexp.
 
@@ -221,7 +229,37 @@ struct StackElem
    - No string length changes on case mappings (only 1 <-> 1 mappings),
 \par 2.2. Algorithmic problems:
    - Explicit parse stack (grows as needed and is reused by all CRegExp
-     instances; matching is single-threaded).
+     instances on the same thread).
+
+\par 3. Matching pipeline (hot path).
+
+   setRE compiles an SRegInfo tree; optimize() then fills skip facts used
+   by parseRE / mayMatch before the NFA (lowParse) runs:
+
+   - firstCharMask / firstNode — first consuming ASCII set and first
+     literal/class/word (quickCheck). Unused if the prefix is nullable.
+   - startAnchor — pattern begins with ^ (not /m) or ~; only pos==0 or
+     pos==schemeStart can match, even with positionMoves.
+   - endAnchor + maxLen — pattern ends with $ (not /m, no top-level |).
+     A match cannot start more than maxLen characters before eol.
+     maxLen==-1 if * / + / \\N / \\y make length unbounded.
+     $ means toParse==eol (the parse() bound, not str->length()).
+   - requiredChars — up to 4 ASCII sets that must appear somewhere in
+     the subject (TextParser passes a per-line mask). /i letters omitted.
+   - ReOr.branchFirst — skip a | branch in lowParse when the current
+     ASCII char cannot start it. Left unused if the branch is nullable
+     or starts with a zero-width op (\\m \\M \\b lookaround ^ $): those
+     still have side effects (\\M bounds group 0 for a later alternative).
+
+   parse() pins parseBuf to UnicodeString::getBuffer() so the NFA does
+   not index the string per step. Each offset resets \\m/\\M and captures.
+   The backtracking stack is thread_local and shared by every CRegExp on
+   that thread; count_elem is reset per parseRE. Do not clear it from
+   ParserFactory teardown. parseStepLimit (default 1e6) counts NFA steps
+   in one parse(); exceeding it fails the match.
+
+   TextParser calls mayMatch() with the same pos/eol/schemeStart/line
+   mask before parse() to avoid entering the NFA.
 
     @ingroup cregexp
 */
@@ -288,11 +326,45 @@ class CRegExp
   /** Runs RE parser against input string @c str
    */
   bool parse(const UnicodeString* str, SMatches* mtch);
-  /** Runs RE parser against input string @c str
+  /** Runs RE parser against input string @c str.
+   *  @param subjectChars optional mask of ASCII characters present anywhere in @c str
+   *         (not only in [pos, eol)). Lets the matcher reject patterns whose
+   *         mandatory literals are absent from the line without running the NFA.
    */
   bool parse(const UnicodeString* str, int pos, int eol, SMatches* mtch, int soscheme = 0,
-             int moves = -1);
+             int moves = -1, const AsciiCharMask* subjectChars = nullptr);
   bool canStartWith(wchar ch) const;
+  /**
+   * Fills @c mask with every ASCII character of @c str; use as @c subjectChars in parse().
+   */
+  static void collectAsciiChars(const UnicodeString& str, AsciiCharMask& mask);
+  /**
+   * Cheap pre-check of what parse() would reject before running the matcher:
+   * a start anchor (^ or ~) at another position, an end-anchored pattern whose
+   * bounded length cannot reach @c eol, or a mandatory literal missing from
+   * @c subjectChars. False means parse() cannot succeed there.
+   * @c eol is the same bound parse() would receive ($ is toParse == eol).
+   */
+  bool mayMatch(int pos, int eol, int soscheme, const AsciiCharMask& subjectChars) const
+  {
+    if (startAnchor == StartAnchor::LineStart && pos != 0)
+      return false;
+#ifdef COLORERMODE
+    if (startAnchor == StartAnchor::SchemeStart && pos != soscheme)
+      return false;
+#else
+    (void) soscheme;
+#endif
+    // Moving searches skip forward to eol - maxLen in parseRE; only a
+    // fixed-position attempt is impossible when too much text remains.
+    if (endAnchor && maxLen >= 0 && !positionMoves && eol - pos > maxLen)
+      return false;
+    for (int i = 0; i < requiredCharsCount; i++) {
+      if (((requiredChars[i][0] & subjectChars[0]) | (requiredChars[i][1] & subjectChars[1])) == 0)
+        return false;
+    }
+    return true;
+  }
   /**
    * Caps backtracking steps in one parse() call. When exceeded, the match
    * fails (it is not a wall-clock quantum). Default 1 000 000.
@@ -310,8 +382,20 @@ class CRegExp
   SRegInfo* tree_root = nullptr;
   EError error = EError::EOK;
   SRegInfo* firstNode = nullptr;
-  std::array<uint64_t, 2> firstCharMask = {};
+  AsciiCharMask firstCharMask = {};
   bool firstCharMaskUseful = false;
+  // Pattern begins with ^ (single-line) or ~: only one start position can match.
+  enum class StartAnchor : uint8_t { None, LineStart, SchemeStart };
+  StartAnchor startAnchor = StartAnchor::None;
+  // Pattern ends with $ (single-line, no top-level alternation): match can
+  // only finish at eol, so it cannot start more than maxLen before eol.
+  bool endAnchor = false;
+  // Maximum characters the tree can consume; -1 = unbounded (* / + / \N / \y).
+  int maxLen = -1;
+  // Every match must contain at least one character from each of these sets.
+  static constexpr int MAX_REQUIRED_SETS = 4;
+  std::array<AsciiCharMask, MAX_REQUIRED_SETS> requiredChars = {};
+  int requiredCharsCount = 0;
 #ifdef COLORERMODE
   CRegExp* backRE = nullptr;
   const UnicodeString* backStr = nullptr;
@@ -322,6 +406,7 @@ class CRegExp
   bool startChange = false;
   bool endChange = false;
   const UnicodeString* global_pattern = nullptr;
+  const wchar* parseBuf = nullptr;
   int end = 0;
 
   SMatches* matches = nullptr;
@@ -337,33 +422,184 @@ class CRegExp
   bool matchChars(wchar one, wchar another) const;
   struct FirstChars
   {
-    std::array<uint64_t, 2> mask = {};
+    AsciiCharMask mask = {};
     bool nullable = false;
   };
   FirstChars analyzeFirstChars(const SRegInfo* re) const;
   FirstChars firstCharsForNode(const SRegInfo* re) const;
   void addFirstChar(FirstChars& result, wchar ch) const;
+  std::vector<AsciiCharMask> requiredCharsForChain(const SRegInfo* re) const;
+  std::vector<AsciiCharMask> requiredCharsForNode(const SRegInfo* re) const;
+  void addRequiredChar(std::vector<AsciiCharMask>& out, wchar ch) const;
+  void analyzeStartAnchor();
+  void analyzeEndAnchor();
+  int maxLenOfNode(const SRegInfo* re) const;
+  int maxLenOfChain(const SRegInfo* re) const;
+  void analyzeMaxLen();
+  void analyzeRequiredChars();
+  void analyzeBranchFirstChars(SRegInfo* re);
   void optimize();
   bool quickCheck(int toParse);
   bool isWordBoundary(int toParse);
   bool checkMetaSymbol(EMetaSymbols metaSymbol, int& toParse);
   bool matchCopiedRange(const UnicodeString& src, int from, int to, int& toParse, bool icase) const;
   bool lowParse(SRegInfo* re, SRegInfo* prev, int toParse);
-  bool parseRE(int toParse);
+  bool parseRE(int toParse, const AsciiCharMask* subjectChars);
+  void bindSubject(const UnicodeString* str);
 
   int count_elem;
   int parseSteps = 0;
   int parseStepLimit = 1000000;
   bool stepBudgetExceeded = false;
-  void check_stack(bool res, SRegInfo** re, SRegInfo** prev, int* toParse, bool* leftenter,
-                   ReAction* action);
-  void insert_stack(SRegInfo** re, SRegInfo** prev, int* toParse, bool* leftenter, ReAction ifTrueReturn,
-                    ReAction ifFalseReturn, SRegInfo** re2, SRegInfo** prev2, int toParse2);
+  void growRegExpStack();
+  void check_stack(bool res, SRegInfo*& re, SRegInfo*& prev, int& toParse, bool& leftenter, ReAction& action);
+  void insert_stack(SRegInfo*& re, SRegInfo*& prev, int& toParse, bool& leftenter, ReAction ifTrueReturn,
+                    ReAction ifFalseReturn, SRegInfo* re2, SRegInfo* prev2, int toParse2);
 
-  static std::vector<StackElem> RegExpStack;
+  static thread_local std::vector<StackElem> RegExpStack;
+
+  static bool isLineBreak(wchar c)
+  {
+    return c == 0x0A || c == 0x0B || c == 0x0C || c == 0x0D || c == 0x85 || c == 0x2028 || c == 0x2029;
+  }
 
  public:
   static void clearRegExpStack();
 };
+
+inline bool CRegExp::isWordBoundary(int toParse)
+{
+  const bool after = (toParse < end && Character::isLetterOrDigitOrUnderscore(parseBuf[toParse]));
+  const bool before = (toParse > 0 && Character::isLetterOrDigitOrUnderscore(parseBuf[toParse - 1]));
+  return before != after;
+}
+
+inline bool CRegExp::checkMetaSymbol(EMetaSymbols symb, int& toParse)
+{
+  switch (symb) {
+    case EMetaSymbols::ReAnyChr:
+      if (toParse >= end || (!singleLine && isLineBreak(parseBuf[toParse])))
+        return false;
+      toParse++;
+      return true;
+
+    case EMetaSymbols::ReSoL:
+      return toParse == 0 || (multiLine && isLineBreak(parseBuf[toParse - 1]));
+
+    case EMetaSymbols::ReEoL:
+      return toParse == end || (multiLine && toParse && toParse < end && isLineBreak(parseBuf[toParse - 1]));
+
+    case EMetaSymbols::ReDigit:
+      if (toParse >= end || !Character::isDigit(parseBuf[toParse]))
+        return false;
+      toParse++;
+      return true;
+
+    case EMetaSymbols::ReNDigit:
+      if (toParse >= end || Character::isDigit(parseBuf[toParse]))
+        return false;
+      toParse++;
+      return true;
+
+    case EMetaSymbols::ReWordSymb:
+      if (toParse >= end || !Character::isLetterOrDigitOrUnderscore(parseBuf[toParse]))
+        return false;
+      toParse++;
+      return true;
+
+    case EMetaSymbols::ReNWordSymb:
+      if (toParse >= end || Character::isLetterOrDigitOrUnderscore(parseBuf[toParse]))
+        return false;
+      toParse++;
+      return true;
+
+    case EMetaSymbols::ReWSpace:
+      if (toParse >= end || !Character::isWhitespace(parseBuf[toParse]))
+        return false;
+      toParse++;
+      return true;
+
+    case EMetaSymbols::ReNWSpace:
+      if (toParse >= end || Character::isWhitespace(parseBuf[toParse]))
+        return false;
+      toParse++;
+      return true;
+
+    case EMetaSymbols::ReUCase:
+      if (toParse >= end || !Character::isUpperCase(parseBuf[toParse]))
+        return false;
+      toParse++;
+      return true;
+
+    case EMetaSymbols::ReNUCase:
+      if (toParse >= end || !Character::isLowerCase(parseBuf[toParse]))
+        return false;
+      toParse++;
+      return true;
+
+    case EMetaSymbols::ReWBound:
+      return isWordBoundary(toParse);
+
+    case EMetaSymbols::ReNWBound:
+      return !isWordBoundary(toParse);
+
+    case EMetaSymbols::RePreNW:
+      return toParse == 0 || toParse >= end || !Character::isLetter(parseBuf[toParse - 1]);
+
+#ifdef COLORERMODE
+    case EMetaSymbols::ReSoScheme:
+      return (schemeStart == toParse);
+
+    case EMetaSymbols::ReStart:
+      matches->s[0] = toParse;
+      startChange = true;
+      return true;
+
+    case EMetaSymbols::ReEnd:
+      matches->e[0] = toParse;
+      endChange = true;
+      return true;
+#endif
+
+    default:
+      return false;
+  }
+}
+
+inline void CRegExp::check_stack(bool res, SRegInfo*& re, SRegInfo*& prev, int& toParse, bool& leftenter,
+                                 ReAction& action)
+{
+  if (count_elem == 0) {
+    action = res ? rea_True : rea_False;
+    return;
+  }
+
+  const StackElem& ne = RegExpStack[--count_elem];
+  action = res ? ne.ifTrueReturn : ne.ifFalseReturn;
+  re = ne.re;
+  prev = ne.prev;
+  toParse = ne.toParse;
+  leftenter = ne.leftenter;
+}
+
+inline void CRegExp::insert_stack(SRegInfo*& re, SRegInfo*& prev, int& toParse, bool& leftenter,
+                                  ReAction ifTrueReturn, ReAction ifFalseReturn, SRegInfo* re2, SRegInfo* prev2,
+                                  int toParse2)
+{
+  if (RegExpStack.size() == static_cast<size_t>(count_elem)) {
+    growRegExpStack();
+  }
+  RegExpStack[static_cast<size_t>(count_elem++)] =
+      StackElem{re, prev, toParse, leftenter, ifTrueReturn, ifFalseReturn};
+
+  prev = prev2;
+  re = re2;
+  toParse = toParse2;
+  leftenter = true;
+  if (!re && prev != nullptr) {
+    re = prev->parent;
+    leftenter = false;
+  }
+}
 
 #endif  // COLORER_CREGEXP_H

--- a/plugins/colorer/src/Colorer-library/src/colorer/editor/BaseEditor.cpp
+++ b/plugins/colorer/src/Colorer-library/src/colorer/editor/BaseEditor.cpp
@@ -1,6 +1,13 @@
 #include "colorer/editor/BaseEditor.h"
 #include "colorer/parsers/TextParserImpl.h"
 
+// Editor facade over TextParser. invalidLine is the first stale line.
+// Visible window wSize; colored cover is 2*wSize; LineRegion ring is
+// 3*wSize and never shrinks. validate(lno, true) paints the cover;
+// validate(..., false) only warms ParseCache (idleJob).
+// modifyLineEvent tries a single-line reparse before invalidating.
+// See .agents/skills/colorer-hrc/core-parse.md.
+
 #define IDLE_PARSE(time) (100 + (time) * 4)
 
 const int CHOOSE_STR = 4;
@@ -132,6 +139,9 @@ void BaseEditor::remapLRS(bool recreate)
 
 void BaseEditor::setFileType(FileType* ftype)
 {
+  if (ftype == nullptr) {
+    throw FileTypeException("FileType is null");
+  }
   COLORER_LOG_DEBUG("[BaseEditor] setFileType: %", ftype->getName());
   currentFileType = ftype;
   parserFactory->getHrcLibrary().loadFileType(ftype);
@@ -360,6 +370,8 @@ void BaseEditor::modifyEvent(int topLine)
   }
 }
 
+// Single-line edit. tryParseLine keeps the rest of the file valid when
+// the scheme stack past `line` is unchanged; otherwise same as modifyEvent.
 void BaseEditor::modifyLineEvent(int line)
 {
   if (invalidLine > line) {
@@ -390,6 +402,8 @@ inline int BaseEditor::getLastVisibleLine() const
   return ((r1 > r2) ? r2 : r1) - 1;
 }
 
+// rebuildRegions: color into the LineRegion ring for the visible cover.
+// !rebuildRegions: TPM_CACHE_UPDATE from invalidLine without moving the ring.
 void BaseEditor::validate(int lno, bool rebuildRegions)
 {
   int parseFrom;

--- a/plugins/colorer/src/Colorer-library/src/colorer/editor/BaseEditor.h
+++ b/plugins/colorer/src/Colorer-library/src/colorer/editor/BaseEditor.h
@@ -17,6 +17,19 @@
  * state, outline structure creation, pair constructions search.
  * This class has event-oriented structure. Each editor event
  * is passed into this object and gets internal processing.
+ *
+ * invalidLine is the first stale line. getLineRegions() calls
+ * validate(lno, true), which colors a cover of 2*wSize lines around
+ * the visible window into a LineRegion ring of 3*wSize (the ring
+ * never shrinks). idleJob() calls validate(..., false) to warm
+ * TextParser's ParseCache without moving that ring.
+ * modifyLineEvent() uses TextParser::tryParseLine: if the scheme
+ * stack past the edited line is unchanged, invalidLine is left as-is.
+ *
+ * idleJob / breakParse may run from a background thread; do not parse
+ * the same BaseEditor concurrently. TextParser takes a shared lock on
+ * HrcLibrary for the duration of parse / tryParseLine.
+ *
  * @ingroup colorer_editor
  */
 class BaseEditor : public RegionHandler

--- a/plugins/colorer/src/Colorer-library/src/colorer/handlers/StyledHRDMapper.cpp
+++ b/plugins/colorer/src/Colorer-library/src/colorer/handlers/StyledHRDMapper.cpp
@@ -9,7 +9,7 @@ void StyledHRDMapper::loadRegionMappings(XmlInputSource& is)
   if (!xml.parse()) {
     throw Exception("Error loading HRD file '" + is.getPath() + "'");
   }
-  std::list<XMLNode> nodes;
+  XMLNodeList nodes;
   xml.getNodes(nodes);
 
   if (nodes.begin()->name != hrdTagHrd) {

--- a/plugins/colorer/src/Colorer-library/src/colorer/handlers/TextHRDMapper.cpp
+++ b/plugins/colorer/src/Colorer-library/src/colorer/handlers/TextHRDMapper.cpp
@@ -9,7 +9,7 @@ void TextHRDMapper::loadRegionMappings(XmlInputSource& is)
   if (!xml.parse()) {
     throw Exception("Error loading HRD file '" + is.getPath() + "'");
   }
-  std::list<XMLNode> nodes;
+  XMLNodeList nodes;
   xml.getNodes(nodes);
 
   if (nodes.begin()->name != hrdTagHrd) {

--- a/plugins/colorer/src/Colorer-library/src/colorer/io/FileInputSource.cpp
+++ b/plugins/colorer/src/Colorer-library/src/colorer/io/FileInputSource.cpp
@@ -1,5 +1,6 @@
 #include <fcntl.h>
 #include <sys/stat.h>
+#include <cerrno>
 #include <cstring>
 
 #if defined WIN32
@@ -12,8 +13,40 @@
 #ifndef O_BINARY
 #define O_BINARY 0x0
 #endif
+#ifndef O_RDONLY
+#define O_RDONLY 0
+#endif
 
 #include "colorer/io/FileInputSource.h"
+
+namespace {
+
+struct FileDescriptor {
+  int fd = -1;
+
+  FileDescriptor() = default;
+  ~FileDescriptor()
+  {
+    close();
+  }
+  FileDescriptor(const FileDescriptor&) = delete;
+  FileDescriptor& operator=(const FileDescriptor&) = delete;
+
+  void close()
+  {
+    if (fd == -1) {
+      return;
+    }
+#ifdef _MSC_VER
+    _close(fd);
+#else
+    ::close(fd);
+#endif
+    fd = -1;
+  }
+};
+
+}  // namespace
 
 FileInputSource::FileInputSource(const UnicodeString* basePath, FileInputSource* base)
 {
@@ -67,32 +100,60 @@ const byte* FileInputSource::openStream()
 {
   if (stream != nullptr)
     throw InputSourceException("openStream(): source stream already opened: '" + *baseLocation + "'");
-#ifdef _MSC_VER
-  int source;
-  _sopen_s(&source, UStr::to_stdstr(baseLocation).c_str(), _O_BINARY | O_RDONLY, _SH_DENYNO, _S_IREAD | _S_IWRITE);
-#else
-  int source = open(UStr::to_stdstr(baseLocation).c_str(), O_BINARY);
-#endif
-  if (source == -1)
-    throw InputSourceException("Can't open file '" + *baseLocation + "'");
-  struct stat st
-  {};
-  fstat(source, &st);
-  len = st.st_size;
 
-  stream = new byte[len];
-  memset(stream, 0, sizeof(byte) * len);
+  FileDescriptor source;
 #ifdef _MSC_VER
-  if (_read(source, stream, len) != len) {
-    throw InputSourceException("Error on read file" + *baseLocation);
-  }
-  _close(source);
+  if (_sopen_s(&source.fd, UStr::to_stdstr(baseLocation).c_str(), _O_BINARY | O_RDONLY, _SH_DENYNO,
+               _S_IREAD | _S_IWRITE) != 0 ||
+      source.fd == -1)
 #else
-  if (read(source, stream, len) != len) {
-    throw InputSourceException("Error on read file" + *baseLocation);
-  }
-  close(source);
+  source.fd = open(UStr::to_stdstr(baseLocation).c_str(), O_RDONLY | O_BINARY);
+  if (source.fd == -1)
 #endif
+  {
+    throw InputSourceException("Can't open file '" + *baseLocation + "'");
+  }
+
+  struct stat st {};
+  if (fstat(source.fd, &st) != 0) {
+    throw InputSourceException("Can't stat file '" + *baseLocation + "'");
+  }
+  len = static_cast<int>(st.st_size);
+  if (len < 0) {
+    throw InputSourceException("File is too large '" + *baseLocation + "'");
+  }
+
+  stream = new byte[len == 0 ? 1 : len];
+  if (len == 0) {
+    stream[0] = 0;
+    return stream;
+  }
+  memset(stream, 0, sizeof(byte) * static_cast<size_t>(len));
+
+  int got = 0;
+  while (got < len) {
+#ifdef _MSC_VER
+    const int n = _read(source.fd, stream + got, static_cast<unsigned>(len - got));
+#else
+    const int n = static_cast<int>(read(source.fd, stream + got, static_cast<size_t>(len - got)));
+#endif
+    if (n < 0) {
+      if (errno == EINTR) {
+        continue;
+      }
+      delete[] stream;
+      stream = nullptr;
+      len = 0;
+      throw InputSourceException("Error on read file '" + *baseLocation + "'");
+    }
+    if (n == 0) {
+      delete[] stream;
+      stream = nullptr;
+      len = 0;
+      throw InputSourceException("Error on read file '" + *baseLocation + "'");
+    }
+    got += n;
+  }
   return stream;
 }
 

--- a/plugins/colorer/src/Colorer-library/src/colorer/parsers/CatalogParser.cpp
+++ b/plugins/colorer/src/Colorer-library/src/colorer/parsers/CatalogParser.cpp
@@ -14,7 +14,7 @@ void CatalogParser::parse(const UnicodeString* path)
   if (!xml.parse()) {
     throw CatalogParserException(*path + UnicodeString(" parse error"));
   }
-  std::list<XMLNode> nodes;
+  XMLNodeList nodes;
   xml.getNodes(nodes);
 
   if (nodes.begin()->name != catTagCatalog) {

--- a/plugins/colorer/src/Colorer-library/src/colorer/parsers/FileTypeImpl.h
+++ b/plugins/colorer/src/Colorer-library/src/colorer/parsers/FileTypeImpl.h
@@ -1,6 +1,7 @@
 #ifndef COLORER_FILETYPEIMPL_H
 #define COLORER_FILETYPEIMPL_H
 
+#include <shared_mutex>
 #include <unordered_map>
 #include <vector>
 #include "colorer/FileType.h"
@@ -106,6 +107,7 @@ class FileType::Impl
   std::unordered_map<UnicodeString, TypeParameter> paramsHash;
   std::vector<UnicodeString> importVector;
   uXmlInputSource inputSource;
+  std::shared_mutex* library_access {nullptr};
 };
 
 #endif  // COLORER_FILETYPEIMPL_H

--- a/plugins/colorer/src/Colorer-library/src/colorer/parsers/HrcLibrary.cpp
+++ b/plugins/colorer/src/Colorer-library/src/colorer/parsers/HrcLibrary.cpp
@@ -1,64 +1,79 @@
 #include "colorer/HrcLibrary.h"
 #include "colorer/parsers/HrcLibraryImpl.h"
 
+#include <mutex>
+#include <shared_mutex>
+
 HrcLibrary::HrcLibrary() : pimpl(spimpl::make_unique_impl<Impl>()) {}
 
 void HrcLibrary::loadSource(XmlInputSource* is)
 {
+  std::unique_lock<std::shared_mutex> lock(pimpl->access);
   pimpl->loadSource(is, Impl::LoadType::FULL);
 }
 
 void HrcLibrary::loadProtoTypes(XmlInputSource* is)
 {
+  std::unique_lock<std::shared_mutex> lock(pimpl->access);
   pimpl->loadSource(is, Impl::LoadType::PROTOTYPE);
 }
 
 FileType* HrcLibrary::enumerateFileTypes(unsigned int index)
 {
+  std::shared_lock<std::shared_mutex> lock(pimpl->access);
   return pimpl->enumerateFileTypes(index);
 }
 
 FileType* HrcLibrary::getFileType(const UnicodeString* name)
 {
+  std::shared_lock<std::shared_mutex> lock(pimpl->access);
   return pimpl->getFileType(name);
 }
 
 FileType* HrcLibrary::getFileType(const UnicodeString& name)
 {
+  std::shared_lock<std::shared_mutex> lock(pimpl->access);
   return pimpl->getFileType(&name);
 }
 
 FileType* HrcLibrary::chooseFileType(const UnicodeString* fileName, const UnicodeString* firstLine, int typeNo)
 {
+  std::shared_lock<std::shared_mutex> lock(pimpl->access);
   return pimpl->chooseFileType(fileName, firstLine, typeNo);
 }
 
 size_t HrcLibrary::getFileTypesCount()
 {
+  std::shared_lock<std::shared_mutex> lock(pimpl->access);
   return pimpl->getFileTypesCount();
 }
 
 size_t HrcLibrary::getRegionCount()
 {
+  std::shared_lock<std::shared_mutex> lock(pimpl->access);
   return pimpl->getRegionCount();
 }
 
 const Region* HrcLibrary::getRegion(unsigned int id)
 {
+  std::shared_lock<std::shared_mutex> lock(pimpl->access);
   return pimpl->getRegion(id);
 }
 
 const Region* HrcLibrary::getRegion(const UnicodeString* name)
 {
+  std::unique_lock<std::shared_mutex> lock(pimpl->access);
   return pimpl->getRegion(name);
 }
 
 void HrcLibrary::loadFileType(FileType* filetype)
 {
+  std::unique_lock<std::shared_mutex> lock(pimpl->access);
   pimpl->loadFileType(filetype);
 }
 
 void HrcLibrary::loadHrcSettings(const XmlInputSource& is)
 {
+  std::unique_lock<std::shared_mutex> lock(pimpl->access);
   pimpl->loadHrcSettings(is);
 }

--- a/plugins/colorer/src/Colorer-library/src/colorer/parsers/HrcLibraryImpl.cpp
+++ b/plugins/colorer/src/Colorer-library/src/colorer/parsers/HrcLibraryImpl.cpp
@@ -1,5 +1,7 @@
 #include "colorer/parsers/HrcLibraryImpl.h"
 
+#include <algorithm>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <unordered_map>
@@ -14,6 +16,9 @@ HrcLibrary::Impl::Impl()
   regionNamesHash.reserve(1000);
   regionNamesVector.reserve(1000);
   schemeHash.reserve(4000);
+#ifdef COLORER_FEATURE_ZIPINPUTSOURCE
+  zip_cache_ptr = XmlJarCache::bound() != nullptr ? XmlJarCache::bound() : &zip_cache;
+#endif
 }
 
 HrcLibrary::Impl::~Impl()
@@ -40,6 +45,10 @@ void HrcLibrary::Impl::loadSource(XmlInputSource* input_source, const LoadType l
   if (!input_source) {
     throw HrcLibraryException("Can't open stream - 'null' is bad stream.");
   }
+
+#ifdef COLORER_FEATURE_ZIPINPUTSOURCE
+  XmlJarCache::Current jar_scope(*zip_cache_ptr);
+#endif
 
   // Сохраняем текущий контекст парсинга файла, т.к. у нас рекурсивное использование
   XmlInputSource* temp_is = current_input_source;
@@ -121,11 +130,14 @@ void HrcLibrary::Impl::loadFileType(FileType* filetype)
 
 void HrcLibrary::Impl::loadHrcSettings(const XmlInputSource& is)
 {
+#ifdef COLORER_FEATURE_ZIPINPUTSOURCE
+  XmlJarCache::Current jar_scope(*zip_cache_ptr);
+#endif
   XmlReader xml_parser(is);
   if (!xml_parser.parse()) {
     throw HrcLibraryException("Error reading " + is.getPath());
   }
-  std::list<XMLNode> nodes;
+  XMLNodeList nodes;
   xml_parser.getNodes(nodes);
 
   if (nodes.begin()->name != u"hrc-settings") {
@@ -217,7 +229,7 @@ void HrcLibrary::Impl::parseHRC(const XmlInputSource& is)
   if (!xml.parse()) {
     throw HrcLibraryException("Error reading hrc file '" + is.getPath() + "'");
   }
-  std::list<XMLNode> nodes;
+  XMLNodeList nodes;
   xml.getNodes(nodes);
 
   if (nodes.begin()->name != hrcTagHrc) {
@@ -307,6 +319,7 @@ void HrcLibrary::Impl::addPrototype(const XMLNode& elem)
 
   parsePrototypeBlock(elem, type);
 
+  ptype->library_access = &access;
   fileTypeHash.try_emplace(typeName, type);
   if (!ptype->isPackage) {
     fileTypeVector.push_back(type);
@@ -603,7 +616,10 @@ void HrcLibrary::Impl::addSchemeInherit(SchemeImpl* scheme, const XMLNode& elem)
   scheme_node->schemeName = std::make_unique<UnicodeString>(nqSchemeName);
   auto schemeName = qualifyForeignName(scheme_node->schemeName.get(), QualifyNameType::QNT_SCHEME, false);
   if (schemeName != nullptr) {
-    scheme_node->scheme = schemeHash.find(*schemeName)->second;
+    const auto scheme_it = schemeHash.find(*schemeName);
+    if (scheme_it != schemeHash.end()) {
+      scheme_node->scheme = scheme_it->second;
+    }
     scheme_node->schemeName = std::move(schemeName);
   }
 
@@ -981,14 +997,146 @@ void HrcLibrary::Impl::updateSchemeLink(uUnicodeString& scheme_name, SchemeImpl*
   if (scheme_name != nullptr && *scheme_impl == nullptr) {
     const auto schemeName = qualifyForeignName(scheme_name.get(), QualifyNameType::QNT_SCHEME, true);
     if (schemeName != nullptr) {
-      *scheme_impl = schemeHash.find(*schemeName)->second;
+      const auto scheme_it = schemeHash.find(*schemeName);
+      if (scheme_it != schemeHash.end()) {
+        *scheme_impl = scheme_it->second;
+      }
     }
-    else {
+    if (*scheme_impl == nullptr) {
       COLORER_LOG_ERROR(message[scheme_type], *scheme_name, *current_scheme->schemeName);
     }
 
     scheme_name.reset();
   }
+}
+
+namespace {
+
+bool keywordsMergeable(const SchemeNodeKeywords* a, const SchemeNodeKeywords* b)
+{
+  return a->kwList->matchCase == b->kwList->matchCase && a->worddiv == nullptr &&
+         b->worddiv == nullptr;
+}
+
+std::unique_ptr<SchemeNodeKeywords> mergeKeywordNodes(const std::vector<const SchemeNodeKeywords*>& src)
+{
+  size_t total = 0;
+  for (const auto* node : src) {
+    total += static_cast<size_t>(node->kwList->count);
+  }
+  auto merged = std::make_unique<SchemeNodeKeywords>();
+  merged->kwList = std::make_unique<KeywordList>(total);
+  auto* kw = merged->kwList.get();
+  kw->matchCase = src.front()->kwList->matchCase;
+  for (const auto* node : src) {
+    const auto* list = node->kwList.get();
+    for (int i = 0; i < list->count; i++) {
+      auto& dst = kw->kwList[kw->count];
+      dst.keyword = std::make_unique<UnicodeString>(*list->kwList[i].keyword);
+      dst.region = list->kwList[i].region;
+      dst.isSymbol = list->kwList[i].isSymbol;
+      kw->firstChar->add((*dst.keyword)[0]);
+      kw->minKeywordLength = std::min(kw->minKeywordLength, dst.keyword->length());
+      kw->count++;
+    }
+  }
+  std::stable_sort(kw->kwList, kw->kwList + kw->count, [](const KeywordInfo& a, const KeywordInfo& b) {
+    const int cmp = a.keyword->compare(*b.keyword);
+    if (cmp != 0) {
+      return cmp < 0;
+    }
+    return a.isSymbol < b.isSymbol;
+  });
+  const KeywordInfo* const new_end =
+      std::unique(kw->kwList, kw->kwList + kw->count, [](const KeywordInfo& a, const KeywordInfo& b) {
+        return a.isSymbol == b.isSymbol && a.keyword->compare(*b.keyword) == 0;
+      });
+  kw->count = static_cast<int>(new_end - kw->kwList);
+  kw->firstChar->freeze();
+  kw->substrIndex();
+  return merged;
+}
+
+constexpr uint8_t kSearchUnbuilt = 0;
+constexpr uint8_t kSearchBuilding = 1;
+constexpr uint8_t kSearchDone = 2;
+
+}  // namespace
+
+void HrcLibrary::Impl::mergeSearchKeywords(SchemeImpl* scheme)
+{
+  std::vector<SchemeNode*> merged;
+  merged.reserve(scheme->searchNodes.size());
+  for (size_t i = 0; i < scheme->searchNodes.size();) {
+    auto* node = scheme->searchNodes[i];
+    if (node->type != SchemeNode::SchemeNodeType::SNT_KEYWORDS) {
+      merged.push_back(node);
+      i++;
+      continue;
+    }
+    auto* first = static_cast<SchemeNodeKeywords*>(node);
+    if (first->kwList->count == 0) {
+      i++;
+      continue;
+    }
+    std::vector<const SchemeNodeKeywords*> run {first};
+    size_t j = i + 1;
+    for (; j < scheme->searchNodes.size(); j++) {
+      auto* next = scheme->searchNodes[j];
+      if (next->type != SchemeNode::SchemeNodeType::SNT_KEYWORDS) {
+        break;
+      }
+      auto* kw = static_cast<SchemeNodeKeywords*>(next);
+      if (kw->kwList->count == 0) {
+        continue;
+      }
+      if (!keywordsMergeable(first, kw)) {
+        break;
+      }
+      run.push_back(kw);
+    }
+    if (run.size() == 1) {
+      merged.push_back(node);
+    } else {
+      auto owned = mergeKeywordNodes(run);
+      merged.push_back(owned.get());
+      scheme->searchOwnedNodes.emplace_back(std::move(owned));
+    }
+    i = j;
+  }
+  scheme->searchNodes = std::move(merged);
+}
+
+void HrcLibrary::Impl::buildSearchNodes(SchemeImpl* scheme,
+                                        std::unordered_map<const SchemeImpl*, uint8_t>& state)
+{
+  auto& st = state[scheme];
+  if (st != kSearchUnbuilt) {
+    return;
+  }
+  st = kSearchBuilding;
+  scheme->searchNodes.clear();
+  scheme->searchOwnedNodes.clear();
+  for (const auto& node : scheme->nodes) {
+    if (node->type == SchemeNode::SchemeNodeType::SNT_INHERIT) {
+      auto* inherit = static_cast<SchemeNodeInherit*>(node.get());
+      if (inherit->scheme != nullptr && inherit->virtualEntryVector.empty() &&
+          !inherit->scheme->virtualTarget)
+      {
+        if (state[inherit->scheme] == kSearchBuilding) {
+          scheme->searchNodes.push_back(node.get());
+          continue;
+        }
+        buildSearchNodes(inherit->scheme, state);
+        scheme->searchNodes.insert(scheme->searchNodes.end(), inherit->scheme->searchNodes.begin(),
+                                   inherit->scheme->searchNodes.end());
+        continue;
+      }
+    }
+    scheme->searchNodes.push_back(node.get());
+  }
+  mergeSearchKeywords(scheme);
+  st = kSearchDone;
 }
 
 void HrcLibrary::Impl::updateLinks()
@@ -1043,20 +1191,12 @@ void HrcLibrary::Impl::updateLinks()
     }
   }
 
+  // Flatten static inherit into searchNodes, merge keyword lists, then
+  // build per-ASCII candidate slices (searchDispatch). Virtual inherit
+  // stays as SNT_INHERIT and is resolved at parse time via VTList.
+  std::unordered_map<const SchemeImpl*, uint8_t> searchState;
   for (const auto& [key, scheme] : schemeHash) {
-    scheme->searchNodes.clear();
-    for (const auto& node : scheme->nodes) {
-      if (node->type == SchemeNode::SchemeNodeType::SNT_INHERIT) {
-        auto* inherit = static_cast<SchemeNodeInherit*>(node.get());
-        if (inherit->scheme && inherit->virtualEntryVector.empty() && !inherit->scheme->virtualTarget) {
-          for (const auto& inheritedNode : inherit->scheme->nodes) {
-            scheme->searchNodes.push_back(inheritedNode.get());
-          }
-          continue;
-        }
-      }
-      scheme->searchNodes.push_back(node.get());
-    }
+    buildSearchNodes(scheme, searchState);
   }
 
   std::unordered_map<const SchemeImpl*, std::array<uint8_t, 128>> startCache;
@@ -1206,7 +1346,11 @@ uUnicodeString HrcLibrary::Impl::qualifyForeignName(const UnicodeString* name, c
       if (idx > -1) {
         tname = current_parse_type->pimpl->importVector.at(idx);
       }
-      FileType* importer = fileTypeHash.find(tname)->second;
+      const auto importer_it = fileTypeHash.find(tname);
+      if (importer_it == fileTypeHash.end()) {
+        continue;
+      }
+      FileType* importer = importer_it->second;
       if (!importer->pimpl->type_loading) {
         loadFileType(importer);
       }
@@ -1255,7 +1399,10 @@ uUnicodeString HrcLibrary::Impl::useEntities(const UnicodeString* name)
     auto qEnName = qualifyForeignName(&enname, QualifyNameType::QNT_ENTITY, true);
     const UnicodeString* enval = nullptr;
     if (qEnName != nullptr) {
-      enval = schemeEntitiesHash.find(*qEnName)->second;
+      const auto entity_it = schemeEntitiesHash.find(*qEnName);
+      if (entity_it != schemeEntitiesHash.end()) {
+        enval = entity_it->second;
+      }
     }
     if (enval == nullptr) {
       epos++;

--- a/plugins/colorer/src/Colorer-library/src/colorer/parsers/HrcLibraryImpl.h
+++ b/plugins/colorer/src/Colorer-library/src/colorer/parsers/HrcLibraryImpl.h
@@ -1,12 +1,18 @@
 #ifndef COLORER_HRCLIBRARYIMPL_H
 #define COLORER_HRCLIBRARYIMPL_H
 
+#include <shared_mutex>
+#include <cstdint>
 #include <unordered_map>
 #include "colorer/HrcLibrary.h"
 #include "colorer/cregexp/cregexp.h"
 #include "colorer/parsers/SchemeImpl.h"
 #include "colorer/xml/XMLNode.h"
 #include "colorer/xml/XmlInputSource.h"
+
+#ifdef COLORER_FEATURE_ZIPINPUTSOURCE
+#include "colorer/xml/libxml2/SharedXmlInputSource.h"
+#endif
 
 class FileType;
 
@@ -34,6 +40,8 @@ class HrcLibrary::Impl
   size_t getRegionCount() const;
   const Region* getRegion(unsigned int id) const;
   const Region* getRegion(const UnicodeString* name);
+
+  mutable std::shared_mutex access;
 
  protected:
   enum class QualifyNameType { QNT_DEFINE, QNT_SCHEME, QNT_ENTITY };
@@ -89,6 +97,8 @@ class HrcLibrary::Impl
   uUnicodeString qualifyForeignName(const UnicodeString* name, QualifyNameType qntype, bool logErrors);
 
   void updateLinks();
+  void buildSearchNodes(SchemeImpl* scheme, std::unordered_map<const SchemeImpl*, uint8_t>& state);
+  void mergeSearchKeywords(SchemeImpl* scheme);
   void updateSchemeLink(uUnicodeString& scheme_name, SchemeImpl** scheme_impl, byte scheme_type,
                         const SchemeImpl* current_scheme);
   uUnicodeString useEntities(const UnicodeString* name);
@@ -99,6 +109,11 @@ class HrcLibrary::Impl
 
   void updatePrototype(const XMLNode& elem);
   void updatePrototypeParams(const XMLNode& node, FileType* current_parse_prototype);
+
+#ifdef COLORER_FEATURE_ZIPINPUTSOURCE
+  XmlJarCache zip_cache;
+  XmlJarCache* zip_cache_ptr {nullptr};
+#endif
 };
 
 #endif  // COLORER_HRCLIBRARYIMPL_H

--- a/plugins/colorer/src/Colorer-library/src/colorer/parsers/KeywordList.cpp
+++ b/plugins/colorer/src/Colorer-library/src/colorer/parsers/KeywordList.cpp
@@ -46,6 +46,9 @@ void KeywordList::substrIndex()
       hasNonSymbols = true;
     }
   }
+  firstCharAscii = {};
+  asciiBegin = {};
+  asciiEnd = {};
   for (int i = count - 1; i > 0; i--) {
     for (int ii = i - 1; ii >= 0; ii--) {
       if ((*kwList[ii].keyword)[0] != (*kwList[i].keyword)[0]) {
@@ -58,5 +61,18 @@ void KeywordList::substrIndex()
         break;
       }
     }
+  }
+  for (int i = 0; i < count; ) {
+    const auto ch = static_cast<uint32_t>((*kwList[i].keyword)[0]);
+    int j = i + 1;
+    while (j < count && static_cast<uint32_t>((*kwList[j].keyword)[0]) == ch) {
+      j++;
+    }
+    if (ch < 128) {
+      firstCharAscii[ch >> 6] |= uint64_t(1) << (ch & 63);
+      asciiBegin[ch] = i;
+      asciiEnd[ch] = j;
+    }
+    i = j;
   }
 }

--- a/plugins/colorer/src/Colorer-library/src/colorer/parsers/KeywordList.h
+++ b/plugins/colorer/src/Colorer-library/src/colorer/parsers/KeywordList.h
@@ -1,7 +1,9 @@
 #ifndef COLORER_KEYWORDLIST_H
 #define COLORER_KEYWORDLIST_H
 
+#include <array>
 #include <climits>
+#include <cstdint>
 #include "colorer/Common.h"
 #include "colorer/Region.h"
 
@@ -31,6 +33,9 @@ class KeywordList
   int count = 0;
   int minKeywordLength = INT_MAX;
   std::unique_ptr<CharacterClass> firstChar;
+  std::array<uint64_t, 2> firstCharAscii = {};
+  std::array<int, 128> asciiBegin = {};
+  std::array<int, 128> asciiEnd = {};
   KeywordInfo* kwList = nullptr;
   explicit KeywordList(size_t list_size);
   ~KeywordList();

--- a/plugins/colorer/src/Colorer-library/src/colorer/parsers/ParserFactoryImpl.cpp
+++ b/plugins/colorer/src/Colorer-library/src/colorer/parsers/ParserFactoryImpl.cpp
@@ -8,17 +8,22 @@
 
 ParserFactory::Impl::Impl()
 {
+#ifdef COLORER_FEATURE_ZIPINPUTSOURCE
+  XmlJarCache::Current jar_scope(jar_cache);
+#endif
   hrc_library = new HrcLibrary();
 }
 
 ParserFactory::Impl::~Impl()
 {
   delete hrc_library;
-  CRegExp::clearRegExpStack();
 }
 
 void ParserFactory::Impl::loadCatalog(const UnicodeString* catalog_path)
 {
+#ifdef COLORER_FEATURE_ZIPINPUTSOURCE
+  XmlJarCache::Current jar_scope(jar_cache);
+#endif
   if (!catalog_path || catalog_path->isEmpty()) {
     COLORER_LOG_DEBUG("loadCatalog for empty path");
 
@@ -46,6 +51,9 @@ void ParserFactory::Impl::loadCatalog(const UnicodeString* catalog_path)
 
 void ParserFactory::Impl::loadHrcPath(const UnicodeString* location, const UnicodeString* base_path) const
 {
+#ifdef COLORER_FEATURE_ZIPINPUTSOURCE
+  XmlJarCache::Current jar_scope(jar_cache);
+#endif
   if (!location) {
     return;
   }
@@ -81,6 +89,9 @@ void ParserFactory::Impl::loadHrcPath(const UnicodeString* location, const Unico
 
 void ParserFactory::Impl::loadHrcSettings(const UnicodeString* location, const bool user_defined) const
 {
+#ifdef COLORER_FEATURE_ZIPINPUTSOURCE
+  XmlJarCache::Current jar_scope(jar_cache);
+#endif
   uUnicodeString path;
   if (!user_defined && (!location || location->isEmpty())) {
     // hrcsetting уровня приложения загружается по фиксированному пути
@@ -107,6 +118,9 @@ void ParserFactory::Impl::loadHrcSettings(const UnicodeString* location, const b
 
 void ParserFactory::Impl::loadHrdPath(const UnicodeString* location)
 {
+#ifdef COLORER_FEATURE_ZIPINPUTSOURCE
+  XmlJarCache::Current jar_scope(jar_cache);
+#endif
   if (!location) {
     return;
   }
@@ -158,7 +172,7 @@ void ParserFactory::Impl::loadHrd(const UnicodeString& hrd_path)
     throw ParserFactoryException(UnicodeString("Error reading ").append(hrd_path));
   }
 
-  std::list<XMLNode> nodes;
+  XMLNodeList nodes;
   xml_parser.getNodes(nodes);
 
   auto elem = nodes.begin();
@@ -189,7 +203,7 @@ void ParserFactory::Impl::loadHrdSets(const UnicodeString& hrd_path)
     throw ParserFactoryException(UnicodeString("Error reading ").append(hrd_path));
   }
 
-  std::list<XMLNode> nodes;
+  XMLNodeList nodes;
   xml_parser.getNodes(nodes);
 
   if (nodes.begin()->name != catTagHrdSets) {
@@ -231,8 +245,11 @@ std::vector<UnicodeString> ParserFactory::Impl::enumHrdClasses() const
 
 std::vector<const HrdNode*> ParserFactory::Impl::enumHrdInstances(const UnicodeString& classID) const
 {
-  auto hash = hrd_nodes.find(classID);
   std::vector<const HrdNode*> result;
+  const auto hash = hrd_nodes.find(classID);
+  if (hash == hrd_nodes.end()) {
+    return result;
+  }
   result.reserve(hash->second->size());
   for (const auto& p : *hash->second) {
     result.push_back(p.get());
@@ -294,6 +311,9 @@ std::unique_ptr<TextHRDMapper> ParserFactory::Impl::createTextMapper(const Unico
 
 void ParserFactory::Impl::fillMapper(const UnicodeString& classID, const UnicodeString* nameID, RegionMapper& mapper)
 {
+#ifdef COLORER_FEATURE_ZIPINPUTSOURCE
+  XmlJarCache::Current jar_scope(jar_cache);
+#endif
   const UnicodeString* name_id;
   const UnicodeString name_default(HrdNameDefault);
   uUnicodeString hrd;

--- a/plugins/colorer/src/Colorer-library/src/colorer/parsers/ParserFactoryImpl.h
+++ b/plugins/colorer/src/Colorer-library/src/colorer/parsers/ParserFactoryImpl.h
@@ -7,6 +7,9 @@
 #include "colorer/handlers/StyledHRDMapper.h"
 #include "colorer/handlers/TextHRDMapper.h"
 #include "colorer/parsers/HrdNode.h"
+#ifdef COLORER_FEATURE_ZIPINPUTSOURCE
+#include "colorer/xml/libxml2/SharedXmlInputSource.h"
+#endif
 
 class ParserFactory::Impl
 {
@@ -57,6 +60,9 @@ class ParserFactory::Impl
   std::vector<UnicodeString> hrc_locations;
   std::unordered_map<UnicodeString, std::unique_ptr<std::vector<std::unique_ptr<HrdNode>>>> hrd_nodes;
 
+#ifdef COLORER_FEATURE_ZIPINPUTSOURCE
+  mutable XmlJarCache jar_cache;
+#endif
   HrcLibrary* hrc_library;
 };
 

--- a/plugins/colorer/src/Colorer-library/src/colorer/parsers/SchemeImpl.h
+++ b/plugins/colorer/src/Colorer-library/src/colorer/parsers/SchemeImpl.h
@@ -32,6 +32,9 @@ class SchemeImpl : public Scheme
   }
 
  protected:
+  // Per ASCII first character: searchNodes[nodeIndexes[offsets[ch] .. offsets[ch+1]))
+  // are the only nodes that canStartWith(ch). Built in HrcLibrary::updateLinks.
+  // Absent when the scheme has <2 nodes or the table would not shrink the scan.
   struct SearchDispatch
   {
     std::array<uint32_t, 129> offsets = {};
@@ -40,6 +43,7 @@ class SchemeImpl : public Scheme
 
   uUnicodeString schemeName;
   std::vector<std::unique_ptr<SchemeNode>> nodes;
+  std::vector<std::unique_ptr<SchemeNode>> searchOwnedNodes;
   std::vector<SchemeNode*> searchNodes;
   std::unique_ptr<SearchDispatch> searchDispatch;
   FileType* fileType = nullptr;

--- a/plugins/colorer/src/Colorer-library/src/colorer/parsers/TextParser.cpp
+++ b/plugins/colorer/src/Colorer-library/src/colorer/parsers/TextParser.cpp
@@ -1,6 +1,8 @@
 #include "colorer/parsers/FileTypeImpl.h"
 #include "colorer/parsers/TextParserImpl.h"
 
+#include <shared_mutex>
+
 TextParser::TextParser() : pimpl(spimpl::make_unique_impl<Impl>()) {}
 
 void TextParser::breakParse()
@@ -15,11 +17,22 @@ void TextParser::clearCache()
 
 int TextParser::parse(int from, int num, TextParseMode mode)
 {
+  // Shared lock: a concurrent HrcLibrary::loadFileType cannot mutate schemes.
+  std::shared_lock<std::shared_mutex> hrc_lock;
+  FileType* type = pimpl->currentFileType();
+  if (type != nullptr && type->pimpl->library_access != nullptr) {
+    hrc_lock = std::shared_lock<std::shared_mutex>(*type->pimpl->library_access);
+  }
   return pimpl->parse(from, num, mode);
 }
 
 bool TextParser::tryParseLine(int line)
 {
+  std::shared_lock<std::shared_mutex> hrc_lock;
+  FileType* type = pimpl->currentFileType();
+  if (type != nullptr && type->pimpl->library_access != nullptr) {
+    hrc_lock = std::shared_lock<std::shared_mutex>(*type->pimpl->library_access);
+  }
   return pimpl->tryParseLine(line);
 }
 

--- a/plugins/colorer/src/Colorer-library/src/colorer/parsers/TextParserHelpers.cpp
+++ b/plugins/colorer/src/Colorer-library/src/colorer/parsers/TextParserHelpers.cpp
@@ -6,8 +6,9 @@
 ParseCache::~ParseCache()
 {
   // COLORER_LOG_DEEPTRACE("[TPCache] ~ParseCache():%,%-%", *scheme->getName(), sline, eline);
+  ParseCache* previous = prev;
   delete backLine;
-  delete children;
+  dropChildren();
   prev = nullptr;
 
   if (next) {
@@ -22,36 +23,84 @@ ParseCache::~ParseCache()
       tmp->next = nullptr;
     }
     delete next;
+    next = nullptr;
   }
 
   delete[] vcache;
+  if (parent && parent->search_child == this) {
+    parent->search_child = previous;
+  }
 }
+
+void ParseCache::dropChildren()
+{
+  delete children;
+  children = nullptr;
+  search_child = nullptr;
+}
+
+void ParseCache::dropNext()
+{
+  delete next;
+  next = nullptr;
+}
+
+namespace {
+
+ParseCache* rightmostAtOrBefore(ParseCache* node, int ln)
+{
+  while (node->next && node->next->sline <= ln) {
+    node = node->next;
+  }
+  return node;
+}
+
+}  // namespace
 
 ParseCache* ParseCache::searchLine(int ln, ParseCache** cache)
 {
-  ParseCache* r1 = nullptr;
-  ParseCache* r2 = nullptr;
-  ParseCache* tmp = this;
   *cache = nullptr;
-  while (tmp) {
-    COLORER_LOG_DEEPTRACE("[TPCache] searchLine() tmp:%,%-%", *tmp->scheme->getName(), tmp->sline, tmp->eline);
-    if (tmp->sline <= ln && tmp->eline >= ln) {
-      if (tmp->children) {
-        r1 = tmp->children->searchLine(ln, &r2);
-      }
-      if (r1) {
-        *cache = r2;
-        return r1;
-      }
-      *cache = r2;  // last child
-      return tmp;
-    }
-    if (tmp->sline <= ln) {
-      *cache = tmp;
-    }
-    tmp = tmp->next;
+
+  ParseCache* node = this;
+  if (parent && parent->search_child) {
+    node = parent->search_child;
   }
-  return nullptr;
+
+  if (node->sline <= ln) {
+    node = rightmostAtOrBefore(node, ln);
+  }
+  else if (node->prev && node->prev->sline <= ln) {
+    // One sibling back: tryParseLine(line+1) then searchLine(line).
+    node = node->prev;
+  }
+  else {
+    // Long jump toward the start: walk from the head, not back from EOF.
+    node = rightmostAtOrBefore(this, ln);
+  }
+
+  if (parent) {
+    parent->search_child = node;
+  }
+  if (node->sline > ln) {
+    return nullptr;
+  }
+
+  COLORER_LOG_DEEPTRACE("[TPCache] searchLine() tmp:%,%-%", *node->scheme->getName(), node->sline, node->eline);
+  if (node->eline < ln) {
+    *cache = node;
+    return nullptr;
+  }
+
+  ParseCache* child_cache = nullptr;
+  if (node->children) {
+    if (auto* found = node->children->searchLine(ln, &child_cache)) {
+      *cache = child_cache;
+      return found;
+    }
+  }
+
+  *cache = child_cache;  // last child
+  return node;
 }
 
 /////////////////////////////////////////////////////////////////////////

--- a/plugins/colorer/src/Colorer-library/src/colorer/parsers/TextParserHelpers.h
+++ b/plugins/colorer/src/Colorer-library/src/colorer/parsers/TextParserHelpers.h
@@ -88,11 +88,22 @@ class ParseCache
   ~ParseCache();
   /**
    * Searched a cache position for the specified line number.
+   * Siblings are ordered by sline and do not overlap; the rightmost
+   * node with sline <= ln is the unique covering candidate (or a
+   * predecessor when that node ends before ln).
    * @param ln     Line number to search for
    * @param cache  Cache entry, filled with last child cache entry.
    * @return       Cache entry, assigned to the specified line number
    */
   ParseCache* searchLine(int ln, ParseCache** cache);
+  /** Delete the children list and clear the search cursor into it. */
+  void dropChildren();
+  /** Delete the sibling suffix starting at next. */
+  void dropNext();
+
+ private:
+  /** Last searched immediate child. idleJob's forward chunks resume here. */
+  ParseCache* search_child = nullptr;
 };
 
 #endif // COLORER_TEXTPARSERPELPERS_H

--- a/plugins/colorer/src/Colorer-library/src/colorer/parsers/TextParserImpl.cpp
+++ b/plugins/colorer/src/Colorer-library/src/colorer/parsers/TextParserImpl.cpp
@@ -89,14 +89,12 @@ int TextParser::Impl::parse(int from, int num, TextParseMode mode)
         return from;
       }
       if (updateCache) {
-        delete parent->children;
-        parent->children = nullptr;
+        parent->dropChildren();
       }
     }
     else {
       if (updateCache) {
-        delete forward->next;
-        forward->next = nullptr;
+        forward->dropNext();
       }
     }
     baseScheme = parent->scheme;
@@ -476,12 +474,14 @@ int TextParser::Impl::searchBL(SchemeNodeBlock* node, int no, int lowLen, int hi
 
   if (updateCache) {
     if (old_gy == current_parse_line) {
-      delete OldCacheF;
       if (ResF) {
-        ResF->next = nullptr;
+        ResF->dropNext();
       }
       else if (ResP) {
-        ResP->children = nullptr;
+        ResP->dropChildren();
+      }
+      else {
+        delete OldCacheF;
       }
       forward = ResF;
       parent = ResP;

--- a/plugins/colorer/src/Colorer-library/src/colorer/parsers/TextParserImpl.cpp
+++ b/plugins/colorer/src/Colorer-library/src/colorer/parsers/TextParserImpl.cpp
@@ -1,5 +1,12 @@
 #include "colorer/parsers/TextParserImpl.h"
 
+// Coloring loop: parse() → colorize() → searchMatch() per column gx.
+// One scheme is active. Parent end-RE (root_end_re) bounds the window;
+// content is keywords / regexp / block / inherit from searchNodes
+// (ASCII first-char slice in searchDispatch when present).
+// str_chars is the line's ASCII occupancy; CRegExp::mayMatch uses it
+// to reject patterns before the NFA. See .agents/skills/colorer-hrc/core-parse.md.
+
 TextParser::Impl::Impl()
 {
   COLORER_LOG_DEEPTRACE("[TextParserImpl] constructor");
@@ -20,6 +27,11 @@ void TextParser::Impl::setFileType(FileType* type)
   initCache();
 }
 
+FileType* TextParser::Impl::currentFileType() const
+{
+  return baseScheme != nullptr ? baseScheme->fileType : nullptr;
+}
+
 void TextParser::Impl::setLineSource(LineSource* lh)
 {
   lineSource = lh;
@@ -30,6 +42,9 @@ void TextParser::Impl::setRegionHandler(RegionHandler* rh)
   regionHandler = rh;
 }
 
+// Locate the ParseCache node covering `from`, then colorize from there
+// toward the root. CACHE_UPDATE drops children from `from` and rebuilds
+// them; CACHE_READ only colors. Returns the last colored line.
 int TextParser::Impl::parse(int from, int num, TextParseMode mode)
 {
   gx = 0;
@@ -205,6 +220,8 @@ void TextParser::Impl::ensureLineLowercase()
   str_lowercase_ready = true;
 }
 
+// Binary search in the keyword table for this gx. ASCII first-char bitset
+// plus asciiBegin/End slice; lowercase line built only for ignore-case lists.
 int TextParser::Impl::searchKW(const SchemeNodeKeywords* node, int /*no*/, int lowlen,
                                int /*hilen*/)
 {
@@ -231,12 +248,23 @@ int TextParser::Impl::searchKW(const SchemeNodeKeywords* node, int /*no*/, int l
     }
   }
 
-  if (gx < lowlen && !node->kwList->firstChar->contains((*use_str)[gx])) {
-    return MATCH_NOTHING;
-  }
-
   int left = 0;
   int right = node->kwList->count;
+  if (gx < lowlen) {
+    const auto ch = static_cast<uint32_t>((*use_str)[gx]);
+    if (ch < 128) {
+      if ((node->kwList->firstCharAscii[ch >> 6] & (uint64_t(1) << (ch & 63))) == 0) {
+        return MATCH_NOTHING;
+      }
+      left = node->kwList->asciiBegin[ch];
+      right = node->kwList->asciiEnd[ch];
+    } else if (!node->kwList->firstChar->contains(static_cast<wchar>(ch))) {
+      return MATCH_NOTHING;
+    }
+  }
+  if (left >= right) {
+    return MATCH_NOTHING;
+  }
   while (true) {
     int pos = left + (right - left) / 2;
     int kwlen = node->kwList->kwList[pos].keyword->length();
@@ -318,7 +346,10 @@ int TextParser::Impl::searchIN(SchemeNodeInherit* node, int no, int lowLen, int 
 int TextParser::Impl::searchRE(SchemeNodeRegexp* node, int /*no*/, int lowLen, int hiLen)
 {
   SMatches match;
-  if (!node->start->parse(str, gx, node->lowPriority ? lowLen : hiLen, &match, schemeStart)) {
+  const int eol = node->lowPriority ? lowLen : hiLen;
+  if (!node->start->mayMatch(gx, eol, schemeStart, str_chars) ||
+      !node->start->parse(str, gx, eol, &match, schemeStart, -1, &str_chars))
+  {
     return MATCH_NOTHING;
   }
   COLORER_LOG_DEEPTRACE("[TextParserImpl] RE matched. gx=%", gx);
@@ -349,7 +380,10 @@ int TextParser::Impl::searchBL(SchemeNodeBlock* node, int no, int lowLen, int hi
 
   // проверяем совпадение по регулярному выражению start
   SMatches match;
-  if (!node->start->parse(str, gx, node->lowPriority ? lowLen : hiLen, &match, schemeStart)) {
+  const int eol = node->lowPriority ? lowLen : hiLen;
+  if (!node->start->mayMatch(gx, eol, schemeStart, str_chars) ||
+      !node->start->parse(str, gx, eol, &match, schemeStart, -1, &str_chars))
+  {
     return MATCH_NOTHING;
   }
 
@@ -452,7 +486,7 @@ int TextParser::Impl::searchBL(SchemeNodeBlock* node, int no, int lowLen, int hi
       forward = ResF;
       parent = ResP;
     }
-    else {
+    else if (OldCacheF != nullptr) {
       OldCacheF->eline = current_parse_line;
       OldCacheF->vcache = vtlist.store();
       forward = OldCacheF;
@@ -474,6 +508,8 @@ int TextParser::Impl::searchBL(SchemeNodeBlock* node, int no, int lowLen, int hi
   return MATCH_SCHEME;
 }
 
+// First matching node at gx wins. ASCII characters use searchDispatch
+// (nodes that canStartWith(ch)); otherwise the full searchNodes list.
 int TextParser::Impl::searchMatch(const SchemeImpl* cscheme, int no, int lowLen, int hiLen)
 {
   COLORER_LOG_DEEPTRACE("[TextParserImpl] searchMatch: entered scheme \"%\"", *cscheme->getName());
@@ -486,18 +522,20 @@ int TextParser::Impl::searchMatch(const SchemeImpl* cscheme, int no, int lowLen,
 #endif
   size_t searchBegin = 0;
   size_t searchEnd = cscheme->searchNodes.size();
-  bool useDispatch = false;
-  if (cscheme->searchDispatch && gx < str->length()) {
+  const auto* dispatch = cscheme->searchDispatch.get();
+  if (dispatch != nullptr && gx < str->length()) {
     const auto ch = static_cast<uint32_t>((*str)[gx]);
     if (ch < 128) {
-      searchBegin = cscheme->searchDispatch->offsets[ch];
-      searchEnd = cscheme->searchDispatch->offsets[ch + 1];
-      useDispatch = true;
+      searchBegin = dispatch->offsets[ch];
+      searchEnd = dispatch->offsets[ch + 1];
+    } else {
+      dispatch = nullptr;
     }
+  } else {
+    dispatch = nullptr;
   }
   for (size_t i = searchBegin; i < searchEnd; i++) {
-    auto* schemeNode = cscheme->searchNodes[
-      useDispatch ? cscheme->searchDispatch->nodeIndexes[i] : i];
+    auto* schemeNode = cscheme->searchNodes[dispatch ? dispatch->nodeIndexes[i] : i];
     COLORER_LOG_DEEPTRACE("[TextParserImpl] searchMatch: processing node:%/%, type:%", idx + 1,
                          searchEnd - searchBegin,
                          SchemeNode::schemeNodeTypeNames[static_cast<int>(schemeNode->type)]);
@@ -539,6 +577,10 @@ int TextParser::Impl::searchMatch(const SchemeImpl* cscheme, int no, int lowLen,
   return MATCH_NOTHING;
 }
 
+// One scheme, successive lines. Each line: fetch once, fill str_chars,
+// try parent end-RE, then searchMatch until gx reaches that bound.
+// End-RE hit → leave the block. Else next line, or the next maxBlockSize
+// window on this line when chunkLongLines is set.
 bool TextParser::Impl::colorize(CRegExp* root_end_re, bool lowContentPriority, bool tryPopOnEnd)
 {
   len = -1;
@@ -559,13 +601,13 @@ bool TextParser::Impl::colorize(CRegExp* root_end_re, bool lowContentPriority, b
       if (str == nullptr) {
         // LineSource can return null if the line is not available (e.g. editor shutdown).
         // Stop parsing gracefully instead of throwing across threads.
-        str = nullptr;
         clearLine = -1;
         endLine = current_parse_line;
         stackLevel--;
         return true;
       }
       str_lowercase_ready = false;
+      CRegExp::collectAsciiChars(*str, str_chars);
       regionHandler->clearLine(current_parse_line, str);
     }
     // hack to include invisible regions in start of block
@@ -582,8 +624,8 @@ bool TextParser::Impl::colorize(CRegExp* root_end_re, bool lowContentPriority, b
 
     // searches for the end of parent block
     int res = 0;
-    if (root_end_re) {
-      res = root_end_re->parse(str, gx, len, &matchend, schemeStart);
+    if (root_end_re && root_end_re->mayMatch(gx, len, schemeStart, str_chars)) {
+      res = root_end_re->parse(str, gx, len, &matchend, schemeStart, -1, &str_chars);
     }
     if (!res) {
       matchend.s[0] = matchend.e[0] = gx + maxBlockSize > len ? len : gx + maxBlockSize;
@@ -712,6 +754,9 @@ bool TextParser::Impl::sameTryLevel(const TryLevel& a, const TryLevel& b)
   return true;
 }
 
+// Reparse `line` without dropping the cache tree. True iff the open-block
+// stack continuing past this line still matches what the cache predicted
+// for line+1 (same schemes, start-RE captures, backtrace start text).
 bool TextParser::Impl::tryParseLine(int line)
 {
   if (!regionHandler || !lineSource || !baseScheme || line < 0) {

--- a/plugins/colorer/src/Colorer-library/src/colorer/parsers/TextParserImpl.h
+++ b/plugins/colorer/src/Colorer-library/src/colorer/parsers/TextParserImpl.h
@@ -12,8 +12,9 @@
  * works with parsed internal HRC structure and colorisez
  * text in a target editor system.
  *
- * Hot path: parse() walks ParseCache to the scheme covering `from`,
- * then colorize() on each line. One scheme is active; gx is the column.
+ * Hot path: parse() walks ParseCache to the scheme covering `from`
+ * (searchLine resumes from a per-parent sibling cursor), then
+ * colorize() on each line. One scheme is active; gx is the column.
  * Per line the ASCII occupancy mask (str_chars) is computed once and
  * passed into every CRegExp::mayMatch/parse. searchMatch() uses the
  * scheme's searchDispatch (first-character candidate list) then tries

--- a/plugins/colorer/src/Colorer-library/src/colorer/parsers/TextParserImpl.h
+++ b/plugins/colorer/src/Colorer-library/src/colorer/parsers/TextParserImpl.h
@@ -11,6 +11,20 @@
  * This is the base Colorer syntax parser, which
  * works with parsed internal HRC structure and colorisez
  * text in a target editor system.
+ *
+ * Hot path: parse() walks ParseCache to the scheme covering `from`,
+ * then colorize() on each line. One scheme is active; gx is the column.
+ * Per line the ASCII occupancy mask (str_chars) is computed once and
+ * passed into every CRegExp::mayMatch/parse. searchMatch() uses the
+ * scheme's searchDispatch (first-character candidate list) then tries
+ * keywords / regexp / block / inherit in HRC order. A block start-RE
+ * recurses into colorize(end-RE). Multi-line blocks become ParseCache
+ * nodes; single-line matches do not.
+ *
+ * tryParseLine() reparses one line under TPM_CACHE_READ and keeps the
+ * rest of the file valid if the open-block stack (scheme, start-RE
+ * captures) still matches what the cache predicted for the next line.
+ *
  * @ingroup colorer_parsers
  */
 class TextParser::Impl
@@ -24,6 +38,7 @@ class TextParser::Impl
   void setRegionHandler(RegionHandler* rh);
   int parse(int from, int num, TextParseMode mode);
   bool tryParseLine(int line);
+  FileType* currentFileType() const;
   void breakParse();
   void initCache();
   void setMaxBlockSize(int max_block_size);
@@ -41,6 +56,8 @@ class TextParser::Impl
   UnicodeString* str = nullptr;
   UnicodeString str_lowercase;
   bool str_lowercase_ready = false;
+  // ASCII characters present in str; lets CRegExp skip patterns that cannot match the line.
+  AsciiCharMask str_chars = {};
   int stackLevel = 0;
   int current_parse_line = 0;
   int gx = 0;

--- a/plugins/colorer/src/Colorer-library/src/colorer/strings/icu/Character.cpp
+++ b/plugins/colorer/src/Colorer-library/src/colorer/strings/icu/Character.cpp
@@ -1,46 +1,6 @@
 #include "colorer/strings/icu/Character.h"
 
-bool Character::isWhitespace(UChar c)
-{
-  return u_isspace(c);
-}
-
-bool Character::isLowerCase(UChar c)
-{
-  return u_islower(c);
-}
-
-bool Character::isUpperCase(UChar c)
-{
-  return u_isupper(c);
-}
-
-bool Character::isLetter(UChar c)
-{
-  return u_isalpha(c);
-}
-
-bool Character::isLetterOrDigitOrUnderscore(UChar c)
-{
-  return u_isdigit(c) || u_isalpha(c) || c == '_';
-}
-
-bool Character::isDigit(UChar c)
-{
-  return u_isdigit(c);
-}
-
-UChar Character::toLowerCase(UChar c)
-{
-  return (UChar) u_tolower(c);
-}
-
-UChar Character::toUpperCase(UChar c)
-{
-  return (UChar) u_toupper(c);
-}
-
 UChar Character::toTitleCase(UChar c)
 {
-  return (UChar) u_totitle(c);
+  return static_cast<UChar>(u_totitle(c));
 }

--- a/plugins/colorer/src/Colorer-library/src/colorer/strings/icu/Character.h
+++ b/plugins/colorer/src/Colorer-library/src/colorer/strings/icu/Character.h
@@ -2,19 +2,82 @@
 #define COLORER_CHARACTER_H
 
 #include "colorer/strings/icu/common_icu.h"
+#include "unicode/uchar.h"
 
 class Character
 {
  public:
-  static bool isWhitespace(UChar c);
-  static bool isLowerCase(UChar c);
-  static bool isUpperCase(UChar c);
-  static bool isLetter(UChar c);
-  static bool isLetterOrDigitOrUnderscore(UChar c);
-  static bool isDigit(UChar c);
+  static bool isWhitespace(UChar c)
+  {
+    if (static_cast<uint32_t>(c) <= 0x7f) {
+      return c == 0x20 || (c >= 0x09 && c <= 0x0D);
+    }
+    return u_isspace(c);
+  }
 
-  static UChar toLowerCase(UChar c);
-  static UChar toUpperCase(UChar c);
+  static bool isLowerCase(UChar c)
+  {
+    if (static_cast<uint32_t>(c) <= 0x7f) {
+      return c >= 0x61 && c <= 0x7A;
+    }
+    return u_islower(c);
+  }
+
+  static bool isUpperCase(UChar c)
+  {
+    if (static_cast<uint32_t>(c) <= 0x7f) {
+      return c >= 0x41 && c <= 0x5A;
+    }
+    return u_isupper(c);
+  }
+
+  static bool isLetter(UChar c)
+  {
+    if (static_cast<uint32_t>(c) <= 0x7f) {
+      return (c >= 0x41 && c <= 0x5A) || (c >= 0x61 && c <= 0x7A);
+    }
+    return u_isalpha(c);
+  }
+
+  static bool isLetterOrDigitOrUnderscore(UChar c)
+  {
+    if (static_cast<uint32_t>(c) <= 0x7f) {
+      return (c >= 0x41 && c <= 0x5A) || (c >= 0x61 && c <= 0x7A) || (c >= 0x30 && c <= 0x39) ||
+          c == 0x5F;
+    }
+    return u_isdigit(c) || u_isalpha(c) || c == 0x5F;
+  }
+
+  static bool isDigit(UChar c)
+  {
+    if (static_cast<uint32_t>(c) <= 0x7f) {
+      return c >= 0x30 && c <= 0x39;
+    }
+    return u_isdigit(c);
+  }
+
+  static UChar toLowerCase(UChar c)
+  {
+    if (static_cast<uint32_t>(c) <= 0x7f) {
+      if (c >= 0x41 && c <= 0x5A) {
+        return static_cast<UChar>(c + 0x20);
+      }
+      return c;
+    }
+    return static_cast<UChar>(u_tolower(c));
+  }
+
+  static UChar toUpperCase(UChar c)
+  {
+    if (static_cast<uint32_t>(c) <= 0x7f) {
+      if (c >= 0x61 && c <= 0x7A) {
+        return static_cast<UChar>(c - 0x20);
+      }
+      return c;
+    }
+    return static_cast<UChar>(u_toupper(c));
+  }
+
   static UChar toTitleCase(UChar c);
 };
 

--- a/plugins/colorer/src/Colorer-library/src/colorer/strings/icu/CharacterClass.h
+++ b/plugins/colorer/src/Colorer-library/src/colorer/strings/icu/CharacterClass.h
@@ -1,0 +1,129 @@
+#ifndef COLORER_CHARACTERCLASS_H
+#define COLORER_CHARACTERCLASS_H
+
+#include "colorer/strings/icu/common_icu.h"
+#include <array>
+#include <cstdint>
+
+class CharacterClass
+{
+ public:
+  bool contains(UChar32 c) const
+  {
+    if (static_cast<uint32_t>(c) <= 0x7f) {
+      if (!asciiReady) {
+        rebuildAscii();
+      }
+      return (asciiMask[c >> 6] & (uint64_t(1) << (c & 63))) != 0;
+    }
+    return set.contains(c);
+  }
+
+  CharacterClass& add(UChar32 c)
+  {
+    set.add(c);
+    asciiReady = false;
+    return *this;
+  }
+
+  CharacterClass& add(UChar32 start, UChar32 end)
+  {
+    set.add(start, end);
+    asciiReady = false;
+    return *this;
+  }
+
+  CharacterClass& add(const UnicodeString& s)
+  {
+    set.add(s);
+    asciiReady = false;
+    return *this;
+  }
+
+  CharacterClass& addAll(const CharacterClass& other)
+  {
+    set.addAll(other.set);
+    asciiReady = false;
+    return *this;
+  }
+
+  CharacterClass& addAll(const icu::UnicodeSet& other)
+  {
+    set.addAll(other);
+    asciiReady = false;
+    return *this;
+  }
+
+  CharacterClass& addAll(const UnicodeString& s)
+  {
+    set.addAll(s);
+    asciiReady = false;
+    return *this;
+  }
+
+  CharacterClass& remove(const UnicodeString& s)
+  {
+    set.remove(s);
+    asciiReady = false;
+    return *this;
+  }
+
+  CharacterClass& removeAll(const CharacterClass& other)
+  {
+    set.removeAll(other.set);
+    asciiReady = false;
+    return *this;
+  }
+
+  CharacterClass& removeAll(const icu::UnicodeSet& other)
+  {
+    set.removeAll(other);
+    asciiReady = false;
+    return *this;
+  }
+
+  CharacterClass& removeAll(const UnicodeString& s)
+  {
+    set.removeAll(s);
+    asciiReady = false;
+    return *this;
+  }
+
+  CharacterClass& retainAll(const CharacterClass& other)
+  {
+    set.retainAll(other.set);
+    asciiReady = false;
+    return *this;
+  }
+
+  CharacterClass& complement()
+  {
+    set.complement();
+    asciiReady = false;
+    return *this;
+  }
+
+  void freeze()
+  {
+    set.freeze();
+    rebuildAscii();
+  }
+
+ private:
+  void rebuildAscii() const
+  {
+    asciiMask = {};
+    for (UChar32 c = 0; c < 128; c++) {
+      if (set.contains(c)) {
+        asciiMask[c >> 6] |= uint64_t(1) << (c & 63);
+      }
+    }
+    asciiReady = true;
+  }
+
+  icu::UnicodeSet set;
+  mutable std::array<uint64_t, 2> asciiMask {};
+  mutable bool asciiReady = false;
+};
+
+#endif  // COLORER_CHARACTERCLASS_H

--- a/plugins/colorer/src/Colorer-library/src/colorer/strings/icu/UStr.cpp
+++ b/plugins/colorer/src/Colorer-library/src/colorer/strings/icu/UStr.cpp
@@ -64,7 +64,7 @@ std::unique_ptr<CharacterClass> UStr::createCharClass(const UnicodeString& ccs, 
     return nullptr;
   }
 
-  auto cc = std::make_unique<icu::UnicodeSet>();
+  auto cc = std::make_unique<CharacterClass>();
   icu::UnicodeSet cc_temp;
   bool inverse = false;
   UChar prev_char = BAD_WCHAR;
@@ -84,6 +84,7 @@ std::unique_ptr<CharacterClass> UStr::createCharClass(const UnicodeString& ccs, 
       if (inverse) {
         cc->complement();
       }
+      cc->freeze();
       return cc;
     }
     if (ccs[pos] == '{') {

--- a/plugins/colorer/src/Colorer-library/src/colorer/strings/icu/common_icu.h
+++ b/plugins/colorer/src/Colorer-library/src/colorer/strings/icu/common_icu.h
@@ -6,7 +6,6 @@
 
 using UnicodeString = icu::UnicodeString;
 using uUnicodeString = std::unique_ptr<UnicodeString>;
-using CharacterClass = icu::UnicodeSet;
 
 constexpr UChar BAD_WCHAR = 0xFFFF;
 

--- a/plugins/colorer/src/Colorer-library/src/colorer/strings/icu/strings.h
+++ b/plugins/colorer/src/Colorer-library/src/colorer/strings/icu/strings.h
@@ -2,6 +2,7 @@
 #define COLORER_STRINGS_H
 
 #include "colorer/strings/icu/common_icu.h"
+#include "colorer/strings/icu/CharacterClass.h"
 #include "colorer/strings/icu/Character.h"
 #include "colorer/strings/icu/Encodings.h"
 #include "colorer/strings/icu/UStr.h"

--- a/plugins/colorer/src/Colorer-library/src/colorer/strings/legacy/CString.cpp
+++ b/plugins/colorer/src/Colorer-library/src/colorer/strings/legacy/CString.cpp
@@ -51,7 +51,7 @@ CString::CString(const byte* stream, int32_t size, int def_encoding)
         }
         if (cps || strncmp((char*)stream + p, "encoding=", 9) != 0) continue;
         p += 9;
-        if (!cps && (stream[p] == '\"' || stream[p] == '\'')) {
+        if (stream[p] == '\"' || stream[p] == '\'') {
           p++;
           cps = p;
         } else
@@ -103,7 +103,7 @@ CString::CString(const byte* stream, int32_t size, int def_encoding)
       } else {
         int nextbytes = 0;
         while (stream[pos] << (nextbytes + 1)  & 0x80) nextbytes++;
-        wc = (stream[pos]  &  0xFF >> (nextbytes + 2)) << (nextbytes * 6);
+        wc = (stream[pos] & (0xFF >> (nextbytes + 2))) << (nextbytes * 6);
         while (nextbytes--) {
           wc += (stream[++pos]  &  0x3F) << (nextbytes * 6);
         }

--- a/plugins/colorer/src/Colorer-library/src/colorer/strings/legacy/Encodings.cpp
+++ b/plugins/colorer/src/Colorer-library/src/colorer/strings/legacy/Encodings.cpp
@@ -96,32 +96,30 @@ int Encodings::toBytes(int encoding, wchar wc, byte* dest)
     return 1;
   }
   if (encoding == ENC_UTF8) {
-    int dpos = 0;
     if (wc <= 0x7F) {
-      dest[dpos] = wc & 0x7F;
+      dest[0] = static_cast<byte>(wc);
+      return 1;
     }
-    if (wc > 0x7F && wc <= 0x7FF) {
-      dest[dpos] =(byte)(0xC0 + (wc >> 6));
-      dpos++;
-      dest[dpos] = 0x80 + (wc & 0x3F);
+    if (wc <= 0x7FF) {
+      dest[0] = static_cast<byte>(0xC0 | (wc >> 6));
+      dest[1] = static_cast<byte>(0x80 | (wc & 0x3F));
+      return 2;
     }
-    if (wc > 0x7FF && wc <= 0xFFFF) {
-      dest[dpos] = 0xE0 + (wc >> 12);
-      dpos++;
-      dest[dpos] = 0x80 + ((wc >> 6) & 0x3F);
-      dpos++;
-      dest[dpos] = 0x80 + (wc & 0x3F);
+#if (__WCHAR_MAX__ > 0xffff)
+    if (wc <= 0xFFFF) {
+#endif
+      dest[0] = static_cast<byte>(0xE0 | (wc >> 12));
+      dest[1] = static_cast<byte>(0x80 | ((wc >> 6) & 0x3F));
+      dest[2] = static_cast<byte>(0x80 | (wc & 0x3F));
+      return 3;
+#if (__WCHAR_MAX__ > 0xffff) // 4-byte UTF-8 is impossible for 16-bit wchar
     }
-    if (wc > 0xFFFF) {
-      dest[dpos] = 0xF0 + (wc >> 14);
-      dpos++;
-      dest[dpos] = 0x80 + ((wc >> 12) & 0x3F);
-      dpos++;
-      dest[dpos] = 0x80 + ((wc >> 6) & 0x3F);
-      dpos++;
-      dest[dpos] = 0x80 + (wc & 0x3F);
-    }
-    return dpos + 1;
+    dest[0] = static_cast<byte>(0xF0 | (wc >> 18));
+    dest[1] = static_cast<byte>(0x80 | ((wc >> 12) & 0x3F));
+    dest[2] = static_cast<byte>(0x80 | ((wc >> 6) & 0x3F));
+    dest[3] = static_cast<byte>(0x80 | (wc & 0x3F));
+    return 4;
+#endif
   }
   if (encoding == ENC_UTF16) {
     dest[0] = wc & 0xFF;
@@ -138,7 +136,7 @@ int Encodings::toBytes(int encoding, wchar wc, byte* dest)
     dest[0] = wc & 0xFF;
     dest[1] = (wc >> 8) & 0xFF;
     dest[2] = (wc >> 16) & 0xFF;
-    dest[3] = (wc >> 14) & 0xFF;
+    dest[3] = (wc >> 24) & 0xFF;
     return 4;
   }
 
@@ -146,7 +144,7 @@ int Encodings::toBytes(int encoding, wchar wc, byte* dest)
     dest[3] = wc & 0xFF;
     dest[2] = (wc >> 8) & 0xFF;
     dest[1] = (wc >> 16) & 0xFF;
-    dest[0] = (wc >> 14) & 0xFF;
+    dest[0] = (wc >> 24) & 0xFF;
     return 4;
   }
 #endif

--- a/plugins/colorer/src/Colorer-library/src/colorer/strings/legacy/UnicodeString.h
+++ b/plugins/colorer/src/Colorer-library/src/colorer/strings/legacy/UnicodeString.h
@@ -99,6 +99,12 @@ class UnicodeString
     return wstr[i];
   }
 
+  /** Internal character buffer. May be null when length() is 0. */
+  inline const wchar* getBuffer() const
+  {
+    return wstr.get();
+  }
+
   /** String length in unicode characters */
   inline int32_t length() const
   {

--- a/plugins/colorer/src/Colorer-library/src/colorer/utils/Environment.cpp
+++ b/plugins/colorer/src/Colorer-library/src/colorer/utils/Environment.cpp
@@ -7,6 +7,22 @@
 
 namespace colorer {
 
+namespace {
+
+const std::regex& envVarBraceRegex()
+{
+  static const std::regex re(R"--(\$\{([[:alpha:]]\w*)\})--");
+  return re;
+}
+
+const std::regex& envVarDollarRegex()
+{
+  static const std::regex re(R"--(\$([[:alpha:]]\w*)\b)--");
+  return re;
+}
+
+}  // namespace
+
 fs::path Environment::to_filepath(const UnicodeString* str)
 {
 #ifdef _WINDOWS
@@ -155,8 +171,13 @@ UnicodeString Environment::expandSpecialEnvironment(const UnicodeString& path)
 {
   COLORER_LOG_DEBUG("expand system environment for '%'", path);
 
+  if (path.indexOf('$') == -1) {
+    COLORER_LOG_DEBUG("result of expand '%'", path);
+    return path;
+  }
+
   const auto text = UStr::to_stdstr(&path);
-  auto result = expandEnvByRegexp(text, std::regex(R"--(\$([[:alpha:]]\w*)\b)--"));
+  auto result = expandEnvByRegexp(text, envVarDollarRegex());
 
   COLORER_LOG_DEBUG("result of expand '%'", result);
   return UStr::to_unistr(result);
@@ -179,9 +200,14 @@ UnicodeString Environment::expandEnvironment(const UnicodeString& path)
   COLORER_LOG_DEBUG("result of expand '%'", result);
   return result;
 #else
+  if (path.indexOf('$') == -1) {
+    COLORER_LOG_DEBUG("result of expand '%'", path);
+    return path;
+  }
+
   const auto text = UStr::to_stdstr(&path);
-  auto res = expandEnvByRegexp(text, std::regex(R"--(\$\{([[:alpha:]]\w*)\})--"));
-  res = expandEnvByRegexp(res, std::regex(R"--(\$([[:alpha:]]\w*)\b)--"));
+  auto res = expandEnvByRegexp(text, envVarBraceRegex());
+  res = expandEnvByRegexp(res, envVarDollarRegex());
   COLORER_LOG_DEBUG("result of expand '%'", res);
   return UStr::to_unistr(res);
 #endif
@@ -200,6 +226,10 @@ UnicodeString Environment::getCurrentDir()
 
 std::string Environment::expandEnvByRegexp(const std::string& path, const std::regex& regex)
 {
+  if (path.find('$') == std::string::npos) {
+    return path;
+  }
+
   std::smatch matcher;
   std::string result;
   auto text = path;

--- a/plugins/colorer/src/Colorer-library/src/colorer/viewer/TextLinesStore.cpp
+++ b/plugins/colorer/src/Colorer-library/src/colorer/viewer/TextLinesStore.cpp
@@ -3,25 +3,15 @@
 #include "colorer/Exception.h"
 #include "colorer/io/InputSource.h"
 
-TextLinesStore::~TextLinesStore()
-{
-  freeFile();
-}
-
 void TextLinesStore::freeFile()
 {
   fileName.reset();
-  for (auto it : lines) {
-    delete it;
-  }
   lines.clear();
 }
 
 void TextLinesStore::loadFile(const UnicodeString* inFileName, bool tab2spaces)
 {
-  if (this->fileName) {
-    freeFile();
-  }
+  freeFile();
 
   uUnicodeString file;
 
@@ -59,7 +49,7 @@ void TextLinesStore::loadFile(const UnicodeString* inFileName, bool tab2spaces)
 
   while (filepos < length + 1) {
     if (filepos == length || (*file)[filepos] == '\r' || (*file)[filepos] == '\n') {
-      lines.push_back(new UnicodeString(*file, prevpos, filepos - prevpos));
+      lines.emplace_back(*file, prevpos, filepos - prevpos);
       if (tab2spaces) {
         replaceTabs(lines.size() - 1);
       }
@@ -82,7 +72,7 @@ UnicodeString* TextLinesStore::getLine(size_t lno)
   if (lines.size() <= lno) {
     return nullptr;
   }
-  return lines[lno];
+  return &lines[lno];
 }
 
 size_t TextLinesStore::getLineCount() const
@@ -92,5 +82,5 @@ size_t TextLinesStore::getLineCount() const
 
 void TextLinesStore::replaceTabs(size_t lno)
 {
-  lines.at(lno)->findAndReplace("\t", "    ");
+  lines.at(lno).findAndReplace("\t", "    ");
 }

--- a/plugins/colorer/src/Colorer-library/src/colorer/viewer/TextLinesStore.h
+++ b/plugins/colorer/src/Colorer-library/src/colorer/viewer/TextLinesStore.h
@@ -17,7 +17,7 @@ public:
   /** Empty constructor. Does nothing.
   */
   TextLinesStore()=default;
-  ~TextLinesStore() override;
+  ~TextLinesStore() override = default;
 
   /** Loads specified file into vector of strings.
       @param inFileName File to load.
@@ -36,7 +36,7 @@ protected:
   */
   void freeFile();
 private:
-  std::vector<UnicodeString *> lines;
+  std::vector<UnicodeString> lines;
   uUnicodeString fileName;
   void replaceTabs(size_t lno);
 

--- a/plugins/colorer/src/Colorer-library/src/colorer/xml/XMLNode.h
+++ b/plugins/colorer/src/Colorer-library/src/colorer/xml/XMLNode.h
@@ -1,8 +1,8 @@
 #ifndef COLORER_XMLNODE_H
 #define COLORER_XMLNODE_H
 
-#include <list>
 #include <unordered_map>
+#include <vector>
 #include "colorer/Common.h"
 
 class XMLNode
@@ -16,7 +16,9 @@ class XMLNode
   UnicodeString name;  // tag name
   UnicodeString text;  // tag value ( if is a text tag )
   std::unordered_map<UnicodeString, UnicodeString> attributes;
-  std::list<XMLNode> children;
+  std::vector<XMLNode> children;
 };
+
+using XMLNodeList = std::vector<XMLNode>;
 
 #endif  // COLORER_XMLNODE_H

--- a/plugins/colorer/src/Colorer-library/src/colorer/xml/XmlReader.cpp
+++ b/plugins/colorer/src/Colorer-library/src/colorer/xml/XmlReader.cpp
@@ -16,7 +16,7 @@ bool XmlReader::parse()
   return xml_reader->isParsed();
 }
 
-void XmlReader::getNodes(std::list<XMLNode>& nodes) const
+void XmlReader::getNodes(XMLNodeList& nodes) const
 {
   xml_reader->parse(nodes);
 }

--- a/plugins/colorer/src/Colorer-library/src/colorer/xml/XmlReader.h
+++ b/plugins/colorer/src/Colorer-library/src/colorer/xml/XmlReader.h
@@ -11,7 +11,7 @@ class XmlReader
   explicit XmlReader(const XmlInputSource& xml_input_source);
   ~XmlReader();
   bool parse();
-  void getNodes(std::list<XMLNode>& nodes) const;
+  void getNodes(XMLNodeList& nodes) const;
 
  private:
   const XmlInputSource* input_source;

--- a/plugins/colorer/src/Colorer-library/src/colorer/xml/libxml2/LibXmlReader.cpp
+++ b/plugins/colorer/src/Colorer-library/src/colorer/xml/libxml2/LibXmlReader.cpp
@@ -1,7 +1,10 @@
 #include "colorer/xml/libxml2/LibXmlReader.h"
 #include <libxml/parserInternals.h>
+#include <cstdarg>
+#include <cstdio>
 #include <cstring>
 #include <fstream>
+#include <utility>
 #include "colorer/Exception.h"
 #include "colorer/base/BaseNames.h"
 #include "colorer/utils/Environment.h"
@@ -14,40 +17,95 @@
 #define strdup(p) _strdup(p)
 #endif
 
-uUnicodeString LibXmlReader::current_file = nullptr;
-bool LibXmlReader::is_first_call = false;
+namespace {
+
+struct XmlLoadContext
+{
+  UnicodeString current_file;
+  bool is_first_call = true;
+};
+
+thread_local XmlLoadContext* tls_load = nullptr;
+
+class XmlLoadCurrent
+{
+ public:
+  explicit XmlLoadCurrent(XmlLoadContext* load) : previous(tls_load)
+  {
+    tls_load = load;
+  }
+  ~XmlLoadCurrent()
+  {
+    tls_load = previous;
+  }
+  XmlLoadCurrent(const XmlLoadCurrent&) = delete;
+  XmlLoadCurrent& operator=(const XmlLoadCurrent&) = delete;
+
+ private:
+  XmlLoadContext* previous;
+};
+
+XmlLoadContext* loadContext(xmlParserCtxtPtr ctxt)
+{
+  if (tls_load != nullptr) {
+    return tls_load;
+  }
+  if (ctxt != nullptr && ctxt->_private != nullptr) {
+    return static_cast<XmlLoadContext*>(ctxt->_private);
+  }
+  return nullptr;
+}
+
+thread_local char xml_err_buf[4096];
+thread_local int xml_err_slen = 0;
+
+}  // namespace
 
 LibXmlReader::LibXmlReader(const UnicodeString& source_file)
 {
   xmlSetExternalEntityLoader(xmlMyExternalEntityLoader);
   xmlSetGenericErrorFunc(nullptr, xml_error_func);
 
-  current_file = std::make_unique<UnicodeString>(source_file);
-  is_first_call = true;
+  xmlParserCtxtPtr ctxt = xmlNewParserCtxt();
+  if (ctxt == nullptr) {
+    return;
+  }
 
-  // you can pass any string for the file name, it can be processed/converted into xml by MyExternalEntityLoader
-  xmldoc = xmlReadFile(UStr::to_stdstr(&source_file).c_str(), nullptr, XML_PARSE_NOENT | XML_PARSE_NONET);
+  XmlLoadContext load;
+  load.current_file = source_file;
+  ctxt->_private = &load;
+  const XmlLoadCurrent current(&load);
+
+  xmlDocPtr xmldoc =
+      xmlCtxtReadFile(ctxt, UStr::to_stdstr(&source_file).c_str(), nullptr, XML_PARSE_NOENT | XML_PARSE_NONET);
+  parsed = xmldoc != nullptr;
+  if (xmldoc != nullptr) {
+    xmlNode* current_node = xmlDocGetRootElement(xmldoc);
+    size_t count = 0;
+    for (xmlNode* node = current_node; node != nullptr; node = node->next) {
+      ++count;
+    }
+    nodes.reserve(count);
+    while (current_node != nullptr) {
+      XMLNode result;
+      populateNode(current_node, result);
+      nodes.push_back(std::move(result));
+      current_node = current_node->next;
+    }
+    xmlFreeDoc(xmldoc);
+    ctxt->myDoc = nullptr;
+  }
+  ctxt->_private = nullptr;
+  xmlFreeParserCtxt(ctxt);
 }
 
 LibXmlReader::LibXmlReader(const XmlInputSource& source) : LibXmlReader(source.getPath()) {}
 
-LibXmlReader::~LibXmlReader()
-{
-  if (xmldoc != nullptr) {
-    xmlFreeDoc(xmldoc);
-  }
-  current_file.reset();
-}
+LibXmlReader::~LibXmlReader() = default;
 
-void LibXmlReader::parse(std::list<XMLNode>& nodes)
+void LibXmlReader::parse(XMLNodeList& out_nodes)
 {
-  xmlNode* current = xmlDocGetRootElement(xmldoc);
-  while (current != nullptr) {
-    XMLNode result;
-    populateNode(current, result);
-    nodes.push_back(result);
-    current = current->next;
-  }
+  out_nodes = std::move(nodes);
 }
 
 bool LibXmlReader::populateNode(xmlNode* node, XMLNode& result)
@@ -90,16 +148,23 @@ void LibXmlReader::getChildren(xmlNode* node, XMLNode& result)
   if (node->children == nullptr) {
     return;
   }
-  node = node->children;
 
-  while (node != nullptr) {
-    if (!xmlIsBlankNode(node)) {
-      XMLNode child;
-      if (populateNode(node, child)) {
-        result.children.push_back(child);
-      }
+  size_t count = 0;
+  for (const xmlNode* child = node->children; child != nullptr; child = child->next) {
+    if (child->type == XML_ELEMENT_NODE) {
+      ++count;
     }
-    node = node->next;
+  }
+  result.children.reserve(count);
+
+  for (xmlNode* child = node->children; child != nullptr; child = child->next) {
+    if (child->type != XML_ELEMENT_NODE) {
+      continue;
+    }
+    XMLNode xml_child;
+    if (populateNode(child, xml_child)) {
+      result.children.push_back(std::move(xml_child));
+    }
   }
 }
 
@@ -117,9 +182,15 @@ void LibXmlReader::getAttributes(const xmlNode* node, std::unordered_map<Unicode
 xmlParserInputPtr LibXmlReader::xmlZipEntityLoader(const PathInJar& paths, xmlParserCtxtPtr ctxt)
 {
   const auto is = SharedXmlInputSource::getSharedInputSource(paths.path_to_jar);
-  is->open();
-
-  const auto unzipped_stream = unzip(is->getSrc(), is->getSize(), paths.path_in_jar);
+  std::unique_ptr<std::vector<byte>> unzipped_stream;
+  try {
+    is->open();
+    unzipped_stream = unzip(is->getSrc(), is->getSize(), paths.path_in_jar);
+  } catch (...) {
+    is->delref();
+    throw;
+  }
+  is->delref();
 
   xmlParserInputBufferPtr buf =
       xmlParserInputBufferCreateMem(reinterpret_cast<const char*>(unzipped_stream->data()),
@@ -146,38 +217,48 @@ xmlParserInputPtr LibXmlReader::xmlMyExternalEntityLoader(const char* URL, const
    * At the same time, there is no path to the source file or to the file in the entity in the function parameters.
    */
 
+  XmlLoadContext* load = loadContext(ctxt);
+  if (load == nullptr) {
+    return xmlNewInputFromFile(ctxt, URL);
+  }
+
   auto filename = Encodings::fromUTF8(const_cast<char*>(URL), static_cast<int32_t>(strlen(URL)));
   UnicodeString string_url(*filename.get());
 
   // read entity string like "env:$FAR_HOME/hrd/catalog-console.xml"
   static const UnicodeString env(u"env:");
-  if (!is_first_call && string_url.startsWith(env)) {
+  if (!load->is_first_call && string_url.startsWith(env)) {
     const auto exp = colorer::Environment::expandSpecialEnvironment(string_url);
     string_url = UnicodeString(exp, env.length());
   }
 
 #ifdef COLORER_FEATURE_ZIPINPUTSOURCE
-  if (string_url.startsWith(jar) || current_file->startsWith(jar)) {
-    const auto paths = LibXmlInputSource::getFullPathsToZip(string_url, is_first_call ? nullptr : current_file.get());
-    is_first_call = false;
+  if (string_url.startsWith(jar) || load->current_file.startsWith(jar)) {
+    const auto paths =
+        LibXmlInputSource::getFullPathsToZip(string_url, load->is_first_call ? nullptr : &load->current_file);
+    load->is_first_call = false;
     xmlParserInputPtr ret = nullptr;
     try {
       ret = xmlZipEntityLoader(paths, ctxt);
+    } catch (const Exception& e) {
+      // Must not throw through libxml2's C entity-loader callback.
+      COLORER_LOG_ERROR("zip entity load failed: %", e.what());
     } catch (...) {
+      COLORER_LOG_ERROR("zip entity load failed");
     }
     return ret;
   }
 #endif
   // We check if the file exists after all the conversions. If not, then we check the file relative to the one being processed.
   // This is relevant for the case of non-Latin letters in the path to the main file and entity on linux. There is no such problem on windows.
-  if (!is_first_call && !colorer::Environment::isRegularFile(string_url)) {
-    auto new_string_url = colorer::Environment::getAbsolutePath(*current_file.get(), string_url);
+  if (!load->is_first_call && !colorer::Environment::isRegularFile(string_url)) {
+    auto new_string_url = colorer::Environment::getAbsolutePath(load->current_file, string_url);
     if (colorer::Environment::isRegularFile(new_string_url)) {
       string_url = std::move(new_string_url);
     }
   }
 
-  is_first_call = false;
+  load->is_first_call = false;
   // read it as a regular file
   xmlParserInputPtr ret = xmlNewInputFromFile(ctxt, UStr::to_stdstr(&string_url).c_str());
 
@@ -186,8 +267,6 @@ xmlParserInputPtr LibXmlReader::xmlMyExternalEntityLoader(const char* URL, const
 
 void LibXmlReader::xml_error_func(void* /*ctx*/, const char* msg, ...)
 {
-  static char buf[4096];
-  static int slen = 0;
   va_list args;
 
   /* libxml2 prints IO errors from bad includes paths by
@@ -196,29 +275,29 @@ void LibXmlReader::xml_error_func(void* /*ctx*/, const char* msg, ...)
    * the line break. My enthusiasm about this is indescribable.
    */
   va_start(args, msg);
-  const int rc = vsnprintf(&buf[slen], sizeof(buf) - slen, msg, args);
+  const int rc = vsnprintf(&xml_err_buf[xml_err_slen], sizeof(xml_err_buf) - xml_err_slen, msg, args);
   va_end(args);
 
   /* This shouldn't really happen */
   if (rc < 0) {
     COLORER_LOG_ERROR("+++ out of cheese error. redo from start +++\n");
-    slen = 0;
-    memset(buf, 0, sizeof(buf));
+    xml_err_slen = 0;
+    memset(xml_err_buf, 0, sizeof(xml_err_buf));
     return;
   }
 
-  slen += rc;
-  if (slen >= static_cast<int>(sizeof(buf))) {
+  xml_err_slen += rc;
+  if (xml_err_slen >= static_cast<int>(sizeof(xml_err_buf))) {
     /* truncated, let's flush this */
-    buf[sizeof(buf) - 1] = '\n';
-    slen = sizeof(buf);
+    xml_err_buf[sizeof(xml_err_buf) - 1] = '\n';
+    xml_err_slen = sizeof(xml_err_buf);
   }
 
   /* We're assuming here that the last character is \n. */
-  if (buf[slen - 1] == '\n') {
-    buf[slen - 1] = '\0';
-    COLORER_LOG_ERROR("%", buf);
-    memset(buf, 0, sizeof(buf));
-    slen = 0;
+  if (xml_err_buf[xml_err_slen - 1] == '\n') {
+    xml_err_buf[xml_err_slen - 1] = '\0';
+    COLORER_LOG_ERROR("%", xml_err_buf);
+    memset(xml_err_buf, 0, sizeof(xml_err_buf));
+    xml_err_slen = 0;
   }
 }

--- a/plugins/colorer/src/Colorer-library/src/colorer/xml/libxml2/LibXmlReader.h
+++ b/plugins/colorer/src/Colorer-library/src/colorer/xml/libxml2/LibXmlReader.h
@@ -3,7 +3,7 @@
 
 #include <libxml/parser.h>
 #include <libxml/tree.h>
-#include <list>
+#include <unordered_map>
 #include "colorer/xml/XMLNode.h"
 #include "colorer/xml/XmlInputSource.h"
 
@@ -14,28 +14,24 @@ class LibXmlReader
 
   ~LibXmlReader();
 
-  void parse(std::list<XMLNode>& nodes);
+  void parse(XMLNodeList& nodes);
 
   [[nodiscard]]
   bool isParsed() const
   {
-    return xmldoc != nullptr;
+    return parsed;
   }
 
  private:
-
-  xmlDocPtr xmldoc {nullptr};
+  bool parsed {false};
+  XMLNodeList nodes;
 
   explicit LibXmlReader(const UnicodeString& source_file);
   static void getAttributes(const xmlNode* node, std::unordered_map<UnicodeString, UnicodeString>& data);
-  void getChildren(xmlNode* node, XMLNode& result);
-  bool populateNode(xmlNode* node, XMLNode& result);
+  static void getChildren(xmlNode* node, XMLNode& result);
+  static bool populateNode(xmlNode* node, XMLNode& result);
   static uUnicodeString getElementText(const xmlNode* node);
 
-  /* the name of the file that is being processed */
-  static uUnicodeString current_file;
-  /* is this the first xmlMyExternalEntityLoader call for current file*/
-  static bool is_first_call;
   static xmlParserInputPtr xmlMyExternalEntityLoader(const char* URL, const char* ID, xmlParserCtxtPtr ctxt);
   static void xml_error_func(void* ctx, const char* msg, ...);
 

--- a/plugins/colorer/src/Colorer-library/src/colorer/xml/libxml2/SharedXmlInputSource.cpp
+++ b/plugins/colorer/src/Colorer-library/src/colorer/xml/libxml2/SharedXmlInputSource.cpp
@@ -3,7 +3,51 @@
 #include "colorer/Exception.h"
 #include "colorer/utils/Environment.h"
 
-std::unordered_map<UnicodeString, SharedXmlInputSource*>* SharedXmlInputSource::isHash = nullptr;
+thread_local XmlJarCache* XmlJarCache::current_ = nullptr;
+
+XmlJarCache::Current::Current(XmlJarCache& cache) : previous(current_)
+{
+  current_ = &cache;
+}
+
+XmlJarCache::Current::~Current()
+{
+  current_ = previous;
+}
+
+XmlJarCache& XmlJarCache::fallback()
+{
+  static thread_local XmlJarCache tls_fallback;
+  return tls_fallback;
+}
+
+XmlJarCache& XmlJarCache::active()
+{
+  return current_ != nullptr ? *current_ : fallback();
+}
+
+XmlJarCache* XmlJarCache::bound()
+{
+  return current_;
+}
+
+SharedXmlInputSource* XmlJarCache::get(const UnicodeString& path)
+{
+  const auto existing = entries.find(path);
+  if (existing != entries.end()) {
+    existing->second->addref();
+    return existing->second.get();
+  }
+
+  auto sis = std::unique_ptr<SharedXmlInputSource>(new SharedXmlInputSource(path));
+  auto* const raw = sis.get();
+  const auto [it, inserted] = entries.try_emplace(path, std::move(sis));
+  if (!inserted) {
+    it->second->addref();
+    return it->second.get();
+  }
+  return raw;
+}
 
 int SharedXmlInputSource::addref()
 {
@@ -14,7 +58,6 @@ int SharedXmlInputSource::delref()
 {
   ref_count--;
   if (ref_count <= 0) {
-    delete this;
     return -1;
   }
   return ref_count;
@@ -22,36 +65,12 @@ int SharedXmlInputSource::delref()
 
 SharedXmlInputSource* SharedXmlInputSource::getSharedInputSource(const UnicodeString& path)
 {
-  if (isHash == nullptr) {
-    isHash = new std::unordered_map<UnicodeString, SharedXmlInputSource*>();
-  }
-
-  const auto s = isHash->find(path);
-  if (s != isHash->end()) {
-    SharedXmlInputSource* sis = s->second;
-    sis->addref();
-    return sis;
-  }
-
-  auto* sis = new SharedXmlInputSource(path);
-  isHash->try_emplace(path, sis);
-  return sis;
+  return XmlJarCache::active().get(path);
 }
 
-SharedXmlInputSource::SharedXmlInputSource(const UnicodeString& path): source_path(path)
+SharedXmlInputSource::SharedXmlInputSource(const UnicodeString& path) : source_path(path)
 {
-
   is_open = false;
-}
-
-SharedXmlInputSource::~SharedXmlInputSource()
-{
-  // You don't need to delete an object that has been deleted from the array. We are already in the destructor.
-  isHash->erase(source_path);
-  if (isHash->empty()) {
-    delete isHash;
-    isHash = nullptr;
-  }
 }
 
 int SharedXmlInputSource::getSize() const

--- a/plugins/colorer/src/Colorer-library/src/colorer/xml/libxml2/SharedXmlInputSource.h
+++ b/plugins/colorer/src/Colorer-library/src/colorer/xml/libxml2/SharedXmlInputSource.h
@@ -1,8 +1,37 @@
 #ifndef SHAREDXMLINPUTSOURCE_H
 #define SHAREDXMLINPUTSOURCE_H
 
+#include <memory>
 #include <unordered_map>
 #include "colorer/Common.h"
+
+class SharedXmlInputSource;
+
+class XmlJarCache
+{
+ public:
+  class Current
+  {
+   public:
+    explicit Current(XmlJarCache& cache);
+    ~Current();
+    Current(const Current&) = delete;
+    Current& operator=(const Current&) = delete;
+
+   private:
+    XmlJarCache* previous;
+  };
+
+  SharedXmlInputSource* get(const UnicodeString& path);
+
+  static XmlJarCache& active();
+  static XmlJarCache* bound();
+
+ private:
+  std::unordered_map<UnicodeString, std::unique_ptr<SharedXmlInputSource>> entries;
+  static thread_local XmlJarCache* current_;
+  static XmlJarCache& fallback();
+};
 
 class SharedXmlInputSource
 {
@@ -25,12 +54,11 @@ class SharedXmlInputSource
   SharedXmlInputSource& operator=(SharedXmlInputSource const&) = delete;
   SharedXmlInputSource(SharedXmlInputSource&&) = delete;
   SharedXmlInputSource& operator=(SharedXmlInputSource&&) = delete;
+  ~SharedXmlInputSource() = default;
 
  private:
+  friend class XmlJarCache;
   explicit SharedXmlInputSource(const UnicodeString& path);
-  ~SharedXmlInputSource();
-
-  static std::unordered_map<UnicodeString, SharedXmlInputSource*>* isHash;
 
   int ref_count {1};
   bool is_open {false};


### PR DESCRIPTION
Обновление ядра colorer.
с предыдущей версии произведены дополнительыне оптимизации. Сейчас в 2-3 раза быстрее относительно предыдущей версии. Это в сумме с изменениями в самих схемах.
Так при использовании icu скорость работы почти сравнялась с legacy string.

для примера sqlite3.c на моей машине обрабатывается утилитой за 0,53 секунды. На предыдущей версии 2.2 секунды , а до всех оптимизаций августа/сентября - 14.4 секунды