### PR TITLE
colorer: Drop thread_local to avoid TLS overhead in shared-library builds

### DIFF
--- a/plugins/colorer/src/Colorer-library/src/colorer/cregexp/cregexp.cpp
+++ b/plugins/colorer/src/Colorer-library/src/colorer/cregexp/cregexp.cpp
@@ -2,7 +2,7 @@
 #include <algorithm>
 #include <climits>
 
-thread_local std::vector<StackElem> CRegExp::RegExpStack;
+std::vector<StackElem> CRegExp::RegExpStack;
 
 
 /////////////////////////////////////////////////////////////////////////////

--- a/plugins/colorer/src/Colorer-library/src/colorer/cregexp/cregexp.h
+++ b/plugins/colorer/src/Colorer-library/src/colorer/cregexp/cregexp.h
@@ -253,10 +253,10 @@ struct StackElem
 
    parse() pins parseBuf to UnicodeString::getBuffer() so the NFA does
    not index the string per step. Each offset resets \\m/\\M and captures.
-   The backtracking stack is thread_local and shared by every CRegExp on
-   that thread; count_elem is reset per parseRE. Do not clear it from
-   ParserFactory teardown. parseStepLimit (default 1e6) counts NFA steps
-   in one parse(); exceeding it fails the match.
+   The backtracking stack is process-wide and reused by every CRegExp;
+   count_elem is reset per parseRE. Do not parse concurrently. Do not
+   clear the stack from ParserFactory teardown. parseStepLimit (default
+   1e6) counts NFA steps in one parse(); exceeding it fails the match.
 
    TextParser calls mayMatch() with the same pos/eol/schemeStart/line
    mask before parse() to avoid entering the NFA.
@@ -456,7 +456,7 @@ class CRegExp
   void insert_stack(SRegInfo*& re, SRegInfo*& prev, int& toParse, bool& leftenter, ReAction ifTrueReturn,
                     ReAction ifFalseReturn, SRegInfo* re2, SRegInfo* prev2, int toParse2);
 
-  static thread_local std::vector<StackElem> RegExpStack;
+  static std::vector<StackElem> RegExpStack;
 
   static bool isLineBreak(wchar c)
   {

--- a/plugins/colorer/src/Colorer-library/src/colorer/xml/libxml2/LibXmlReader.cpp
+++ b/plugins/colorer/src/Colorer-library/src/colorer/xml/libxml2/LibXmlReader.cpp
@@ -25,18 +25,18 @@ struct XmlLoadContext
   bool is_first_call = true;
 };
 
-thread_local XmlLoadContext* tls_load = nullptr;
+XmlLoadContext* current_load = nullptr;
 
 class XmlLoadCurrent
 {
  public:
-  explicit XmlLoadCurrent(XmlLoadContext* load) : previous(tls_load)
+  explicit XmlLoadCurrent(XmlLoadContext* load) : previous(current_load)
   {
-    tls_load = load;
+    current_load = load;
   }
   ~XmlLoadCurrent()
   {
-    tls_load = previous;
+    current_load = previous;
   }
   XmlLoadCurrent(const XmlLoadCurrent&) = delete;
   XmlLoadCurrent& operator=(const XmlLoadCurrent&) = delete;
@@ -47,8 +47,8 @@ class XmlLoadCurrent
 
 XmlLoadContext* loadContext(xmlParserCtxtPtr ctxt)
 {
-  if (tls_load != nullptr) {
-    return tls_load;
+  if (current_load != nullptr) {
+    return current_load;
   }
   if (ctxt != nullptr && ctxt->_private != nullptr) {
     return static_cast<XmlLoadContext*>(ctxt->_private);
@@ -56,8 +56,8 @@ XmlLoadContext* loadContext(xmlParserCtxtPtr ctxt)
   return nullptr;
 }
 
-thread_local char xml_err_buf[4096];
-thread_local int xml_err_slen = 0;
+char xml_err_buf[4096];
+int xml_err_slen = 0;
 
 }  // namespace
 

--- a/plugins/colorer/src/Colorer-library/src/colorer/xml/libxml2/SharedXmlInputSource.cpp
+++ b/plugins/colorer/src/Colorer-library/src/colorer/xml/libxml2/SharedXmlInputSource.cpp
@@ -3,7 +3,7 @@
 #include "colorer/Exception.h"
 #include "colorer/utils/Environment.h"
 
-thread_local XmlJarCache* XmlJarCache::current_ = nullptr;
+XmlJarCache* XmlJarCache::current_ = nullptr;
 
 XmlJarCache::Current::Current(XmlJarCache& cache) : previous(current_)
 {
@@ -17,8 +17,8 @@ XmlJarCache::Current::~Current()
 
 XmlJarCache& XmlJarCache::fallback()
 {
-  static thread_local XmlJarCache tls_fallback;
-  return tls_fallback;
+  static XmlJarCache process_fallback;
+  return process_fallback;
 }
 
 XmlJarCache& XmlJarCache::active()

--- a/plugins/colorer/src/Colorer-library/src/colorer/xml/libxml2/SharedXmlInputSource.h
+++ b/plugins/colorer/src/Colorer-library/src/colorer/xml/libxml2/SharedXmlInputSource.h
@@ -29,7 +29,7 @@ class XmlJarCache
 
  private:
   std::unordered_map<UnicodeString, std::unique_ptr<SharedXmlInputSource>> entries;
-  static thread_local XmlJarCache* current_;
+  static XmlJarCache* current_;
   static XmlJarCache& fallback();
 };
 


### PR DESCRIPTION
по следам https://github.com/elfmz/far2l/pull/3620 удалил thread_local