### PR TITLE
Fix crash on proclist opening

### DIFF
--- a/far2l/src/plist.cpp
+++ b/far2l/src/plist.cpp
@@ -277,7 +277,7 @@ static void enumerateProcesses(std::vector<FarPidInfo>& v)
 
 void ShowProcessList()
 {
-	MenuDataEx dummy; // will refresh immediately
+	MenuDataEx dummy{L"", 0, 0}; // will refresh immediately
 	VMenu ProcList(Msg::ProcessListTitle, &dummy, 1, ScrY - 4);
 
 	ProcList.SetPosition(-1, -1, 0, 0);


### PR DESCRIPTION
on uninitialized menu item name length

```
Thread 6 Crashed:
  0   libsystem_kernel.dylib        	       0x184a825e8 __pthread_kill + 8
  1   libsystem_pthread.dylib       	       0x184abd8d8 pthread_kill + 296
  2   libsystem_c.dylib             	       0x1849c4644 abort + 148
  3   far2l                         	       0x1030fd748 CustomPanic + 804 (CustomPanic.cpp:58)
  4   far2l                         	       0x1031833c8 Panic(char const*, ...) + 384 (Panic.cpp:41)
  5   far2l                         	       0x10305d680 SafeMMap::sSigaction(int, __siginfo*, void*) + 632
  (SafeMMap.cpp:272)
  6   libsystem_platform.dylib      	       0x184ac7744 _sigtramp + 56
  7   libsystem_pthread.dylib       	       0x184abd8d8 pthread_kill + 296
  8   libsystem_c.dylib             	       0x1849c4644 abort + 148
  9   far2l                         	       0x1030fd748 CustomPanic + 804 (CustomPanic.cpp:58)
  10  far2l                         	       0x1031833c8 Panic(char const*, ...) + 384 (Panic.cpp:41)
  11  far2l                         	       0x10305d680 SafeMMap::sSigaction(int, __siginfo*, void*) + 632
  (SafeMMap.cpp:272)
  12  libsystem_platform.dylib      	       0x184ac7744 _sigtramp + 56
  13  far2l                         	       0x102d62648 StrLength(wchar_t const*) + 24 (locale.hpp:43)
  14  far2l                         	       0x102d625c4 FARString::Copy(wchar_t const*) + 48 (FARString.hpp:183)
  15  far2l                         	       0x102d5ac0c FARString::operator=(wchar_t const*) + 32 (FARString.hpp:210)
  16  far2l                         	       0x102f20824 VMenu::VMenu(wchar_t const*, MenuDataEx*, int, int, unsigned
  int, long long (*)(void*, int, int, long long), Dialog*) + 720 (vmenu.cpp:118)
  17  far2l                         	       0x102f212e0 VMenu::VMenu(wchar_t const*, MenuDataEx*, int, int, unsigned
  int, long long (*)(void*, int, int, long long), Dialog*) + 84 (vmenu.cpp:98)
  18  far2l                         	       0x102ecb250 ShowProcessList() + 108 (plist.cpp:281)
  19  far2l                         	       0x102ebebd8 Manager::ProcessKey(unsigned int) + 676 (manager.cpp:888)
  20  far2l                         	       0x102ebd3e0 Manager::ProcessMainLoop() + 360 (manager.cpp:742)
  21  far2l                         	       0x102ebe8d8 Manager::EnterMainLoop() + 100 (manager.cpp:706)
  22  far2l                         	       0x102ebaf14 MainProcess(FARString, FARString, FARString, int, int, bool) +
  2864 (main.cpp:355)
  23  far2l                         	       0x102eb9e24 FarAppMain(int, char**) + 4948 (main.cpp:700)
  24  far2l_gui.so                  	       0x108384ecc WinPortAppThread::Entry() + 52 (wxMain.cpp:89)
  25  libwx_baseu-3.3.3.0.0.dylib   	       0x108753728 wxThreadInternal::PthreadStart(wxThread*) + 488
  26  libsystem_pthread.dylib       	       0x184abdc58 _pthread_start + 136
  27  libsystem_pthread.dylib       	       0x184ab8c1c thread_start + 8
```